### PR TITLE
[JENKINS-33863] Upgrade to plugin parent pom 2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,10 +68,6 @@
   </scm>
 
   <properties>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.findbugs.failure.strict>true</maven.findbugs.failure.strict>
     <jenkins.version>1.565</jenkins.version>
     <java.level>6</java.level>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.565</version>
+    <version>2.4</version>
   </parent>
 
   <artifactId>credentials</artifactId>
@@ -72,7 +72,8 @@
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.findbugs.failure.strict>true</maven.findbugs.failure.strict>
-    <maven-hpi-plugin.version>1.96</maven-hpi-plugin.version>
+    <jenkins.version>1.565</jenkins.version>
+    <java.level>6</java.level>
   </properties>
 
   <repositories>
@@ -89,102 +90,39 @@
   </pluginRepositories>
 
   <dependencies>
-    <!-- regular dependencies -->
-    <dependency>
-      <groupId>net.jcip</groupId>
-      <artifactId>jcip-annotations</artifactId>
-      <version>1.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.github.stephenc.findbugs</groupId>
-      <artifactId>findbugs-annotations</artifactId>
-      <version>1.3.9-1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>1.3.9</version>
-    </dependency>
     <!-- plugin dependencies -->
     <dependency>
       <groupId>org.jenkins-ci.plugins.icon-shim</groupId>
       <artifactId>icon-shim</artifactId>
       <version>2.0.2</version>
     </dependency>
-    <!-- jenkins dependencies -->
     <!-- test dependencies -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.11</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>1.9.5</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <version>1.3.1</version>
-          <executions>
-            <execution>
-              <id>enforce-maven</id>
-              <goals>
-                <goal>enforce</goal>
-              </goals>
-              <configuration>
-                <rules>
-                  <requireMavenVersion>
-                    <version>(,2.1.0),(2.1.0,2.2.0),(2.2.0,)</version>
-                    <message>Maven 2.1.0 and 2.2.0 produce incorrect GPG signatures and checksums respectively.
-                    </message>
-                  </requireMavenVersion>
-                  <requireMavenVersion>
-                    <version>(,3.0),[3.0.4,)</version>
-                    <message>Maven 3.0 through 3.0.3 inclusive do not pass correct settings.xml to Maven Release
-                      Plugin.
-                    </message>
-                  </requireMavenVersion>
-                </rules>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
-          <artifactId>maven-release-plugin</artifactId>
-          <version>2.5.2</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.1</version>
         <configuration>
           <excludeFilterFile>src/findbugs/excludesFilter.xml</excludeFilterFile>
-          <failOnError>${maven.findbugs.failure.strict}</failOnError>
         </configuration>
-        <executions>
-          <execution>
-            <phase>verify</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>
-        <version>${maven-hpi-plugin.version}</version>
         <executions>
           <execution>
             <goals>
@@ -192,11 +130,6 @@
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <systemProperties>
-            <hudson.bundled.plugins>${basedir}/work/plugins/credentials.hpl</hudson.bundled.plugins>
-          </systemProperties>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -110,13 +110,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <excludeFilterFile>src/findbugs/excludesFilter.xml</excludeFilterFile>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.4</version>
+    <version>2.6</version>
   </parent>
 
   <artifactId>credentials</artifactId>

