### PR TITLE
Fix a small bug in URIRequirementBuilder.

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/domains/URIRequirementBuilder.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/domains/URIRequirementBuilder.java
@@ -196,7 +196,7 @@ public class URIRequirementBuilder {
      */
     @NonNull
     public URIRequirementBuilder withPath(@CheckForNull String path) {
-        withoutScheme();
+        withoutPath();
         if (path != null) {
             requirements.add(new PathRequirement(path));
         }

--- a/src/test/java/com/cloudbees/plugins/credentials/domains/DomainTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/domains/DomainTest.java
@@ -48,7 +48,7 @@ public class DomainTest {
     public void pathRequirements() throws Exception {
         Domain instance =
                 new Domain("test federation", "the instance under test", Arrays.<DomainSpecification>asList(
-                        new SchemeSpecification("http, https, svn, git, pop3, imap, spdy"),
+                        new SchemeSpecification("https"),
                         new HostnameSpecification("*.jenkins-ci.org", null),
                         new PathSpecification("/download/**/jenkins.war", null, false)));
 
@@ -56,6 +56,7 @@ public class DomainTest {
         assertThat(instance.test(URIRequirementBuilder.fromUri("https://updates.jenkins-ci.org/download/1.532/jenkins.war").build()), is(true));
         assertThat(instance.test(URIRequirementBuilder.fromUri("https://updates.jenkins-ci.org/download/jenkins.war").build()), is(true));
         assertThat(instance.test(URIRequirementBuilder.fromUri("https://updates.jenkins-ci.org/download/1/2/3/jenkins.war").build()), is(true));
+        assertThat(instance.test(URIRequirementBuilder.fromUri("http://updates.jenkins-ci.org/download/1/2/3/jenkins.war").build()), is(false));
 
     }
 }


### PR DESCRIPTION
Fixes a bug I found while investigating jenkinsci/ghprb-plugin/issues/117.

When a path is used in the URIRequirementBuilder, it cleared any SchemeRequirement already set.

This appears to be a copy-paste error.