### PR TITLE
[JENKINS-34329] Stop allowing to update domains to have blank names

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsStoreAction.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsStoreAction.java
@@ -355,7 +355,7 @@ public abstract class CredentialsStoreAction implements Action, IconSpec {
                                               @AncestorInPath CredentialsStoreAction action,
                                               @QueryParameter String value) {
                 if (StringUtils.isBlank(value)) {
-                    return FormValidation.warning(Messages.CredentialsStoreAction_EmptyDomainNameMessage());
+                    return FormValidation.error(Messages.CredentialsStoreAction_EmptyDomainNameMessage());
                 }
                 try {
                     Jenkins.checkGoodName(value);

--- a/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/DomainWrapper/configure.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/DomainWrapper/configure.jelly
@@ -64,7 +64,7 @@
 
         function updateSave(form) {
           function state() {
-            return ($('name').value.length == 0);
+            return ($('name').value.length === 0);
           }
 
           saveButton.set('disabled', state(), false);

--- a/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/DomainWrapper/configure.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/DomainWrapper/configure.jelly
@@ -44,7 +44,7 @@
         <j:otherwise>
           <f:form action="configSubmit" method="POST" name="config">
             <f:entry title="${%Name}" help="/plugin/credentials/help/domain/name.html">
-              <f:textbox field="name"/>
+              <f:textbox field="name" id="name" onchange="updateSave(this.form)" onkeyup="updateSave(this.form)"/>
             </f:entry>
             <f:entry title="${%Description}" help="/plugin/credentials/help/domain/description.html">
               <f:textarea field="description"/>
@@ -54,11 +54,24 @@
                              items="${instance.specifications}"/>
             </f:entry>
             <f:bottomButtonBar>
-              <f:submit value="${%Save}"/>
+              <input type="submit" name="Submit" value="${%Save}" id="save" style="margin-left:5em" />
             </f:bottomButtonBar>
           </f:form>
         </j:otherwise>
       </j:choose>
+      <script><![CDATA[
+        var saveButton = makeButton($('save'), null);
+
+        function updateSave(form) {
+          function state() {
+            return ($('name').value.length == 0);
+          }
+
+          saveButton.set('disabled', state(), false);
+        }
+
+        updateSave(saveButton.getForm());
+        ]]></script>
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/newDomain.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/newDomain.jelly
@@ -56,7 +56,7 @@
 
         function updateOk(form) {
           function state() {
-            return ($('name').value.length == 0);
+            return ($('name').value.length === 0);
           }
 
           okButton.set('disabled', state(), false);


### PR DESCRIPTION
See [JENKINS-34329](https://issues.jenkins-ci.org/browse/JENKINS-34329)

This issue is fixed with this PR that addresses the front-end part together with #44 that addresses the backend part [here](https://github.com/jenkinsci/credentials-plugin/pull/44/files#diff-07a1bb67aa87372e137c913c122e6da7L199) and [here](https://github.com/jenkinsci/credentials-plugin/pull/44/files#diff-07a1bb67aa87372e137c913c122e6da7L323)

- [x] Changed form validation message from warning to error since this is a required field.
- [x] Used same methodology to disable the button as in [newDomain.jelly](https://github.com/jenkinsci/credentials-plugin/blob/master/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/newDomain.jelly) 

@reviewbybees esp. @stephenc 