### PR TITLE
Adjuncts do not include CSS correctly for removable dom fragments

### DIFF
--- a/src/main/resources/lib/credentials/select.jelly
+++ b/src/main/resources/lib/credentials/select.jelly
@@ -43,7 +43,6 @@
       If expressions are allowed then the user can choose between a select drop down and entering an expression.
     </st:attribute>
   </st:documentation>
-  <st:adjunct includes="lib.credentials.select.select"/>
   <f:prepareDatabinding/>
   <j:set var="value" value="${attrs.value ?: instance[attrs.field] ?: attrs.default}" />
   <j:set var="paramValue" value="${attrs.expressionAllowed and value.startsWith('${') and value.endsWith('}')}"/>
@@ -94,5 +93,19 @@
     </j:if>
   </div>
   <script>
+    // conditionally include the adjunct resources as AdjunctManager doesn't do this correctly for CSS
+    if (!document.getElementById('lib.credentials.select.select')) {
+      var link = document.createElement('link');
+      link.id = 'lib.credentials.select.select';
+      link.rel = 'stylesheet';
+      link.type = 'text/css';
+      link.href = "${request.contextPath+'/'+app.getAdjuncts(null).rootURL+'/lib/credentials/select/select.css'}";
+      link.media = 'all';
+      document.getElementsByTagName('head')[0].appendChild(link);
+      var script = document.createElement('script');
+      script.type = 'text/javascript';
+      script.src = "${request.contextPath+'/'+app.getAdjuncts(null).rootURL+'/lib/credentials/select/select.js'}";
+      document.getElementsByTagName('body')[0].appendChild(script);
+    }
   </script>
 </j:jelly>

--- a/src/main/resources/lib/credentials/select.jelly
+++ b/src/main/resources/lib/credentials/select.jelly
@@ -93,6 +93,7 @@
     </j:if>
   </div>
   <script>
+    // HACK: can be removed once base version of Jenkins has fix of https://issues.jenkins-ci.org/browse/JENKINS-26578
     // conditionally include the adjunct resources as AdjunctManager doesn't do this correctly for CSS
     if (!document.getElementById('lib.credentials.select.select')) {
       var link = document.createElement('link');


### PR DESCRIPTION
- I think it only works by accident with script tags
- When the adjunct is initially included the script and css elements are injected at the point where the st:adjunct
  tag is first referenced.
- Thus these tags form part of the DOM that can be removed (e.g. when part of a repeatable / hetero list)
- Because the script is executed, removing the DOM node cannot un-execute the script, so script tags are safe
- Removing the css's link tag, however, removes the styling... and the adjunct manager doesn't know.
- What this hack does is inject the CSS at the end of the DOM's head tag (yes triggering a reflow) but only
  if the CSS link is not present already. The JavaScript tag (because we are bypassing st:adjunct) is conditionally
  appended to the DOM's body so that it can be fetched while other scripts continue executing.

To see the bug this fixes:

- Create a job with the GIT SCM and a couple of SCM locations and some credential parameters
- Save the job
- Load the job
- Remove the first credential parameter, now all the credential tags loose the styling (width:auto on the drop-down) and the Add button overflows to the next line