### PR TITLE
Add OAuthCredentials, related Domain logic, a new DomainRequirementProvider extension point, and the RequiresDomain attribute

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/common/OAuthCredentials.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/common/OAuthCredentials.java
@@ -1,0 +1,50 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011-2013, CloudBees, Inc., Stephen Connolly.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.plugins.credentials.common;
+
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.domains.OAuthScopeRequirement;
+
+import hudson.util.Secret;
+
+/**
+ * Credentials that provide an OAuth access token for authenticating service
+ * requests with a particular provider.
+ *
+ * @param <T> The type of provider-specific requirements to which this
+ * credential should be applied.
+ *
+ * @see com.cloudbees.plugins.credentials.domains.OAuthScopeRequirement
+ * @see com.cloudbees.plugins.credentials.domains.OAuthScopeSpecification
+ */
+public interface OAuthCredentials<T extends OAuthScopeRequirement>
+    extends Credentials {
+  /**
+   * Returns an access token scoped to the set of OAuth scopes represented
+   * by the {@link OAuthScopeRequirement}.
+   *
+   * @return the scoped access token
+   */
+  Secret getAccessToken(T requirement);
+}

--- a/src/main/java/com/cloudbees/plugins/credentials/common/StandardUsernameOAuthCredentials.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/common/StandardUsernameOAuthCredentials.java
@@ -1,0 +1,37 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011-2013, CloudBees, Inc., Stephen Connolly.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.plugins.credentials.common;
+
+import com.cloudbees.plugins.credentials.domains.OAuthScopeRequirement;
+
+/**
+ * Credentials that have a username and an access token combination.
+ *
+ * @param <T> The type of {@link OAuthScopeRequirement}s with which this
+ * credential may be applied.
+ */
+public interface StandardUsernameOAuthCredentials<T
+    extends OAuthScopeRequirement>
+    extends StandardUsernameCredentials, OAuthCredentials<T> {
+}

--- a/src/main/java/com/cloudbees/plugins/credentials/domains/DescribableDomainRequirementProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/domains/DescribableDomainRequirementProvider.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011-2013, CloudBees, Inc., Stephen Connolly.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.plugins.credentials.domains;
+
+import java.util.List;
+
+import com.google.common.collect.Lists;
+
+import hudson.Extension;
+import hudson.ExtensionComponent;
+import hudson.ExtensionList;
+import hudson.model.Descriptor;
+import jenkins.model.Jenkins;
+
+/**
+ * This implementation of {@link DomainRequirementProvider} implements
+ * support for discovering {@link DomainRequirement}s annotated on
+ * {@link hudson.model.Describable} classes by walking the {@link Descriptor}s
+ * registered with {@link Jenkins}.
+ *
+ * TODO(mattmoor): should we allow the annotation on the descriptor itself?
+ */
+@Extension
+public class DescribableDomainRequirementProvider
+    extends DomainRequirementProvider {
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected <T extends DomainRequirement> List<T> provide(Class<T> type) {
+    ExtensionList<Descriptor> extensions =
+        Jenkins.getInstance().getExtensionList(Descriptor.class);
+
+    List<T> result = Lists.newArrayList();
+    for (ExtensionComponent<Descriptor> component :
+             extensions.getComponents()) {
+      Descriptor descriptor = component.getInstance();
+
+      T element = of(descriptor.clazz, type);
+      if (element != null) {
+        // Add an instance of the annotated requirement
+        result.add(element);
+      }
+    }
+    return result;
+  }
+}

