### PR TITLE
Ignore nb-configuration.xml.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ work*/
 .project
 build/
 
+/nb-configuration.xml


### PR DESCRIPTION
Ignore `nb-configuration.xml` for NetBeans IDE users. Normally this file is not created, but in this case the plugin baseline is so old that tests and `hpi:run` cannot run on Java 8, so a specific JDK must be selected. So must specify

```xml
<?xml version="1.0" encoding="UTF-8"?>
<project-shared-configuration>
    <properties xmlns="http://www.netbeans.org/ns/maven-properties-data/1">
        <netbeans.hint.jdkPlatform>JDK_1.7</netbeans.hint.jdkPlatform>
    </properties>
</project-shared-configuration>
```

This is in fact fine to check in (intended to be sharable), but I predict @stephenc would violently disagree.