### PR TITLE
Introduce the notion of "RestrictedCredentials"; these are Credentials w...

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/domains/DomainCredentials.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/domains/DomainCredentials.java
@@ -213,7 +213,20 @@ public class DomainCredentials {
         for (Map.Entry<Domain, List<Credentials>> entry : domainCredentialsMap.entrySet()) {
             if (entry.getKey().test(domainRequirements)) {
                 for (Credentials credential : entry.getValue()) {
-                    if (type.isInstance(credential) && credentialsMatcher.matches(credential)) {
+                    if (!type.isInstance(credential)) {
+                        continue;
+                    }
+                    // If the credentials have a native restriction that isn't imposed
+                    // by the Domain, give the Credentials a chance to self-restrict
+                    // themselves from being surfaced.
+                    if (credential instanceof RestrictedCredentials) {
+                        RestrictedCredentials restrictedCredentials =
+                            (RestrictedCredentials) credential;
+                        if (!restrictedCredentials.test(domainRequirements)) {
+                            continue;
+                        }
+                    }
+                    if (credentialsMatcher.matches(credential)) {
                         result.add(type.cast(credential));
                     }
                 }

--- a/src/main/java/com/cloudbees/plugins/credentials/domains/RestrictedCredentials.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/domains/RestrictedCredentials.java
@@ -1,0 +1,48 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011-2012, CloudBees, Inc., Stephen Connolly.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.plugins.credentials.domains;
+
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsNameProvider;
+import com.cloudbees.plugins.credentials.NameWith;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import java.util.List;
+
+/**
+ * Credentials that have a built in restriction
+ *
+ * @see com.cloudbees.plugins.credentials.domains.DomainRequirement
+ * @see com.cloudbees.plugins.credentials.domains.DomainSpecification
+ */
+public interface RestrictedCredentials extends Credentials {
+  /**
+   * Determine whether these {@link Credentials} are applicable for
+   * the given requirements.
+   *
+   * @param domainRequirements The requirements imposed on this credential.
+   * @return whether this credential meets the given requirement.
+   */
+  boolean test(@NonNull List<DomainRequirement> domainRequirements);
+}

--- a/src/test/java/com/cloudbees/plugins/credentials/domains/RestrictedCredentialsTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/domains/RestrictedCredentialsTest.java
@@ -1,0 +1,81 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011-2013, CloudBees, Inc., Stephen Connolly.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cloudbees.plugins.credentials.domains;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import com.cloudbees.plugins.credentials.BaseCredentials;
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+
+import hudson.security.ACL;
+import jenkins.model.Jenkins;
+
+public class RestrictedCredentialsTest {
+  // Allow for testing using JUnit4, instead of JUnit3.
+  @Rule
+  public JenkinsRule jenkins = new JenkinsRule();
+
+  public static class TestRestrictedCredentials extends BaseCredentials
+      implements RestrictedCredentials {
+    public TestRestrictedCredentials(final boolean answer) {
+      this.answer = answer;
+    }
+
+    @Override
+    public boolean test(List<DomainRequirement> requirements) {
+      return answer;
+    }
+    private final boolean answer;
+  }
+
+  @Test
+  public void testGetRestrictedCredentials() throws Exception {
+    Credentials trueCredentials = new TestRestrictedCredentials(true);
+    Credentials falseCredentials = new TestRestrictedCredentials(false);
+
+    SystemCredentialsProvider.getInstance().getCredentials()
+        .add(trueCredentials);
+    SystemCredentialsProvider.getInstance().getCredentials()
+        .add(falseCredentials);
+
+    Collection<Credentials> matchingCredentials =
+        CredentialsProvider.lookupCredentials(Credentials.class,
+            Jenkins.getInstance(), ACL.SYSTEM);
+
+    assertThat(matchingCredentials, hasItems(trueCredentials));
+    assertThat(matchingCredentials, not(hasItems(falseCredentials)));
+  }
+}


### PR DESCRIPTION
...ith a built-in specification to which they may be applied.

An example of this would be a credential that stores an OAuth token, which is an inherently restricted form of authority with certain built-in "scopes" that limit what it may be used to do.

Since DomainCredentials performs the actual requirement checking at the "Domain" level, this concept isn't something that could be easily introduced via a third-party plugin.