--- a/src/findbugs/excludesFilter.xml
+++ b/src/findbugs/excludesFilter.xml
@@ -1,5 +1,0 @@
-<FindBugsFilter>
-  <Match>
-    <Class name="~.*\.Messages"/>
-  </Match>
-</FindBugsFilter>

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsScope.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsScope.java
@@ -66,7 +66,7 @@ public enum CredentialsScope implements Serializable {
      * in the scope of the request. Where the request is something that happens automatically, e.g. a build triggered
      * by SCM polling, then USER scoped credentials are not usually appropriate (unless the action is one that can fail
      * gracefully)
-     * <p/>
+     * <p>
      * Another way of looking at this is, if the action is one that is configured from the {@link hudson.model.Job}'s
      * Configure page, then don't use USER scope, as that prevents another user from modifying the job configuration
      * (because they will only be able to see their own credentials)

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsStore.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsStore.java
@@ -61,8 +61,8 @@ public abstract class CredentialsStore implements AccessControlled {
 
     /**
      * Checks if the current security principal has this permission.
-     * <p/>
-     * <p/>
+     * <p>
+     * <p>
      * This is just a convenience function.
      *
      * @throws org.acegisecurity.AccessDeniedException
@@ -116,7 +116,7 @@ public abstract class CredentialsStore implements AccessControlled {
     /**
      * Identifies whether this {@link CredentialsStore} supports making changes to the list of domains or
      * whether it only supports a fixed set of domains (which may only be one domain).
-     * <p/>
+     * <p>
      * Note: in order for implementations to return {@code true} all of the following methods must be overridden:
      * <ul>
      * <li>{@link #getDomains}</li>

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsStoreAction.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsStoreAction.java
@@ -28,6 +28,7 @@ import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.domains.DomainSpecification;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.DescriptorExtensionList;
 import hudson.Extension;
 import hudson.Util;
@@ -196,8 +197,9 @@ public abstract class CredentialsStoreAction implements Action, IconSpec {
         getStore().checkPermission(MANAGE_DOMAINS);
         JSONObject data = req.getSubmittedForm();
         Domain domain = req.bindJSON(Domain.class, data);
-        if (getStore().addDomain(domain)) {
-            return HttpResponses.redirectTo("./domain/" + Util.rawEncode(domain.getName()));
+        String domainName = domain.getName();
+        if (domainName != null && getStore().addDomain(domain)) {
+            return HttpResponses.redirectTo("./domain/" + Util.rawEncode(domainName));
 
         }
         return HttpResponses.redirectToDot();
@@ -231,6 +233,7 @@ public abstract class CredentialsStoreAction implements Action, IconSpec {
         }
 
         @Exported
+        @SuppressFBWarnings(value="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification="isGlobal() check implies that domain.getName() is null")
         public String getUrlName() {
             return isGlobal() ? "_" : Util.rawEncode(domain.getName());
         }
@@ -320,8 +323,9 @@ public abstract class CredentialsStoreAction implements Action, IconSpec {
             getStore().checkPermission(MANAGE_DOMAINS);
             JSONObject data = req.getSubmittedForm();
             Domain domain = req.bindJSON(Domain.class, data);
-            if (getStore().updateDomain(this.domain, domain)) {
-                return HttpResponses.redirectTo("../../domain/" + Util.rawEncode(domain.getName()));
+            String domainName = domain.getName();
+            if (domainName != null && getStore().updateDomain(this.domain, domain)) {
+                return HttpResponses.redirectTo("../../domain/" + Util.rawEncode(domainName));
 
             }
             return HttpResponses.redirectToDot();

--- a/src/main/java/com/cloudbees/plugins/credentials/NameWith.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/NameWith.java
@@ -37,7 +37,7 @@ import java.lang.annotation.Target;
  * multiple equivalent credentials. With Java 8 defender methods we could add a default method to {@link Credentials}
  * however given the Java requirements of Jenkins we do not have this luxury. In any case different types of credentials
  * will have different types of naming schemes, eg certificates vs username/password.
- * <p/>
+ * <p>
  * This annotation is applied to implementations or to marker interfaces. Where an implementation class is annotated,
  * that annotation will always win, even if inherited. In the absence of the base class being annotated all the
  * interfaces that the credential implements will be checked for the annotation. When checking multiple interfaces,

--- a/src/main/java/com/cloudbees/plugins/credentials/common/AbstractIdCredentialsListBoxModel.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/common/AbstractIdCredentialsListBoxModel.java
@@ -39,13 +39,13 @@ import jenkins.model.Jenkins;
 
 /**
  * {@link ListBoxModel} with support for credentials.
- * <p/>
+ * <p>
  * This class is convenient for providing the {@code config.groovy} or {@code config.jelly} fragment for a collection of objects of some {@link IdCredentials} subtype.
- * <p/>
+ * <p>
  * If you want to let the user configure a credentials object, do the following:
- * <p/>
+ * <p>
  * First, create a field that stores the credentials ID and defines a corresponding parameter in the constructor:
- * <p/>
+ * <p>
  * <pre>
  * private String credentialsId;
  *
@@ -56,18 +56,18 @@ import jenkins.model.Jenkins;
  * }
  * public String getCredentialsId() {return credentialsId;}
  * </pre>
- * <p/>
+ * <p>
  * Your <tt>config.groovy</tt> should have the following entry to render a drop-down list box:
- * <p/>
+ * <p>
  * <pre>
  * f.entry(title:_("Credentials"), field:"credentialsId") {
  *     f.select()
  * }
  * </pre>
- * <p/>
+ * <p>
  * Finally, your {@link Descriptor} implementation should have the <tt>doFillCredentialsIdItems</tt> method, which
  * lists up the credentials available in this context:
- * <p/>
+ * <p>
  * <pre>
  * public ListBoxModel doFillCredentialsIdItems() {
  *     if (!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) { // or whatever permission is appropriate for this page
@@ -78,23 +78,23 @@ import jenkins.model.Jenkins;
  *         CredentialsProvider.lookupCredentials(StandardUsernameCredentials.class,...));
  * }
  * </pre>
- * <p/>
- * <p/>
+ * <p>
+ * <p>
  * Exactly which overloaded version of the {@link CredentialsProvider#lookupCredentials(Class)} depends on
  * the context in which your model operates. Here are a few common examples:
- * <p/>
+ * <p>
  * <dl>
  * <dt>System-level settings
  * <dd>
  * If your model is a singleton in the whole Jenkins instance, things that belong to the root {@link Jenkins}
  * (such as slaves), or do not have any ancestors serving as the context, then use {@link Jenkins#getInstance} as the context.
- * <p/>
+ * <p>
  * <dt>Job-level settings
  * <dd>
  * If your model is a configuration fragment added to a {@link Item} (such as its major subtype {@link Job}),
  * then use that {@link Item} as the context.
    For example:
- * <p/>
+ * <p>
  * <pre>
  * public ListBoxModel doFillCredentialsIdItems(&#64;AncestorInPath Item context, &#64;QueryParameter String source) {
  *     if (context == null || !context.hasPermission(Item.CONFIGURE)) {

--- a/src/main/java/com/cloudbees/plugins/credentials/common/IdCredentials.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/common/IdCredentials.java
@@ -33,7 +33,7 @@ import java.util.UUID;
 /**
  * Credentials that have an unique ID that assists in retrieving the specific credential from a collection of
  * {@link Credentials}.
- * <p/>
+ * <p>
  * Note: This credential interface is a marker interface
  *
  * @since 1.5

--- a/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/action.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/action.jelly
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<?jelly escape-by-default='true'?>
 <!--
  ~ The MIT License
  ~

--- a/src/main/resources/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl/FileOnMasterKeyStoreSource/config.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl/FileOnMasterKeyStoreSource/config.jelly
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<?jelly escape-by-default='true'?>
 <!--
  ~ The MIT License
  ~

--- a/src/main/resources/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl/UploadedKeyStoreSource/Upload/complete.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl/UploadedKeyStoreSource/Upload/complete.jelly
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<?jelly escape-by-default='true'?>
 <!--
  ~ The MIT License
  ~

--- a/src/main/resources/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl/UploadedKeyStoreSource/Upload/index.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl/UploadedKeyStoreSource/Upload/index.jelly
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<?jelly escape-by-default='true'?>
 <!--
  ~ The MIT License
  ~

--- a/src/main/resources/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl/UploadedKeyStoreSource/config.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl/UploadedKeyStoreSource/config.jelly
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<?jelly escape-by-default='true'?>
 <!--
  ~ The MIT License
  ~

--- a/src/main/resources/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl/credentials.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl/credentials.jelly
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<?jelly escape-by-default='true'?>
 <!--
  ~ The MIT License
  ~

--- a/src/main/resources/com/cloudbees/plugins/credentials/impl/Messages_ja.properties
+++ b/src/main/resources/com/cloudbees/plugins/credentials/impl/Messages_ja.properties
@@ -26,7 +26,6 @@ CertificateCredentialsImpl.DisplayName=\u8a3c\u660e\u66f8
 CertificateCredentialsImpl.EmptyKeystore=\u7a7a\u306e\u30ad\u30fc\u30b9\u30c8\u30a2
 CertificateCredentialsImpl.FileOnMasterKeyStoreSourceDisplayName=\
  Jenkins\u30de\u30b9\u30bf\u30fc\u4e0a\u306ePKCS#12\u8a3c\u660e\u66f8\u30d5\u30a1\u30a4\u30eb
-CertificateCredentialsImpl.FileOnMasterKeyStoreSourceDisplayName=Jenkins\u30de\u30b9\u30bf\u30fc\u4e0a\u306ePKCS#12\u8a3c\u660e\u66f8\u30d5\u30a1\u30a4\u30eb
 CertificateCredentialsImpl.KeyStoreFileDoesNotExist=\u30d5\u30a1\u30a4\u30eb "{0}" \u306f\u5b58\u5728\u3057\u307e\u305b\u3093\u3002
 CertificateCredentialsImpl.KeyStoreFileUnreadable=\u30d5\u30a1\u30a4\u30eb "{0}" \u3092\u8aad\u3081\u307e\u305b\u3093\u3067\u3057\u305f\u3002
 CertificateCredentialsImpl.KeyStoreFileUnspecified=\u30d5\u30a1\u30a4\u30eb\u306e\u30d1\u30b9\u3092\u6307\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002

--- a/src/main/resources/com/cloudbees/plugins/credentials/impl/UsernamePasswordCredentialsImpl/credentials.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/impl/UsernamePasswordCredentialsImpl/credentials.jelly
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<?jelly escape-by-default='true'?>
 <!--
  ~ The MIT License
  ~

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
 This plugin allows you to store credentials in Jenkins.
 </div>


### PR DESCRIPTION
Upgrade to new parent pom. More info [here](https://github.com/jenkinsci/plugin-pom)

- [x] Upgrade to new parent pom (version 2.4) keeping the same baseline version.
- [x] Fix Injected tests.
- [x] Fix Javadoc issues.

@reviewbybees 