--- a/src/main/java/com/cloudbees/plugins/credentials/domains/DomainRequirementProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/domains/DomainRequirementProvider.java
@@ -1,0 +1,124 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011-2013, CloudBees, Inc., Stephen Connolly.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.plugins.credentials.domains;
+
+import static java.util.logging.Level.SEVERE;
+
+import java.util.List;
+import java.util.logging.Logger;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+import hudson.model.Hudson;
+
+/**
+ * This {@link ExtensionPoint} serves as a means for plugins to augment the
+ * domain-requirement discovery process.  The intended usage is:
+ * <code>
+ *   List&lt;T&gt; list = DomainRequirementProvider.lookupRequirements(
+ *      FooRequirement.class);
+ * </code>
+ * This will delegate to the various extension implementations to
+ * {@link #provide(Class)} a {@link List} of requirements from things it
+ * understands how to discover.  The expectation is that it will call:
+ * <code>
+ *   of(discoveredClass, type /* parameter to provide *{@literal /});
+ * </code>
+ * in order to perform the {@link RequiresDomain} resolution.
+ *
+ * @see RequiresDomain
+ * @see DescribableDomainRequirementProvider
+ */
+public abstract class DomainRequirementProvider implements ExtensionPoint {
+  private static final Logger logger =
+      Logger.getLogger(DomainRequirementProvider.class.getName());
+
+  /**
+   * This hook is intended for providers to implement such that they can
+   * surface custom class-discovery logic, on which they will call {@code of()}
+   * to instantiate the elements returned.
+   */
+  protected abstract <T extends DomainRequirement> List<T> provide(
+      Class<T> type);
+
+  /**
+   * The the entrypoint for requirement gathering, this static method delegates
+   * to any registered providers to provide their set of discoverable
+   * requirements.
+   */
+  public static <T extends DomainRequirement> List<T> lookupRequirements(
+      Class<T> type) {
+    ExtensionList<DomainRequirementProvider> providers;
+    try {
+      providers = Hudson.getInstance().getExtensionList(
+          DomainRequirementProvider.class);
+    } catch (Exception e) {
+      logger.log(SEVERE, e.getMessage(), e);
+      return ImmutableList.of();
+    }
+
+    List<T> result = Lists.newArrayList();
+    for (DomainRequirementProvider provider : providers) {
+      result.addAll(provider.provide(type));
+    }
+    return result;
+  }
+
+  /**
+   * This is called by implementations of {@code provide()} to instantiate
+   * the class specified by an actual attribute, if present.  It returns null
+   * otherwise.
+   */
+  @Nullable
+  public static <T extends DomainRequirement> T of(Class<?> type,
+      Class<T> requirementType) {
+    RequiresDomain requiresDomain =
+        (RequiresDomain) type.getAnnotation(RequiresDomain.class);
+    if (requiresDomain == null) {
+      // Not annotated with @RequiresDomain
+      return null;
+    }
+
+    if (!requirementType.isAssignableFrom(requiresDomain.value())) {
+      // The "type" filter excludes the annotation
+      return null;
+    }
+
+    try {
+      // Add an instance of the annotated requirement
+      return (T) requiresDomain.value().newInstance();
+    } catch (InstantiationException e) {
+      logger.log(SEVERE, e.getMessage(), e);
+      return null;
+    } catch (IllegalAccessException e) {
+      logger.log(SEVERE, e.getMessage(), e);
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/cloudbees/plugins/credentials/domains/OAuthScopeRequirement.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/domains/OAuthScopeRequirement.java
@@ -1,0 +1,57 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011-2013, CloudBees, Inc., Stephen Connolly.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.plugins.credentials.domains;
+
+import java.util.Collection;
+
+/**
+ * A requirement for a set of OAuth scopes
+ *
+ * NOTE: The intended usage pattern for this is:
+ * <pre>
+ *   SpecificOAuthScopeRequirement
+ *     extends ProviderOAuthScopeRequirement
+ *     extends OAuthScopeRequirement
+ * </pre>
+ *
+ * A ~concrete example:
+ * <pre>
+ *   GoogleDriveOAuthScopeRequirement
+ *     extends GoogleOAuthScopeRequirement
+ *     extends OAuthScopeRequirement
+ * </pre>
+ *
+ * This is so that client code can type-filter on provider-specific requirements
+ * e.g. {@code GoogleOAuthScopeRequirement.class} to gather all the scopes that
+ * may be asked of a given credential.
+ *
+ * @see OAuthScopeSpecification
+ * @see com.cloudbees.plugins.credentials.common.OAuthCredentials
+ */
+public abstract class OAuthScopeRequirement extends DomainRequirement {
+  /**
+   * The OAuth scopes required for authenticating with a service provider.
+   */
+  public abstract Collection<String> getScopes();
+}

--- a/src/main/java/com/cloudbees/plugins/credentials/domains/OAuthScopeSpecification.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/domains/OAuthScopeSpecification.java
@@ -1,0 +1,146 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011-2013, CloudBees, Inc., Stephen Connolly.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.plugins.credentials.domains;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+
+/**
+ * The base class for provider-specific specifications, instantiated with the
+ * provider-specific requirement type to which the specification should apply.
+ *
+ * NOTE: The reason for provider-specific paired implementations of scope /
+ * requirement is due to the fact that an OAuth credential is per-provider
+ * (e.g. Google, Facebook, GitHub).
+ *
+ * This base implementation, returns {@code UNKNOWN} from {@link #test}
+ * if the passed requirement doesn't match our descriptor's provider
+ * requirement.  It then delegates to {@link #_test}, a hook that by default
+ * returns {@code POSITIVE}/{@code NEGATIVE} depending on whether
+ * {@code specifiedScopes} is a superset of the required scopes.
+ *
+ * @see OAuthScopeRequirement
+ * @see com.cloudbees.plugins.credentials.common.OAuthCredentials
+ * @param <T> The type of requirements to which this specification may apply
+ */
+public abstract class OAuthScopeSpecification<T extends OAuthScopeRequirement>
+    extends DomainSpecification {
+  protected OAuthScopeSpecification(Collection<String> specifiedScopes) {
+    this.specifiedScopes = checkNotNull(specifiedScopes);
+  }
+
+  /**
+   * Tests the scope against this specification.
+   *
+   * @param requirement The set of requirements to validate against this
+   * specification
+   * @return the result of the test.
+   */
+  @Override
+  @edu.umd.cs.findbugs.annotations.SuppressWarnings("BC_UNCONFIRMED_CAST")
+  public final Result test(DomainRequirement requirement) {
+    Class<T> providerRequirement = getDescriptor().getProviderRequirement();
+
+    if (!providerRequirement.isInstance(requirement)) {
+      return Result.UNKNOWN;
+    }
+
+    // NOTE: This cast is checked by the isInstance above
+    return _test((T) requirement);
+  }
+
+  /**
+   * Surfaces a hook for implementations to override or extend the
+   * default functionality of simply matching the set of scopes.
+   */
+  protected Result _test(T requirement) {
+    for (String scope : requirement.getScopes()) {
+      if (!specifiedScopes.contains(scope)) {
+        // We are missing this required scope
+        return Result.NEGATIVE;
+      }
+    }
+    // We matched all the scopes
+    return Result.POSITIVE;
+  }
+
+  /**
+   * Surfaces the set of scopes specified by this requirement for
+   * jelly roundtripping.
+   */
+  public Collection<String> getSpecifiedScopes() {
+    return Collections.unmodifiableCollection(specifiedScopes);
+  }
+  private final Collection<String> specifiedScopes;
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Descriptor<T> getDescriptor() {
+    return (Descriptor<T>) super.getDescriptor();
+  }
+
+  /**
+   * The base descriptor for specification extensions.  This carries the
+   * class of requirements to which this specification should apply.
+   */
+  public abstract static class Descriptor<T extends OAuthScopeRequirement>
+      extends DomainSpecificationDescriptor {
+    public Descriptor(Class<T> providerRequirement) {
+      this.providerRequirement = checkNotNull(providerRequirement);
+    }
+
+    /**
+     * Fetches the names and values of the set of scopes consumed by clients of
+     * this plugin.
+     */
+    public Collection<String> getScopeItems() {
+      List<T> requirements = DomainRequirementProvider.lookupRequirements(
+          getProviderRequirement());
+
+      Set<String> result = Sets.newHashSet();
+      for (T required : requirements) {
+        Iterables.addAll(result, required.getScopes());
+      }
+      return result;
+    }
+
+    /**
+     * Retrieve the class of {@link DomainRequirement}s to which our associated
+     * specifications should apply.
+     */
+    public Class<T> getProviderRequirement() {
+      return providerRequirement;
+    }
+    private final Class<T> providerRequirement;
+  }
+}

--- a/src/main/java/com/cloudbees/plugins/credentials/domains/RequiresDomain.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/domains/RequiresDomain.java
@@ -1,0 +1,72 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011-2013, CloudBees, Inc., Stephen Connolly.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.plugins.credentials.domains;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation is used to indicate that a given class has the specified
+ * {@link DomainRequirement}.  This is used to automatically discover the
+ * extent of requirements by installed components, so that the user can specify
+ * the necessary requirements from a sufficiently complete list presented in
+ * the UI.
+ *
+ * For Example (URI):
+ *  If a plugin only supports https/ssh URIs, we might annotate:
+ *  <code>
+ *    {@literal @}RequiresDomain(value = SecureURIRequirement.class)
+ *  </code>
+ *  Even though only one of the two may be necessary, it is sufficient to only
+ *  surface the options HTTPS/SSH in the specification UI.
+ *
+ * For Example (OAuth):
+ *  This is much more important for less constrained spaces than URI schemes,
+ *  especially when the options are harder to type options, e.g. OAuth scopes.
+ *  In this case, a plugin might annotate:
+ *  <code>
+ *    {@literal @}RequiresDomain(value = OAuthScopesABandC.class)
+ *  </code>
+ *  Even though the task they end up configuring may only require scopes
+ *  "A" and "B".
+ *
+ * @see DomainRequirementProvider
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface RequiresDomain {
+  /**
+   * The class of {@link DomainRequirement} to which the annotated
+   * class adheres.
+   *
+   * TODO(mattmoor): support a list option
+   */
+  Class<? extends DomainRequirement> value();
+}

--- a/src/main/resources/com/cloudbees/plugins/credentials/domains/OAuthScopeSpecification/config.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/domains/OAuthScopeSpecification/config.jelly
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ ~ The MIT License
+ ~
+ ~ Copyright (c) 2011-2013, CloudBees, Inc., Stephen Connolly.
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+ ~ of this software and associated documentation files (the "Software"), to deal
+ ~ in the Software without restriction, including without limitation the rights
+ ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ ~ copies of the Software, and to permit persons to whom the Software is
+ ~ furnished to do so, subject to the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be included in
+ ~ all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ ~ THE SOFTWARE.
+ -->
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <j:choose>
+    <j:set var="scopeOptions" value="${descriptor.scopeItems}" />
+    <j:when test="${!empty(scopeOptions)}">
+      <f:entry title="${%OAuth 2.0 Scopes}" field="specifiedScopes">
+        <select name="specifiedScopes" multiple="multiple" size="5">
+          <j:forEach var="anOption" items="${scopeOptions}">
+            <f:option selected="${instance.specifiedScopes.contains(anOption)}"
+                  value="${anOption}">${anOption}</f:option>
+          </j:forEach>
+        </select>
+      </f:entry>
+    </j:when>
+    <j:otherwise>
+      <f:entry>
+        <div class="error">
+          ${%Install a plugin that requires OAuth Scopes}
+        </div>
+      </f:entry>
+    </j:otherwise>
+  </j:choose>
+</j:jelly>

--- a/src/test/java/com/cloudbees/plugins/credentials/domains/DescribableDomainRequirementProviderTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/domains/DescribableDomainRequirementProviderTest.java
@@ -1,0 +1,222 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011-2013, CloudBees, Inc., Stephen Connolly.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.plugins.credentials.domains;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.WithoutJenkins;
+import org.mockito.MockitoAnnotations;
+
+import com.google.common.collect.ImmutableList;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.tasks.Builder;
+import jenkins.model.Jenkins;
+
+/**
+ * Tests for {@link DescribableDomainRequirementProvider}.
+ */
+public class DescribableDomainRequirementProviderTest {
+  // Allow for testing using JUnit4, instead of JUnit3.
+  @Rule
+  public JenkinsRule jenkins = new JenkinsRule();
+
+  /**
+   */
+  public static class TestRequirement
+      extends OAuthScopeRequirement {
+    @Override
+    public Collection<String> getScopes() {
+      return GOOD_SCOPES;
+    }
+  }
+
+  /**
+   * This is a trivial implementation of a {@link Builder} that
+   * consumes {@link OAuthCredentials}.
+   */
+  @RequiresDomain(value = TestRequirement.class)
+  public static class TestRobotBuilder extends Builder {
+    public TestRobotBuilder() {
+    }
+
+    @Override
+    public DescriptorImpl getDescriptor() {
+      return (DescriptorImpl) Jenkins.getInstance().getDescriptorOrDie(
+        getClass());
+    }
+
+    /**
+     * Descriptor for our trivial builder
+     */
+    @Extension
+    public static final class DescriptorImpl
+        extends Descriptor<Builder> {
+      @Override
+      public String getDisplayName() {
+        return "Test Robot Builder";
+      }
+    }
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void testDescribableRequirementDiscovery() throws Exception {
+    List<TestRequirement> list =
+        DomainRequirementProvider.lookupRequirements(TestRequirement.class);
+
+    assertEquals(1, list.size());
+  }
+
+  @Test
+  @WithoutJenkins
+  public void testNoJenkinsInstance() throws Exception {
+    // Make sure we don't crash if run on a slave, where no Jenkins
+    // is present.
+    List<TestRequirement> list =
+        DomainRequirementProvider.lookupRequirements(TestRequirement.class);
+
+    // However, we also shouldn't discover anything without Jenkins present.
+    assertEquals(0, list.size());
+  }
+
+  /**
+   */
+  public static class BadTestRequirement
+      extends OAuthScopeRequirement {
+    public BadTestRequirement(String x) {
+      // A trivial ctor is required, remove this
+      // and things work fine.
+    }
+
+    @Override
+    public Collection<String> getScopes() {
+      return GOOD_SCOPES;
+    }
+  }
+
+  /**
+   */
+  @RequiresDomain(value = BadTestRequirement.class)
+  public static class TestRobotBuilderBad extends Builder {
+    public TestRobotBuilderBad() {
+    }
+
+    @Override
+    public DescriptorImpl getDescriptor() {
+      return (DescriptorImpl) Jenkins.getInstance().getDescriptorOrDie(
+        getClass());
+    }
+
+    /**
+     * Descriptor for our trivial builder
+     */
+    @Extension
+    public static final class DescriptorImpl
+        extends Descriptor<Builder> {
+      @Override
+      public String getDisplayName() {
+        return "Test Robot Builder (Bad)";
+      }
+    }
+  }
+
+  @Test
+  public void testBadRequirement() throws Exception {
+    List<BadTestRequirement> list =
+        DomainRequirementProvider.lookupRequirements(BadTestRequirement.class);
+
+    assertEquals(0, list.size());
+  }
+
+  /**
+   */
+  public static class AnotherBadTestRequirement
+      extends OAuthScopeRequirement {
+    private AnotherBadTestRequirement() {
+      // A visible ctor is required, make this public
+      // or protected and things work.
+    }
+
+    @Override
+    public Collection<String> getScopes() {
+      return GOOD_SCOPES;
+    }
+  }
+
+  /**
+   */
+  @RequiresDomain(value = AnotherBadTestRequirement.class)
+  public static class TestRobotBuilderBadAgain extends Builder {
+    public TestRobotBuilderBadAgain() {
+    }
+
+    @Override
+    public DescriptorImpl getDescriptor() {
+      return (DescriptorImpl) Jenkins.getInstance().getDescriptorOrDie(
+        getClass());
+    }
+
+    /**
+     * Descriptor for our trivial builder
+     */
+    @Extension
+    public static final class DescriptorImpl
+        extends Descriptor<Builder> {
+      @Override
+      public String getDisplayName() {
+        return "Test Robot Builder (Bad Again)";
+      }
+    }
+  }
+
+  @Test
+  public void testBadRequirementProtection() throws Exception {
+    List<AnotherBadTestRequirement> list =
+        DomainRequirementProvider.lookupRequirements(
+            AnotherBadTestRequirement.class);
+
+    assertEquals(0, list.size());
+  }
+
+  private static String GOOD_SCOPE1 = "foo";
+  private static String GOOD_SCOPE2 = "baz";
+  private static String BAD_SCOPE = "bar";
+  private static Collection<String> GOOD_SCOPES =
+      ImmutableList.of(GOOD_SCOPE1, GOOD_SCOPE2);
+  private static Collection<String> BAD_SCOPES =
+      ImmutableList.of(GOOD_SCOPE1, BAD_SCOPE);
+}

--- a/src/test/java/com/cloudbees/plugins/credentials/domains/OAuthScopeSpecificationTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/domains/OAuthScopeSpecificationTest.java
@@ -1,0 +1,398 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011-2013, CloudBees, Inc., Stephen Connolly.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.plugins.credentials.domains;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.WithoutJenkins;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.common.OAuthCredentials;
+import com.cloudbees.plugins.credentials.domains.DomainSpecification.Result;
+import com.google.common.collect.ImmutableList;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.security.ACL;
+import jenkins.model.Jenkins;
+
+/**
+ * Tests for {@link OAuthScopeSpecification}.
+ */
+public class OAuthScopeSpecificationTest {
+  // Allow for testing using JUnit4, instead of JUnit3.
+  @Rule
+  public JenkinsRule jenkins = new JenkinsRule();
+
+  /**
+   */
+  public static class TestRequirement
+      extends OAuthScopeRequirement {
+    public TestRequirement(Collection<String> scopes) {
+      this.scopes = scopes;
+    }
+
+    @Override
+    public Collection<String> getScopes() {
+      return scopes;
+    }
+    private final Collection<String> scopes;
+  }
+
+  /**
+   */
+  public static class TestGoodRequirement
+      extends TestRequirement {
+    public TestGoodRequirement() {
+      super(GOOD_SCOPES);
+    }
+  }
+
+  /**
+   */
+  public static class TestBadRequirement
+      extends TestRequirement {
+    public TestBadRequirement() {
+      super(BAD_SCOPES);
+    }
+  }
+
+  /**
+   */
+  public static class TestSpec
+      extends OAuthScopeSpecification<TestRequirement> {
+    public TestSpec(Collection<String> scopes) {
+      super(scopes);
+    }
+
+    /**
+     */
+    @Extension
+    public static class DescriptorImpl
+        extends OAuthScopeSpecification.Descriptor<TestRequirement> {
+      public DescriptorImpl() {
+        super(TestRequirement.class);
+      }
+
+      @Override
+      public String getDisplayName() {
+        return "blah";
+      }
+    }
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  @WithoutJenkins
+  public void testBasics() throws Exception {
+    TestSpec spec = new TestSpec(GOOD_SCOPES);
+
+    assertThat(spec.getSpecifiedScopes(),
+        hasItems(GOOD_SCOPE1, GOOD_SCOPE2));
+  }
+
+  @Test
+  public void testUnknownRequirement() throws Exception {
+    TestSpec spec = new TestSpec(GOOD_SCOPES);
+
+    OAuthScopeRequirement requirement = new OAuthScopeRequirement() {
+        @Override
+        public Collection<String> getScopes() {
+          return GOOD_SCOPES;
+        }
+      };
+
+    // Verify that even with the right scopes the type kind excludes
+    // the specification from matching this requirement
+    assertEquals(Result.UNKNOWN, spec.test(requirement));
+  }
+
+  @Test
+  public void testKnownRequirements() throws Exception {
+    TestSpec spec = new TestSpec(GOOD_SCOPES);
+
+    TestRequirement goodReq = new TestGoodRequirement();
+    TestRequirement badReq = new TestBadRequirement();
+
+    // Verify that with the right type of requirement that
+    // good scopes match POSITIVEly and bad scopes match NEGATIVEly
+    assertEquals(Result.POSITIVE, spec.test(goodReq));
+    assertEquals(Result.NEGATIVE, spec.test(badReq));
+  }
+
+  @Test
+  public void testWithCustom_test() throws Exception {
+    TestRequirement badReq = new TestBadRequirement();
+
+    final TestSpec forDescriptor = new TestSpec(GOOD_SCOPES);
+
+    TestSpec spec = new TestSpec(GOOD_SCOPES) {
+        @Override
+        protected Result _test(TestRequirement foo) {
+          return Result.POSITIVE;
+        }
+
+        @Override
+        public Descriptor<TestRequirement> getDescriptor() {
+          return forDescriptor.getDescriptor();
+        }
+      };
+
+    // Verify that if we *override* the '_test' method that we can
+    // even let bad scopes through.
+    assertEquals(Result.POSITIVE, spec.test(badReq));
+  }
+
+  /**
+   */
+  @Extension
+  public static class CustomProvider extends DomainRequirementProvider {
+    @Override
+    protected <T extends DomainRequirement> List<T> provide(Class<T> type) {
+      if (type.isAssignableFrom(TestRequirement.class)) {
+        return ImmutableList.<T>of((T) new TestGoodRequirement());
+      }
+      return ImmutableList.of();
+    }
+  }
+
+  @Test
+  public void testGetScopeItems() throws Exception {
+    TestSpec forDescriptor = new TestSpec(ImmutableList.<String>of());
+
+    Collection<String> discovered =
+        forDescriptor.getDescriptor().getScopeItems();
+
+    assertEquals(2, discovered.size());
+    assertThat(discovered, hasItems(GOOD_SCOPE1, GOOD_SCOPE2));
+    assertThat(discovered, not(hasItems(BAD_SCOPE)));
+  }
+
+  @Mock
+  private OAuthCredentials mockCredentials;
+
+  /**
+   * Verify that credentials that appear outside of a domain with
+   * an OAuth specification can be matched
+   */
+  @Test
+  public void testUnscopedLookup() throws Exception {
+    SystemCredentialsProvider.getInstance().getCredentials()
+        .add(mockCredentials);
+
+    List<OAuthCredentials> matchingCredentials =
+        CredentialsProvider.lookupCredentials(OAuthCredentials.class,
+            Jenkins.getInstance(), ACL.SYSTEM, new TestGoodRequirement());
+
+    assertThat(matchingCredentials, hasItems(mockCredentials));
+  }
+
+  /**
+   * Verify that credentials that appear inside of a domain where the oauth
+   * specification provides no scopes is not matched.
+   */
+  @Test
+  public void testBadDomainScopedLookupEmptySpec() throws Exception {
+    TestSpec spec = new TestSpec(ImmutableList.<String>of());
+    Domain domain = new Domain("domain name", "domain description",
+        ImmutableList.<DomainSpecification>of(spec));
+
+    SystemCredentialsProvider.getInstance().getDomainCredentialsMap()
+        .put(domain, ImmutableList.<Credentials>of(mockCredentials));
+
+    List<OAuthCredentials> matchingCredentials =
+        CredentialsProvider.lookupCredentials(OAuthCredentials.class,
+            Jenkins.getInstance(), ACL.SYSTEM, new TestGoodRequirement());
+
+    assertThat(matchingCredentials, not(hasItems(mockCredentials)));
+  }
+
+  /**
+   * Verify that credentials that appear inside of a domain without any
+   * specification are found and returned.
+   */
+  @Test
+  public void testGoodDomainScopedLookupUnspecifiedDomain() throws Exception {
+    Domain domain = new Domain("domain name", "domain description",
+        ImmutableList.<DomainSpecification>of());
+
+    SystemCredentialsProvider.getInstance().getDomainCredentialsMap()
+        .put(domain, ImmutableList.<Credentials>of(mockCredentials));
+
+    List<OAuthCredentials> matchingCredentials =
+        CredentialsProvider.lookupCredentials(OAuthCredentials.class,
+            Jenkins.getInstance(), ACL.SYSTEM, new TestGoodRequirement());
+
+    assertThat(matchingCredentials, hasItems(mockCredentials));
+  }
+
+  /**
+   * Verify that credentials that appear inside of a domain with a single
+   * unrelated specification (inapplicable) are found and returned.
+   */
+  @Test
+  public void testGoodDomainScopedLookupUnrelatedSpecification()
+      throws Exception {
+    SchemeSpecification spec = new SchemeSpecification("http");
+    Domain domain = new Domain("domain name", "domain description",
+        ImmutableList.<DomainSpecification>of(spec));
+
+    SystemCredentialsProvider.getInstance().getDomainCredentialsMap()
+        .put(domain, ImmutableList.<Credentials>of(mockCredentials));
+
+    List<OAuthCredentials> matchingCredentials =
+        CredentialsProvider.lookupCredentials(OAuthCredentials.class,
+            Jenkins.getInstance(), ACL.SYSTEM, new TestGoodRequirement());
+
+    assertThat(matchingCredentials, hasItems(mockCredentials));
+  }
+
+  /**
+   * Verify that credentials that appear inside of a domain with a matching
+   * specification are found and returned.
+   */
+  @Test
+  public void testGoodDomainScopedLookup() throws Exception {
+    TestSpec spec = new TestSpec(GOOD_SCOPES);
+    Domain domain = new Domain("domain name", "domain description",
+        ImmutableList.<DomainSpecification>of(spec));
+
+    SystemCredentialsProvider.getInstance().getDomainCredentialsMap()
+        .put(domain, ImmutableList.<Credentials>of(mockCredentials));
+
+    List<OAuthCredentials> matchingCredentials =
+        CredentialsProvider.lookupCredentials(OAuthCredentials.class,
+            Jenkins.getInstance(), ACL.SYSTEM, new TestGoodRequirement());
+
+    assertThat(matchingCredentials, hasItems(mockCredentials));
+  }
+
+  /**
+   * Verify that credentials that appear inside of a domain with a matching
+   * superset specification are found and returned.
+   */
+  @Test
+  public void testGoodDomainScopedLookupSubset() throws Exception {
+    TestSpec spec = new TestSpec(GOOD_SCOPES);
+    Domain domain = new Domain("domain name", "domain description",
+        ImmutableList.<DomainSpecification>of(spec));
+
+    SystemCredentialsProvider.getInstance().getDomainCredentialsMap()
+        .put(domain, ImmutableList.<Credentials>of(mockCredentials));
+
+    List<OAuthCredentials> matchingCredentials =
+        CredentialsProvider.lookupCredentials(OAuthCredentials.class,
+            Jenkins.getInstance(), ACL.SYSTEM, new TestRequirement(
+                ImmutableList.of(GOOD_SCOPE1)));
+
+    assertThat(matchingCredentials, hasItems(mockCredentials));
+  }
+
+  /**
+   * Verify that credentials that appear inside of a domain with a mismatched
+   * specification are NOT returned
+   */
+  @Test
+  public void testBadDomainScopedLookup() throws Exception {
+    TestSpec spec = new TestSpec(GOOD_SCOPES);
+    Domain domain = new Domain("domain name", "domain description",
+        ImmutableList.<DomainSpecification>of(spec));
+
+    SystemCredentialsProvider.getInstance().getDomainCredentialsMap()
+        .put(domain, ImmutableList.<Credentials>of(mockCredentials));
+
+    List<OAuthCredentials> matchingCredentials =
+        CredentialsProvider.lookupCredentials(OAuthCredentials.class,
+            Jenkins.getInstance(), ACL.SYSTEM, new TestBadRequirement());
+
+    assertThat(matchingCredentials, not(hasItems(mockCredentials)));
+  }
+
+  /**
+   * Verify that credentials that appear inside of a domain with a subset of the
+   * scopes required are NOT returned
+   */
+  @Test
+  public void testBadDomainScopedLookupSuperset() throws Exception {
+    TestSpec spec = new TestSpec(ImmutableList.of(GOOD_SCOPE1));
+    Domain domain = new Domain("domain name", "domain description",
+        ImmutableList.<DomainSpecification>of(spec));
+
+    SystemCredentialsProvider.getInstance().getDomainCredentialsMap()
+        .put(domain, ImmutableList.<Credentials>of(mockCredentials));
+
+    List<OAuthCredentials> matchingCredentials =
+        CredentialsProvider.lookupCredentials(OAuthCredentials.class,
+            Jenkins.getInstance(), ACL.SYSTEM, new TestGoodRequirement());
+
+    assertThat(matchingCredentials, not(hasItems(mockCredentials)));
+  }
+
+  /**
+   * Verify that credentials that appear inside of a domain with a partially
+   * overlapping set of scopes are NOT matched.
+   */
+  @Test
+  public void testBadDomainScopedLookupOverlap() throws Exception {
+    TestSpec spec = new TestSpec(GOOD_SCOPES);
+    Domain domain = new Domain("domain name", "domain description",
+        ImmutableList.<DomainSpecification>of(spec));
+
+    SystemCredentialsProvider.getInstance().getDomainCredentialsMap()
+        .put(domain, ImmutableList.<Credentials>of(mockCredentials));
+
+    List<OAuthCredentials> matchingCredentials =
+        CredentialsProvider.lookupCredentials(OAuthCredentials.class,
+            Jenkins.getInstance(), ACL.SYSTEM, new TestBadRequirement());
+
+    assertThat(matchingCredentials, not(hasItems(mockCredentials)));
+  }
+
+
+  private static String GOOD_SCOPE1 = "foo";
+  private static String GOOD_SCOPE2 = "baz";
+  private static String BAD_SCOPE = "bar";
+  private static Collection<String> GOOD_SCOPES =
+      ImmutableList.of(GOOD_SCOPE1, GOOD_SCOPE2);
+  private static Collection<String> BAD_SCOPES =
+      ImmutableList.of(GOOD_SCOPE1, BAD_SCOPE);
+}


### PR DESCRIPTION
This commit adds support for OAuth access token based credentials.

A notable distinction from other kinds of credentials is that OAuth credentials take an OAuthScopeRequirement argument for providing credentials, due to the inherently scoped nature of OAuth tokens.

This commit also adds support for DomainRequirement discovery via @RequiresDomain and the DomainRequirementProvider extension point.

See DescribableDomainRequirementProvider for an example implementation of such a provider.

The domain discovery surfaced through this new "provider" is useful to build OAuthScopeSpecifications from OAuthScopeRequirements; the scopes for which are impractical for users to type, but something on which they may want to filter.
