### PR TITLE
Trying to fix certificate upload & password checking

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl.java
@@ -220,13 +220,12 @@ public class CertificateCredentialsImpl extends BaseStandardCredentials implemen
                     if (keyStore.isCertificateEntry(alias)) {
                         keyStore.getCertificate(alias);
                     } else if (keyStore.isKeyEntry(alias)) {
+                        if (passwordChars == null) {
+                            return FormValidation.warning(Messages.CertificateCredentialsImpl_LoadKeyFailedQueryEmptyPassword(alias));
+                        }
                         try {
                             keyStore.getKey(alias, passwordChars);
                         } catch (UnrecoverableEntryException e) {
-                            if (passwordChars == null || passwordChars.length == 0) {
-                                return FormValidation.warning(e,
-                                        Messages.CertificateCredentialsImpl_LoadKeyFailedQueryEmptyPassword(alias));
-                            }
                             return FormValidation.warning(e,
                                     Messages.CertificateCredentialsImpl_LoadKeyFailed(alias));
                         }


### PR DESCRIPTION
As mentioned in #21, certificate credentials are not working well.

I found and fixed one bug, which was a stack trace when `password == null`. The problem is that `doCheckKeyStoreFile` receives a null `password` even when one is visibly set in the form. The check is actually correct when the page is first loaded, but then called again incorrectly if you even focus either the `keyStoreFile` or `password` fields, overwriting the original form validation with a bogus error. Easily reproduced with `src/test/resources/com/cloudbees/plugins/credentials/impl/test.p12` (password `password`).

I tried updating the baseline to 1.532 where JENKINS-19124 is fixed, and deleting the special `<script>`s in `FileOnMasterKeyStoreSource/config.jelly` and `UploadedKeyStoreSource/config.jelly`. This did not seem to break anything, but it did not fix the issue either.

I also tried using `@QueryParameter @RelativePath("..") String password`, which I believe ought to be required, since `password` is defined in a higher form element. But this caused me to get an inscrutable JavaScript error

    Uncaught TypeError: undefined is not a function

from `prototype.js:856`:

```javascript
if (e != $break) throw e;
```

So stopping here, which at least makes the bug less odious.

@reviewbybees