### PR TITLE
CredentialsParameterDefinition.getDefaultParameterValue().isDefaultValue() should return true

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsParameterDefinition.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsParameterDefinition.java
@@ -69,7 +69,7 @@ public class CredentialsParameterDefinition extends SimpleParameterDefinition {
 
     @Override
     public ParameterValue getDefaultParameterValue() {
-        return new CredentialsParameterValue(getName(), getDefaultValue(), getDescription());
+        return new CredentialsParameterValue(getName(), getDefaultValue(), getDescription(), true);
     }
 
     public String getDefaultValue() {


### PR DESCRIPTION
This causes problems with credentials-binding-plugin failing to find a credentials value when a job is started by System (e.g. timer, SCM push, etc).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/credentials-plugin/39)
<!-- Reviewable:end -->
