### PR TITLE
[JENKINS-29646] - fix bug in constructor call that breaks rebuild-plugin

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsParameterDefinition.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsParameterDefinition.java
@@ -45,7 +45,7 @@ public class CredentialsParameterDefinition extends SimpleParameterDefinition {
     public ParameterDefinition copyWithDefaultValue(ParameterValue defaultValue) {
         if (defaultValue instanceof CredentialsParameterValue) {
             CredentialsParameterValue value = (CredentialsParameterValue) defaultValue;
-            return new CredentialsParameterDefinition(getName(), value.getValue(), getDescription(), getCredentialType(), isRequired());
+            return new CredentialsParameterDefinition(getName(), getDescription(), value.getValue(), getCredentialType(), isRequired());
         }
         return this;
     }


### PR DESCRIPTION
This pull request swaps the order of 2 parameters in a call to CredentialsParameterDefinition constructor to match the definition. This error caused the Rebuild Plugin to swap the parameter description with the credential GUID when a rebuild was requested. This in turn selected the credential at the top of the dropdown list instead of the credential from the specified build thereby defeating the reason for using the rebuild plugin (see issue [JENKINS-29646](https://issues.jenkins-ci.org/browse/JENKINS-29646?jql=project%20%3D%20JENKINS%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)))

I have been using this for a couple weeks and it has solved the issue with the Rebuild Plugin behaving in the expected manner.