### PR TITLE
[JENKINS-28407] Create Credentials through CLI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,12 @@
       <artifactId>antlr4-runtime</artifactId>
       <version>${antlr4.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.kohsuke.metainf-services</groupId>
+      <artifactId>metainf-services</artifactId>
+      <version>1.4</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,12 @@
       <version>1.4</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.xmlunit</groupId>
+      <artifactId>xmlunit-matchers</artifactId>
+      <version>2.2.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
@@ -83,6 +83,23 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
         implements ExtensionPoint, Describable<CredentialsProvider>, IconSpec {
 
     /**
+     * A {@link CredentialsProvider} that does nothing for use as a marker
+     *
+     * @since 2.1.1
+     */
+    public static CredentialsProvider NONE = new CredentialsProvider() {
+        /**
+         * {@inheritDoc}
+         */
+        @NonNull
+        @Override
+        public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
+                                                              @Nullable Authentication authentication) {
+            return Collections.emptyList();
+        }
+    };
+
+    /**
      * The permission group for credentials.
      *
      * @since 1.8

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
@@ -87,7 +87,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      *
      * @since 2.1.1
      */
-    public static CredentialsProvider NONE = new CredentialsProvider() {
+    public static final CredentialsProvider NONE = new CredentialsProvider() {
         /**
          * {@inheritDoc}
          */

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsSelectHelper.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsSelectHelper.java
@@ -740,7 +740,8 @@ public class CredentialsSelectHelper extends Descriptor<CredentialsSelectHelper>
          * Returns a human readable descripton of the type of context objects that this resolver resolves.
          * @return a human readable descripton of the type of context objects that this resolver resolves.
          * @throws AbstractMethodError if somebody compiled against pre-2.1.1 implementations. Use
-         * {@link #displayName(ContextResolver)} if you would prefer not to have to catch them.
+         * {@link CredentialsSelectHelper.ContextResolver#displayName(CredentialsSelectHelper.ContextResolver)}
+         * if you would prefer not to have to catch them.
          * @since 2.1.1
          */
         @NonNull
@@ -749,6 +750,7 @@ public class CredentialsSelectHelper extends Descriptor<CredentialsSelectHelper>
         /**
          * Returns a human readable descripton of the type of context objects that the specified resolver resolves.
          *
+         * @param resolver the context resolver to get the display name of.
          * @return a human readable descripton of the type of context objects that the specified resolver resolves.
          * @since 2.1.1
          */

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsStore.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsStore.java
@@ -50,6 +50,7 @@ import java.util.Iterator;
 import java.util.List;
 import jenkins.model.Jenkins;
 import org.acegisecurity.Authentication;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -207,6 +208,23 @@ public abstract class CredentialsStore implements AccessControlled {
     @NonNull
     public List<Domain> getDomains() {
         return Collections.singletonList(Domain.global());
+    }
+
+    /**
+     * Retrieves the domain with the matching name.
+     *
+     * @param name the name (or {@code null} to match {@link Domain#global()} as that is the domain with a null name)
+     * @return the domain or {@code null} if there is no domain with the supplied name.
+     * @since 2.1.1
+     */
+    @CheckForNull
+    public Domain getDomainByName(@CheckForNull String name) {
+        for (Domain d : getDomains()) {
+            if (StringUtils.equals(name, d.getName())) {
+                return d;
+            }
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsStoreAction.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsStoreAction.java
@@ -901,6 +901,8 @@ public abstract class CredentialsStoreAction
          * @since 2.1.1
          */
         @WebMethod(name = "config.xml")
+        @Restricted(NoExternalUse.class)
+        @SuppressWarnings("unused") // stapler web method
         public void doConfigDotXml(StaplerRequest req, StaplerResponse rsp)
                 throws IOException {
             getStore().checkPermission(CredentialsProvider.MANAGE_DOMAINS);
@@ -916,6 +918,14 @@ public abstract class CredentialsStoreAction
                 updateByXml(new StreamSource(req.getReader()));
                 return;
             }
+            if (req.getMethod().equals("DELETE") && getStore().isDomainsModifiable()) {
+                if (getStore().removeDomain(domain)) {
+                    return;
+                } else {
+                    rsp.sendError(HttpServletResponse.SC_CONFLICT);
+                    return;
+                }
+            }
 
             // huh?
             rsp.sendError(HttpServletResponse.SC_BAD_REQUEST);
@@ -930,6 +940,7 @@ public abstract class CredentialsStoreAction
          * @throws IOException if things go wrong.
          * @since 2.1.1
          */
+        @Restricted(NoExternalUse.class)
         public void updateByXml(Source source) throws IOException {
             getStore().checkPermission(CredentialsProvider.MANAGE_DOMAINS);
             final StringWriter out = new StringWriter();
@@ -1304,6 +1315,7 @@ public abstract class CredentialsStoreAction
          * @since 2.0
          */
         @CheckForNull
+        @Restricted(NoExternalUse.class)
         public ContextMenu getContextMenu(String prefix) {
             if (getStore().hasPermission(UPDATE) || getStore().hasPermission(DELETE)) {
                 ContextMenu result = new ContextMenu();
@@ -1347,6 +1359,8 @@ public abstract class CredentialsStoreAction
          * @since 2.1.1
          */
         @WebMethod(name = "config.xml")
+        @Restricted(NoExternalUse.class)
+        @SuppressWarnings("unused") // stapler web method
         public void doConfigDotXml(StaplerRequest req, StaplerResponse rsp)
                 throws IOException {
             if (req.getMethod().equals("GET")) {
@@ -1362,6 +1376,15 @@ public abstract class CredentialsStoreAction
                 updateByXml(new StreamSource(req.getReader()));
                 return;
             }
+            if (req.getMethod().equals("DELETE")) {
+                getStore().checkPermission(DELETE);
+                if (getStore().removeCredentials(domain.getDomain(), credentials)) {
+                    return;
+                } else {
+                    rsp.sendError(HttpServletResponse.SC_CONFLICT);
+                    return;
+                }
+            }
 
             // huh?
             rsp.sendError(HttpServletResponse.SC_BAD_REQUEST);
@@ -1376,6 +1399,7 @@ public abstract class CredentialsStoreAction
          * @throws IOException if things go wrong
          * @since 2.1.1
          */
+        @Restricted(NoExternalUse.class)
         public void updateByXml(Source source) throws IOException {
             getStore().checkPermission(UPDATE);
             final StringWriter out = new StringWriter();

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsStoreAction.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsStoreAction.java
@@ -27,6 +27,12 @@ import com.cloudbees.plugins.credentials.common.IdCredentials;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.domains.DomainSpecification;
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import com.thoughtworks.xstream.io.xml.XppDriver;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -40,6 +46,7 @@ import hudson.model.Descriptor;
 import hudson.model.Failure;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
+import hudson.model.Items;
 import hudson.model.ModelObject;
 import hudson.model.User;
 import hudson.security.ACL;
@@ -47,7 +54,12 @@ import hudson.security.AccessControlled;
 import hudson.security.Permission;
 import hudson.util.FormValidation;
 import hudson.util.HttpResponses;
+import hudson.util.Secret;
+import hudson.util.XStream2;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.StringReader;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -57,9 +69,15 @@ import java.util.Map;
 import java.util.TreeMap;
 import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+import javax.xml.transform.Source;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
 import jenkins.model.Jenkins;
 import jenkins.model.ModelObjectWithChildren;
 import jenkins.model.ModelObjectWithContextMenu;
+import jenkins.util.xml.XMLUtils;
 import net.sf.json.JSONObject;
 import org.acegisecurity.AccessDeniedException;
 import org.apache.commons.lang.StringUtils;
@@ -71,9 +89,11 @@ import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.WebMethod;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 import org.kohsuke.stapler.interceptor.RequirePOST;
+import org.xml.sax.SAXException;
 
 import static com.cloudbees.plugins.credentials.ContextMenuIconUtils.getMenuItemIconUrlByClassSpec;
 
@@ -104,6 +124,32 @@ public abstract class CredentialsStoreAction
      * Expose {@link CredentialsProvider#MANAGE_DOMAINS} for Jelly.
      */
     public static final Permission MANAGE_DOMAINS = CredentialsProvider.MANAGE_DOMAINS;
+
+    /**
+     * An {@link XStream2} that replaces {@link Secret} instances with {@literal REDACTED}
+     *
+     * @since 2.1.1
+     */
+    public static final XStream2 SECRETS_REDACTED;
+
+    static {
+        SECRETS_REDACTED = new XStream2();
+        SECRETS_REDACTED.registerConverter(new Converter() {
+
+            public boolean canConvert(Class type) {
+                return type == Secret.class;
+            }
+
+            public void marshal(Object source, HierarchicalStreamWriter writer, MarshallingContext context) {
+                writer.startNode("secret-redacted");
+                writer.endNode();
+            }
+
+            public Object unmarshal(HierarchicalStreamReader reader, final UnmarshallingContext context) {
+                return null;
+            }
+        });
+    }
 
     /**
      * Returns the {@link CredentialsStore} backing this action.
@@ -425,14 +471,42 @@ public abstract class CredentialsStoreAction
     @RequirePOST
     public HttpResponse doCreateDomain(StaplerRequest req) throws ServletException, IOException {
         getStore().checkPermission(MANAGE_DOMAINS);
-        JSONObject data = req.getSubmittedForm();
-        Domain domain = req.bindJSON(Domain.class, data);
-        String domainName = domain.getName();
-        if (domainName != null && getStore().addDomain(domain)) {
-            return HttpResponses.redirectTo("./domain/" + Util.rawEncode(domainName));
-
+        if (!getStore().isDomainsModifiable()) {
+            return HttpResponses.status(HttpServletResponse.SC_BAD_REQUEST);
         }
-        return HttpResponses.redirectToDot();
+        String requestContentType = req.getContentType();
+        if (requestContentType == null) {
+            throw new Failure("No Content-Type header set");
+        }
+
+        if (requestContentType.startsWith("application/xml") || requestContentType.startsWith("text/xml")) {
+            final StringWriter out = new StringWriter();
+            try {
+                XMLUtils.safeTransform(new StreamSource(req.getReader()), new StreamResult(out));
+                out.close();
+            } catch (TransformerException e) {
+                throw new IOException("Failed to parse credential", e);
+            } catch (SAXException e) {
+                throw new IOException("Failed to parse credential", e);
+            }
+
+            Domain domain = (Domain)
+                    Items.XSTREAM.unmarshal(new XppDriver().createReader(new StringReader(out.toString())));
+            if (getStore().addDomain(domain)) {
+                return HttpResponses.ok();
+            } else {
+                return HttpResponses.status(HttpServletResponse.SC_CONFLICT);
+            }
+        } else {
+            JSONObject data = req.getSubmittedForm();
+            Domain domain = req.bindJSON(Domain.class, data);
+            String domainName = domain.getName();
+            if (domainName != null && getStore().addDomain(domain)) {
+                return HttpResponses.redirectTo("./domain/" + Util.rawEncode(domainName));
+
+            }
+            return HttpResponses.redirectToDot();
+        }
     }
 
     /**
@@ -666,10 +740,35 @@ public abstract class CredentialsStoreAction
         @SuppressWarnings("unused") // stapler web method
         public HttpResponse doCreateCredentials(StaplerRequest req) throws ServletException, IOException {
             getStore().checkPermission(CREATE);
-            JSONObject data = req.getSubmittedForm();
-            Credentials credentials = req.bindJSON(Credentials.class, data.getJSONObject("credentials"));
-            getStore().addCredentials(domain, credentials);
-            return HttpResponses.redirectTo("../../domain/" + getUrlName());
+            String requestContentType = req.getContentType();
+            if (requestContentType == null) {
+                throw new Failure("No Content-Type header set");
+            }
+
+            if (requestContentType.startsWith("application/xml") || requestContentType.startsWith("text/xml")) {
+                final StringWriter out = new StringWriter();
+                try {
+                    XMLUtils.safeTransform(new StreamSource(req.getReader()), new StreamResult(out));
+                    out.close();
+                } catch (TransformerException e) {
+                    throw new IOException("Failed to parse credential", e);
+                } catch (SAXException e) {
+                    throw new IOException("Failed to parse credential", e);
+                }
+
+                Credentials credentials = (Credentials)
+                        Items.XSTREAM.unmarshal(new XppDriver().createReader(new StringReader(out.toString())));
+                if (getStore().addCredentials(domain, credentials)) {
+                    return HttpResponses.ok();
+                } else {
+                    return HttpResponses.status(HttpServletResponse.SC_CONFLICT);
+                }
+            } else {
+                JSONObject data = req.getSubmittedForm();
+                Credentials credentials = req.bindJSON(Credentials.class, data.getJSONObject("credentials"));
+                getStore().addCredentials(domain, credentials);
+                return HttpResponses.redirectTo("../../domain/" + getUrlName());
+            }
         }
 
         /**
@@ -791,6 +890,61 @@ public abstract class CredentialsStoreAction
         public ContextMenu doChildrenContextMenu(StaplerRequest request,
                                                  StaplerResponse response) throws Exception {
             return getChildrenContextMenu("");
+        }
+
+        /**
+         * Accepts {@literal config.xml} submission, as well as serve it.
+         *
+         * @param req the request
+         * @param rsp the response
+         * @throws IOException if things go wrong
+         * @since 2.1.1
+         */
+        @WebMethod(name = "config.xml")
+        public void doConfigDotXml(StaplerRequest req, StaplerResponse rsp)
+                throws IOException {
+            getStore().checkPermission(CredentialsProvider.MANAGE_DOMAINS);
+            if (req.getMethod().equals("GET")) {
+                // read
+                rsp.setContentType("application/xml");
+                Items.XSTREAM2.toXML(domain,
+                        new OutputStreamWriter(rsp.getOutputStream(), rsp.getCharacterEncoding()));
+                return;
+            }
+            if (req.getMethod().equals("POST") && getStore().isDomainsModifiable()) {
+                // submission
+                updateByXml(new StreamSource(req.getReader()));
+                return;
+            }
+
+            // huh?
+            rsp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+        }
+
+        /**
+         * Updates a {@link Credentials} by its XML definition.
+         *
+         * @param source source of the Item's new definition.
+         *               The source should be either a <code>StreamSource</code> or a <code>SAXSource</code>, other
+         *               sources may not be handled.
+         * @throws IOException if things go wrong.
+         * @since 2.1.1
+         */
+        public void updateByXml(Source source) throws IOException {
+            getStore().checkPermission(CredentialsProvider.MANAGE_DOMAINS);
+            final StringWriter out = new StringWriter();
+            try {
+                XMLUtils.safeTransform(source, new StreamResult(out));
+                out.close();
+            } catch (TransformerException e) {
+                throw new IOException("Failed to parse credential", e);
+            } catch (SAXException e) {
+                throw new IOException("Failed to parse credential", e);
+            }
+
+            Domain replacement = (Domain)
+                    Items.XSTREAM.unmarshal(new XppDriver().createReader(new StringReader(out.toString())));
+            getStore().updateDomain(domain, replacement);
         }
 
         /**
@@ -1182,6 +1336,61 @@ public abstract class CredentialsStoreAction
         public ContextMenu doContextMenu(StaplerRequest request, StaplerResponse response)
                 throws Exception {
             return getContextMenu("");
+        }
+
+        /**
+         * Accepts {@literal config.xml} submission, as well as serve it.
+         *
+         * @param req the request
+         * @param rsp the response
+         * @throws IOException if things go wrong
+         * @since 2.1.1
+         */
+        @WebMethod(name = "config.xml")
+        public void doConfigDotXml(StaplerRequest req, StaplerResponse rsp)
+                throws IOException {
+            if (req.getMethod().equals("GET")) {
+                // read
+                getStore().checkPermission(VIEW);
+                rsp.setContentType("application/xml");
+                SECRETS_REDACTED.toXML(credentials,
+                        new OutputStreamWriter(rsp.getOutputStream(), rsp.getCharacterEncoding()));
+                return;
+            }
+            if (req.getMethod().equals("POST")) {
+                // submission
+                updateByXml(new StreamSource(req.getReader()));
+                return;
+            }
+
+            // huh?
+            rsp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+        }
+
+        /**
+         * Updates a {@link Credentials} by its XML definition.
+         *
+         * @param source source of the Item's new definition.
+         *               The source should be either a <code>StreamSource</code> or a <code>SAXSource</code>, other
+         *               sources may not be handled.
+         * @throws IOException if things go wrong
+         * @since 2.1.1
+         */
+        public void updateByXml(Source source) throws IOException {
+            getStore().checkPermission(UPDATE);
+            final StringWriter out = new StringWriter();
+            try {
+                XMLUtils.safeTransform(source, new StreamResult(out));
+                out.close();
+            } catch (TransformerException e) {
+                throw new IOException("Failed to parse credential", e);
+            } catch (SAXException e) {
+                throw new IOException("Failed to parse credential", e);
+            }
+
+            Credentials credentials = (Credentials)
+                    Items.XSTREAM.unmarshal(new XppDriver().createReader(new StringReader(out.toString())));
+            getStore().updateCredentials(domain.getDomain(), this.credentials, credentials);
         }
 
         /**

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/BaseCredentialsCLICommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/BaseCredentialsCLICommand.java
@@ -1,0 +1,110 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc..
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.plugins.credentials.cli;
+
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.common.IdCredentials;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.xml.XppDriver;
+import hudson.cli.CLICommand;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.xml.transform.Source;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+import jenkins.util.xml.XMLUtils;
+import org.apache.commons.lang.StringUtils;
+import org.xml.sax.SAXException;
+
+/**
+ * Base class for the Credentials CLI commands.
+ *
+ * @since 2.1.1
+ */
+public abstract class BaseCredentialsCLICommand extends CLICommand {
+    protected static Credentials getCredentialsById(CredentialsStore store, Domain domain, String id) {
+        List<Credentials> credentialsList = store.getCredentials(domain);
+        Set<String> ids = new HashSet<String>(credentialsList.size());
+        Credentials existing = null;
+        int index = 0;
+        for (Credentials c : credentialsList) {
+            String cid;
+            if (c instanceof IdCredentials) {
+                cid = ((IdCredentials) c).getId();
+            } else {
+                while (ids.contains("index-" + index)) {
+                    index++;
+                }
+                cid = "index-" + index;
+                index++;
+            }
+            if (id.equals(cid)) {
+                existing = c;
+                break;
+            }
+            ids.add(cid);
+        }
+        return existing;
+    }
+
+    protected static Domain getDomainByName(CredentialsStore store, String domain) {
+        if (StringUtils.equals("_", domain) || StringUtils.isBlank(domain) || "(global)".equals(domain)) {
+            return Domain.global();
+        } else {
+            for (Domain d : store.getDomains()) {
+                if (domain.equals(d.getName())) {
+                    return d;
+                }
+            }
+        }
+        return null;
+    }
+
+
+    protected static HierarchicalStreamReader safeXmlStreamReader(InputStream stream) throws IOException {
+        return safeXmlStreamReader(new StreamSource(stream));
+    }
+
+    protected static HierarchicalStreamReader safeXmlStreamReader(Source source) throws IOException {
+        final StringWriter out = new StringWriter();
+        try {
+            XMLUtils.safeTransform(source, new StreamResult(out));
+            out.close();
+        } catch (TransformerException e) {
+            throw new IOException("Failed to parse", e);
+        } catch (SAXException e) {
+            throw new IOException("Failed to parse", e);
+        }
+        return new XppDriver().createReader(new StringReader(out.toString()));
+
+    }
+}

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/CreateCredentialsByXmlCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/CreateCredentialsByXmlCommand.java
@@ -27,7 +27,6 @@ import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.domains.Domain;
-import com.thoughtworks.xstream.io.xml.XppDriver;
 import hudson.Extension;
 import hudson.model.Items;
 import org.kohsuke.args4j.Argument;

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/CreateCredentialsByXmlCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/CreateCredentialsByXmlCommand.java
@@ -50,7 +50,7 @@ public class CreateCredentialsByXmlCommand extends BaseCredentialsCLICommand {
      */
     @Override
     public String getShortDescription() {
-        return "Create credentials by XML";
+        return Messages.CreateCredentialsByXmlCommand_ShortDescription();
     }
 
     /**

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/CreateCredentialsByXmlCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/CreateCredentialsByXmlCommand.java
@@ -23,25 +23,34 @@
  */
 package com.cloudbees.plugins.credentials.cli;
 
-import com.cloudbees.plugins.credentials.CredentialsSelectHelper;
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.thoughtworks.xstream.io.xml.XppDriver;
 import hudson.Extension;
-import hudson.cli.CLICommand;
-import java.util.Map;
-import org.apache.commons.lang.StringUtils;
+import hudson.model.Items;
+import org.kohsuke.args4j.Argument;
 
 /**
- * Lists the {@link CredentialsSelectHelper.ContextResolver} instances and the context objects they resolve.
+ * Create a new credentials instance by XML.
  *
  * @since 2.1.1
  */
 @Extension
-public class ListCredentialsContextResolversCommand extends BaseCredentialsCLICommand {
+public class CreateCredentialsByXmlCommand extends BaseCredentialsCLICommand {
+    @Argument(metaVar = "STORE", usage = "Store Id", required = true)
+    public CredentialsStore store;
+
+    @Argument(metaVar = "DOMAIN", usage = "Domain Name", required = true, index = 1)
+    public String domain;
+
     /**
      * {@inheritDoc}
      */
     @Override
     public String getShortDescription() {
-        return "List Credentials Context Resolvers";
+        return "Create credentials by XML";
     }
 
     /**
@@ -49,21 +58,18 @@ public class ListCredentialsContextResolversCommand extends BaseCredentialsCLICo
      */
     @Override
     protected int run() throws Exception {
-        Map<String, CredentialsSelectHelper.ContextResolver> resolversByName =
-                CredentialsSelectHelper.getResolversByName();
-        int maxNameLen = 0, maxDisplayLen = 0;
-        for (Map.Entry<String, CredentialsSelectHelper.ContextResolver> entry : resolversByName.entrySet()) {
-            maxNameLen = Math.max(maxNameLen, entry.getKey().length());
-            maxDisplayLen = Math.max(maxDisplayLen,
-                    CredentialsSelectHelper.ContextResolver.displayName(entry.getValue()).length());
+        store.checkPermission(CredentialsProvider.CREATE);
+        Domain domain = getDomainByName(store, this.domain);
+        if (domain == null) {
+            stderr.println("No such domain");
+            return 2;
         }
-        stdout.println(StringUtils.rightPad("Name", maxNameLen) + " Resolves");
-        stdout.println(StringUtils.repeat("=", maxNameLen) + " " + StringUtils.repeat("=", maxDisplayLen));
-        for (Map.Entry<String, CredentialsSelectHelper.ContextResolver> entry : resolversByName.entrySet()) {
-            stdout.println(StringUtils.rightPad(entry.getKey(), maxNameLen)
-                    + " "
-                    + CredentialsSelectHelper.ContextResolver.displayName(entry.getValue()));
+
+        Credentials credentials = (Credentials) Items.XSTREAM.unmarshal(safeXmlStreamReader(stdin));
+        if (store.addCredentials(domain, credentials)) {
+            return 0;
         }
-        return 0;
+        stderr.println("No change");
+        return 1;
     }
 }

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/CreateCredentialsDomainByXmlCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/CreateCredentialsDomainByXmlCommand.java
@@ -23,11 +23,9 @@
  */
 package com.cloudbees.plugins.credentials.cli;
 
-import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.domains.Domain;
-import com.thoughtworks.xstream.io.xml.XppDriver;
 import hudson.Extension;
 import hudson.model.Items;
 import org.kohsuke.args4j.Argument;

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/CreateCredentialsDomainByXmlCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/CreateCredentialsDomainByXmlCommand.java
@@ -47,7 +47,7 @@ public class CreateCredentialsDomainByXmlCommand extends BaseCredentialsCLIComma
      */
     @Override
     public String getShortDescription() {
-        return "Create credentials domain by XML";
+        return Messages.CreateCredentialsDomainByXmlCommand_ShortDescription();
     }
 
     /**

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/CredentialsStoreOptionHandler.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/CredentialsStoreOptionHandler.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc..
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.plugins.credentials.cli;
+
+import com.cloudbees.plugins.credentials.CredentialsSelectHelper;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import org.kohsuke.MetaInfServices;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.OptionDef;
+import org.kohsuke.args4j.spi.OptionHandler;
+import org.kohsuke.args4j.spi.Parameters;
+import org.kohsuke.args4j.spi.Setter;
+
+/**
+ * An {@link OptionHandler} for resolving {@link CredentialsStore} instances.
+ *
+ * @since 2.1.1
+ */
+@MetaInfServices(OptionHandler.class)
+public class CredentialsStoreOptionHandler extends OptionHandler<CredentialsStore> {
+    /**
+     * {@inheritDoc}
+     */
+    public CredentialsStoreOptionHandler(CmdLineParser parser, OptionDef option,
+                                         Setter<? super CredentialsStore> setter) {
+        super(parser, option, setter);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int parseArguments(Parameters params) throws CmdLineException {
+        final String storeId = params.getParameter(0);
+        setter.addValue(CredentialsSelectHelper.resolveForCLI(storeId));
+        return 1;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getDefaultMetaVariable() {
+        return "STORE";
+    }
+}

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/DeleteCredentialsCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/DeleteCredentialsCommand.java
@@ -51,7 +51,7 @@ public class DeleteCredentialsCommand extends BaseCredentialsCLICommand {
      */
     @Override
     public String getShortDescription() {
-        return "Deletes credentials";
+        return Messages.DeleteCredentialsCommand_ShortDescription();
     }
 
     /**

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/DeleteCredentialsCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/DeleteCredentialsCommand.java
@@ -23,25 +23,35 @@
  */
 package com.cloudbees.plugins.credentials.cli;
 
-import com.cloudbees.plugins.credentials.CredentialsSelectHelper;
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.domains.Domain;
 import hudson.Extension;
-import hudson.cli.CLICommand;
-import java.util.Map;
-import org.apache.commons.lang.StringUtils;
+import org.kohsuke.args4j.Argument;
 
 /**
- * Lists the {@link CredentialsSelectHelper.ContextResolver} instances and the context objects they resolve.
+ * Deletes a credential.
  *
  * @since 2.1.1
  */
 @Extension
-public class ListCredentialsContextResolversCommand extends BaseCredentialsCLICommand {
+public class DeleteCredentialsCommand extends BaseCredentialsCLICommand {
+    @Argument(metaVar = "STORE", usage = "Store Id", required = true)
+    public CredentialsStore store;
+
+    @Argument(metaVar = "DOMAIN", usage = "Domain Name", required = true, index = 1)
+    public String domain;
+
+    @Argument(metaVar = "CREDENTIAL", usage = "Credential Id", required = true, index = 2)
+    public String id;
+
     /**
      * {@inheritDoc}
      */
     @Override
     public String getShortDescription() {
-        return "List Credentials Context Resolvers";
+        return "Deletes credentials";
     }
 
     /**
@@ -49,21 +59,23 @@ public class ListCredentialsContextResolversCommand extends BaseCredentialsCLICo
      */
     @Override
     protected int run() throws Exception {
-        Map<String, CredentialsSelectHelper.ContextResolver> resolversByName =
-                CredentialsSelectHelper.getResolversByName();
-        int maxNameLen = 0, maxDisplayLen = 0;
-        for (Map.Entry<String, CredentialsSelectHelper.ContextResolver> entry : resolversByName.entrySet()) {
-            maxNameLen = Math.max(maxNameLen, entry.getKey().length());
-            maxDisplayLen = Math.max(maxDisplayLen,
-                    CredentialsSelectHelper.ContextResolver.displayName(entry.getValue()).length());
+        store.checkPermission(CredentialsProvider.DELETE);
+        Domain domain = getDomainByName(store, this.domain);
+        if (domain == null) {
+            stderr.println("No such domain");
+            return 2;
         }
-        stdout.println(StringUtils.rightPad("Name", maxNameLen) + " Resolves");
-        stdout.println(StringUtils.repeat("=", maxNameLen) + " " + StringUtils.repeat("=", maxDisplayLen));
-        for (Map.Entry<String, CredentialsSelectHelper.ContextResolver> entry : resolversByName.entrySet()) {
-            stdout.println(StringUtils.rightPad(entry.getKey(), maxNameLen)
-                    + " "
-                    + CredentialsSelectHelper.ContextResolver.displayName(entry.getValue()));
+        Credentials existing = getCredentialsById(store, domain, id);
+        if (existing == null) {
+            stderr.println("No such credential");
+            return 3;
         }
-        return 0;
+
+        if (store.removeCredentials(domain, existing)) {
+            return 0;
+        }
+        stderr.println("Not deleted");
+        return 1;
     }
+
 }

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/DeleteCredentialsDomainCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/DeleteCredentialsDomainCommand.java
@@ -23,7 +23,6 @@
  */
 package com.cloudbees.plugins.credentials.cli;
 
-import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.domains.Domain;

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/DeleteCredentialsDomainCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/DeleteCredentialsDomainCommand.java
@@ -42,9 +42,6 @@ public class DeleteCredentialsDomainCommand extends BaseCredentialsCLICommand {
     @Argument(metaVar = "DOMAIN", usage = "Domain Name", required = true, index = 1)
     public String domain;
 
-    @Argument(metaVar = "CREDENTIAL", usage = "Credential Id", required = true, index = 2)
-    public String id;
-
     /**
      * {@inheritDoc}
      */

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/DeleteCredentialsDomainCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/DeleteCredentialsDomainCommand.java
@@ -23,25 +23,35 @@
  */
 package com.cloudbees.plugins.credentials.cli;
 
-import com.cloudbees.plugins.credentials.CredentialsSelectHelper;
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.domains.Domain;
 import hudson.Extension;
-import hudson.cli.CLICommand;
-import java.util.Map;
-import org.apache.commons.lang.StringUtils;
+import org.kohsuke.args4j.Argument;
 
 /**
- * Lists the {@link CredentialsSelectHelper.ContextResolver} instances and the context objects they resolve.
+ * Deletes a credentials domain.
  *
  * @since 2.1.1
  */
 @Extension
-public class ListCredentialsContextResolversCommand extends BaseCredentialsCLICommand {
+public class DeleteCredentialsDomainCommand extends BaseCredentialsCLICommand {
+    @Argument(metaVar = "STORE", usage = "Store Id", required = true)
+    public CredentialsStore store;
+
+    @Argument(metaVar = "DOMAIN", usage = "Domain Name", required = true, index = 1)
+    public String domain;
+
+    @Argument(metaVar = "CREDENTIAL", usage = "Credential Id", required = true, index = 2)
+    public String id;
+
     /**
      * {@inheritDoc}
      */
     @Override
     public String getShortDescription() {
-        return "List Credentials Context Resolvers";
+        return "Delete a credentials domain";
     }
 
     /**
@@ -49,21 +59,18 @@ public class ListCredentialsContextResolversCommand extends BaseCredentialsCLICo
      */
     @Override
     protected int run() throws Exception {
-        Map<String, CredentialsSelectHelper.ContextResolver> resolversByName =
-                CredentialsSelectHelper.getResolversByName();
-        int maxNameLen = 0, maxDisplayLen = 0;
-        for (Map.Entry<String, CredentialsSelectHelper.ContextResolver> entry : resolversByName.entrySet()) {
-            maxNameLen = Math.max(maxNameLen, entry.getKey().length());
-            maxDisplayLen = Math.max(maxDisplayLen,
-                    CredentialsSelectHelper.ContextResolver.displayName(entry.getValue()).length());
+        store.checkPermission(CredentialsProvider.MANAGE_DOMAINS);
+        Domain domain = getDomainByName(store, this.domain);
+        if (domain == null) {
+            stderr.println("No such domain");
+            return 2;
         }
-        stdout.println(StringUtils.rightPad("Name", maxNameLen) + " Resolves");
-        stdout.println(StringUtils.repeat("=", maxNameLen) + " " + StringUtils.repeat("=", maxDisplayLen));
-        for (Map.Entry<String, CredentialsSelectHelper.ContextResolver> entry : resolversByName.entrySet()) {
-            stdout.println(StringUtils.rightPad(entry.getKey(), maxNameLen)
-                    + " "
-                    + CredentialsSelectHelper.ContextResolver.displayName(entry.getValue()));
+
+        if (store.removeDomain(domain)) {
+            return 0;
         }
-        return 0;
+        stderr.println("Not deleted");
+        return 1;
     }
+
 }

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/DeleteCredentialsDomainCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/DeleteCredentialsDomainCommand.java
@@ -51,7 +51,7 @@ public class DeleteCredentialsDomainCommand extends BaseCredentialsCLICommand {
      */
     @Override
     public String getShortDescription() {
-        return "Delete a credentials domain";
+        return Messages.DeleteCredentialsDomainCommand_ShortDescription();
     }
 
     /**

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/GetCredentialsAsXmlCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/GetCredentialsAsXmlCommand.java
@@ -53,7 +53,7 @@ public class GetCredentialsAsXmlCommand extends BaseCredentialsCLICommand {
      */
     @Override
     public String getShortDescription() {
-        return "Gets credentials as XML (secrets redacted)";
+        return Messages.GetCredentialsAsXmlCommand_ShortDescription();
     }
 
     /**

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/GetCredentialsDomainAsXmlCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/GetCredentialsDomainAsXmlCommand.java
@@ -51,7 +51,7 @@ public class GetCredentialsDomainAsXmlCommand extends BaseCredentialsCLICommand 
      */
     @Override
     public String getShortDescription() {
-        return "Gets credentials domain as XML";
+        return Messages.GetCredentialsDomainAsXmlCommand_ShortDescription();
     }
 
     /**

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/GetCredentialsDomainAsXmlCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/GetCredentialsDomainAsXmlCommand.java
@@ -23,25 +23,35 @@
  */
 package com.cloudbees.plugins.credentials.cli;
 
-import com.cloudbees.plugins.credentials.CredentialsSelectHelper;
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.CredentialsStoreAction;
+import com.cloudbees.plugins.credentials.domains.Domain;
 import hudson.Extension;
-import hudson.cli.CLICommand;
-import java.util.Map;
-import org.apache.commons.lang.StringUtils;
+import hudson.model.Items;
+import java.io.OutputStreamWriter;
+import org.kohsuke.args4j.Argument;
 
 /**
- * Lists the {@link CredentialsSelectHelper.ContextResolver} instances and the context objects they resolve.
+ * Retrieves a credentials configuration as XML.
  *
  * @since 2.1.1
  */
 @Extension
-public class ListCredentialsContextResolversCommand extends BaseCredentialsCLICommand {
+public class GetCredentialsDomainAsXmlCommand extends BaseCredentialsCLICommand {
+    @Argument(metaVar = "STORE", usage = "Store Id", required = true)
+    public CredentialsStore store;
+
+    @Argument(metaVar = "DOMAIN", usage = "Domain Name", required = true, index = 1)
+    public String domain;
+
     /**
      * {@inheritDoc}
      */
     @Override
     public String getShortDescription() {
-        return "List Credentials Context Resolvers";
+        return "Gets credentials domain as XML";
     }
 
     /**
@@ -49,21 +59,15 @@ public class ListCredentialsContextResolversCommand extends BaseCredentialsCLICo
      */
     @Override
     protected int run() throws Exception {
-        Map<String, CredentialsSelectHelper.ContextResolver> resolversByName =
-                CredentialsSelectHelper.getResolversByName();
-        int maxNameLen = 0, maxDisplayLen = 0;
-        for (Map.Entry<String, CredentialsSelectHelper.ContextResolver> entry : resolversByName.entrySet()) {
-            maxNameLen = Math.max(maxNameLen, entry.getKey().length());
-            maxDisplayLen = Math.max(maxDisplayLen,
-                    CredentialsSelectHelper.ContextResolver.displayName(entry.getValue()).length());
+        store.checkPermission(CredentialsProvider.UPDATE);
+        Domain domain = getDomainByName(store, this.domain);
+        if (domain == null) {
+            stderr.println("No such domain");
+            return 2;
         }
-        stdout.println(StringUtils.rightPad("Name", maxNameLen) + " Resolves");
-        stdout.println(StringUtils.repeat("=", maxNameLen) + " " + StringUtils.repeat("=", maxDisplayLen));
-        for (Map.Entry<String, CredentialsSelectHelper.ContextResolver> entry : resolversByName.entrySet()) {
-            stdout.println(StringUtils.rightPad(entry.getKey(), maxNameLen)
-                    + " "
-                    + CredentialsSelectHelper.ContextResolver.displayName(entry.getValue()));
-        }
+
+        Items.XSTREAM2.toXML(domain, new OutputStreamWriter(stdout, "UTF-8"));
         return 0;
     }
+
 }

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/GetCredentialsDomainAsXmlCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/GetCredentialsDomainAsXmlCommand.java
@@ -23,10 +23,8 @@
  */
 package com.cloudbees.plugins.credentials.cli;
 
-import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsStore;
-import com.cloudbees.plugins.credentials.CredentialsStoreAction;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import hudson.Extension;
 import hudson.model.Items;

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/ListCredentialsCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/ListCredentialsCommand.java
@@ -30,7 +30,6 @@ import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.common.IdCredentials;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import hudson.Extension;
-import hudson.cli.CLICommand;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/ListCredentialsCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/ListCredentialsCommand.java
@@ -55,7 +55,7 @@ public class ListCredentialsCommand extends BaseCredentialsCLICommand {
      */
     @Override
     public String getShortDescription() {
-        return "Lists the credentials in a specific store";
+        return Messages.ListCredentialsCommand_ShortDescription();
     }
 
     /**

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/ListCredentialsCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/ListCredentialsCommand.java
@@ -43,7 +43,7 @@ import org.kohsuke.args4j.Argument;
  * @since 2.1.1
  */
 @Extension
-public class ListCredentialsCommand extends CLICommand {
+public class ListCredentialsCommand extends BaseCredentialsCLICommand {
     /**
      * The store to list credentials in.
      */
@@ -68,7 +68,7 @@ public class ListCredentialsCommand extends CLICommand {
         for (Domain domain : domains) {
             List<Credentials> credentials = store.getCredentials(domain);
             Map<String, String> nameById = new LinkedHashMap<String, String>(credentials.size());
-            int maxIdLen ="# of Credentials".length(), maxNameLen = 0;
+            int maxIdLen = "# of Credentials".length(), maxNameLen = 0;
             int index = 0;
             for (Credentials c : credentials) {
                 String id;
@@ -87,8 +87,11 @@ public class ListCredentialsCommand extends CLICommand {
                 maxNameLen = Math.max(maxNameLen, name.length());
             }
             stdout.println(StringUtils.repeat("=", maxIdLen + maxNameLen + 1));
-            stdout.println(StringUtils.rightPad("Domain", maxIdLen) + " " + (domain.isGlobal() ? "(global)" : domain.getName()));
-            stdout.println(StringUtils.rightPad("Description", maxIdLen) + " " + StringUtils.defaultString(domain.getDescription()));
+            stdout.println(StringUtils.rightPad("Domain", maxIdLen) + " " + (domain.isGlobal()
+                    ? "(global)"
+                    : domain.getName()));
+            stdout.println(StringUtils.rightPad("Description", maxIdLen) + " " + StringUtils
+                    .defaultString(domain.getDescription()));
             stdout.println(StringUtils.rightPad("# of Credentials", maxIdLen) + " " + credentials.size());
             stdout.println(StringUtils.repeat("=", maxIdLen + maxNameLen + 1));
             stdout.println(StringUtils.rightPad("Id", maxIdLen) + " Name");

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/ListCredentialsCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/ListCredentialsCommand.java
@@ -1,0 +1,104 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc..
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.plugins.credentials.cli;
+
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsNameProvider;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.common.IdCredentials;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import hudson.Extension;
+import hudson.cli.CLICommand;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.args4j.Argument;
+
+/**
+ * Lists the credentials in a specific credentials store
+ *
+ * @since 2.1.1
+ */
+@Extension
+public class ListCredentialsCommand extends CLICommand {
+    /**
+     * The store to list credentials in.
+     */
+    @Argument(metaVar = "STORE", usage = "Store ID", required = true)
+    public CredentialsStore store;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getShortDescription() {
+        return "Lists the credentials in a specific store";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected int run() throws Exception {
+        store.checkPermission(CredentialsProvider.VIEW);
+        List<Domain> domains = store.getDomains();
+        for (Domain domain : domains) {
+            List<Credentials> credentials = store.getCredentials(domain);
+            Map<String, String> nameById = new LinkedHashMap<String, String>(credentials.size());
+            int maxIdLen ="# of Credentials".length(), maxNameLen = 0;
+            int index = 0;
+            for (Credentials c : credentials) {
+                String id;
+                if (c instanceof IdCredentials) {
+                    id = ((IdCredentials) c).getId();
+                } else {
+                    while (nameById.containsKey("index-" + index)) {
+                        index++;
+                    }
+                    id = "index-" + index;
+                    index++;
+                }
+                String name = CredentialsNameProvider.name(c);
+                nameById.put(id, name);
+                maxIdLen = Math.max(maxIdLen, id.length());
+                maxNameLen = Math.max(maxNameLen, name.length());
+            }
+            stdout.println(StringUtils.repeat("=", maxIdLen + maxNameLen + 1));
+            stdout.println(StringUtils.rightPad("Domain", maxIdLen) + " " + (domain.isGlobal() ? "(global)" : domain.getName()));
+            stdout.println(StringUtils.rightPad("Description", maxIdLen) + " " + StringUtils.defaultString(domain.getDescription()));
+            stdout.println(StringUtils.rightPad("# of Credentials", maxIdLen) + " " + credentials.size());
+            stdout.println(StringUtils.repeat("=", maxIdLen + maxNameLen + 1));
+            stdout.println(StringUtils.rightPad("Id", maxIdLen) + " Name");
+            stdout.println(StringUtils.repeat("=", maxIdLen) + " " + StringUtils.repeat("=", maxNameLen));
+            for (Map.Entry<String, String> entry : nameById.entrySet()) {
+                stdout.println(StringUtils.rightPad(entry.getKey(), maxIdLen) + " " + entry.getValue());
+            }
+            stdout.println(StringUtils.repeat("=", maxIdLen + maxNameLen + 1));
+            stdout.println();
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/ListCredentialsContextResolversCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/ListCredentialsContextResolversCommand.java
@@ -41,7 +41,7 @@ public class ListCredentialsContextResolversCommand extends BaseCredentialsCLICo
      */
     @Override
     public String getShortDescription() {
-        return "List Credentials Context Resolvers";
+        return Messages.ListCredentialsContextResolversCommand_ShortDescription();
     }
 
     /**

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/ListCredentialsContextResolversCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/ListCredentialsContextResolversCommand.java
@@ -25,7 +25,6 @@ package com.cloudbees.plugins.credentials.cli;
 
 import com.cloudbees.plugins.credentials.CredentialsSelectHelper;
 import hudson.Extension;
-import hudson.cli.CLICommand;
 import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/ListCredentialsContextResolversCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/ListCredentialsContextResolversCommand.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc..
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.plugins.credentials.cli;
+
+import com.cloudbees.plugins.credentials.CredentialsSelectHelper;
+import hudson.Extension;
+import hudson.cli.CLICommand;
+import java.util.Map;
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * Lists the {@link CredentialsSelectHelper.ContextResolver} instances and the context objects they resolve.
+ *
+ * @since 2.1.1
+ */
+@Extension
+public class ListCredentialsContextResolversCommand extends CLICommand {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getShortDescription() {
+        return "List Credentials Context Resolvers";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected int run() throws Exception {
+        Map<String, CredentialsSelectHelper.ContextResolver> resolversByName =
+                CredentialsSelectHelper.getResolversByName();
+        int maxNameLen = 0, maxDisplayLen = 0;
+        for (Map.Entry<String, CredentialsSelectHelper.ContextResolver> entry : resolversByName.entrySet()) {
+            maxNameLen = Math.max(maxNameLen, entry.getKey().length());
+            maxDisplayLen = Math.max(maxDisplayLen,
+                    CredentialsSelectHelper.ContextResolver.displayName(entry.getValue()).length());
+        }
+        stdout.println(StringUtils.rightPad("Name", maxNameLen) + " Resolves");
+        stdout.println(StringUtils.repeat("=", maxNameLen) + " " + StringUtils.repeat("=", maxDisplayLen));
+        for (Map.Entry<String, CredentialsSelectHelper.ContextResolver> entry : resolversByName.entrySet()) {
+            stdout.println(StringUtils.rightPad(entry.getKey(), maxNameLen)
+                    + " "
+                    + CredentialsSelectHelper.ContextResolver.displayName(entry.getValue()));
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/ListCredentialsProvidersCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/ListCredentialsProvidersCommand.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc..
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.plugins.credentials.cli;
+
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsSelectHelper;
+import hudson.Extension;
+import hudson.cli.CLICommand;
+import java.util.Map;
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * Lists the {@link CredentialsProvider} instances and their names.
+ *
+ * @since 2.1.1
+ */
+@Extension
+public class ListCredentialsProvidersCommand extends CLICommand {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getShortDescription() {
+        return "List Credentials Providers";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected int run() throws Exception {
+        Map<String, CredentialsProvider> providersByName = CredentialsSelectHelper.getProvidersByName();
+        int maxNameLen = 0, maxDisplayLen = 0;
+        for (Map.Entry<String, CredentialsProvider> entry : providersByName.entrySet()) {
+            maxNameLen = Math.max(maxNameLen, entry.getKey().length());
+            maxDisplayLen = Math.max(maxDisplayLen, entry.getValue().getDisplayName().length());
+        }
+        stdout.println(StringUtils.rightPad("Name", maxNameLen) + " Provider");
+        stdout.println(StringUtils.repeat("=", maxNameLen) + " " + StringUtils.repeat("=", maxDisplayLen));
+        for (Map.Entry<String, CredentialsProvider> entry : providersByName.entrySet()) {
+            stdout.println(StringUtils.rightPad(entry.getKey(), maxNameLen) + " " + entry.getValue().getDisplayName());
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/ListCredentialsProvidersCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/ListCredentialsProvidersCommand.java
@@ -26,7 +26,6 @@ package com.cloudbees.plugins.credentials.cli;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsSelectHelper;
 import hudson.Extension;
-import hudson.cli.CLICommand;
 import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/ListCredentialsProvidersCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/ListCredentialsProvidersCommand.java
@@ -42,7 +42,7 @@ public class ListCredentialsProvidersCommand extends BaseCredentialsCLICommand {
      */
     @Override
     public String getShortDescription() {
-        return "List Credentials Providers";
+        return Messages.ListCredentialsProvidersCommand_ShortDescription();
     }
 
     /**

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/UpdateCredentialsByXmlCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/UpdateCredentialsByXmlCommand.java
@@ -53,7 +53,7 @@ public class UpdateCredentialsByXmlCommand extends BaseCredentialsCLICommand {
      */
     @Override
     public String getShortDescription() {
-        return "Update credentials by XML";
+        return Messages.UpdateCredentialsByXmlCommand_ShortDescription();
     }
 
     /**

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/UpdateCredentialsByXmlCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/UpdateCredentialsByXmlCommand.java
@@ -27,7 +27,6 @@ import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.domains.Domain;
-import com.thoughtworks.xstream.io.xml.XppDriver;
 import hudson.Extension;
 import hudson.model.Items;
 import org.kohsuke.args4j.Argument;

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/UpdateCredentialsDomainByXmlCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/UpdateCredentialsDomainByXmlCommand.java
@@ -23,11 +23,9 @@
  */
 package com.cloudbees.plugins.credentials.cli;
 
-import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.domains.Domain;
-import com.thoughtworks.xstream.io.xml.XppDriver;
 import hudson.Extension;
 import hudson.model.Items;
 import org.kohsuke.args4j.Argument;

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/UpdateCredentialsDomainByXmlCommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/UpdateCredentialsDomainByXmlCommand.java
@@ -50,7 +50,7 @@ public class UpdateCredentialsDomainByXmlCommand extends BaseCredentialsCLIComma
      */
     @Override
     public String getShortDescription() {
-        return "Update credentials domain by XML";
+        return Messages.UpdateCredentialsDomainByXmlCommand_ShortDescription();
     }
 
     /**

--- a/src/main/resources/com/cloudbees/plugins/credentials/Messages.properties
+++ b/src/main/resources/com/cloudbees/plugins/credentials/Messages.properties
@@ -44,6 +44,12 @@ CredentialsProvider.UseItemPermissionDescription=Where an immediate action again
 CredentialsParameterDefinition.DisplayName=Credentials Parameter
 CredentialsParameterValue.NotAvailableToCurrentUser=Not available to current user
 CredentialsSelectHelper.DisplayName=Credentials Selection Helper
+CredentialsSelectHelper.CLIMalformedStoreId=Malformed store identifier, expecting Provider::Resolver::ContextPath \
+  got {0}
+CredentialsSelectHelper.CLINoSuchResolver=The specified resolver {0} cannot be uniquely identified.
+CredentialsSelectHelper.CLINoSuchContext=The specified context path {0} is not resolving to an object.
+CredentialsSelectHelper.CLINoSuchProvider=The specified provider {0} cannot be uniquely identified.
+CredentialsSelectHelper.CLINoStore=The specified provider does not have a credentials store in the specified context.
 CredentialsScope.UserDisplayName=User
 CredentialsScope.GlobalDisplayName=Global (Jenkins, nodes, items, all child items, etc)
 CredentialsScope.SystemDisplayName=System (Jenkins and nodes only)

--- a/src/main/resources/com/cloudbees/plugins/credentials/cli/Messages.properties
+++ b/src/main/resources/com/cloudbees/plugins/credentials/cli/Messages.properties
@@ -1,0 +1,34 @@
+#
+# The MIT License
+#
+# Copyright (c) 2016, CloudBees, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+CreateCredentialsByXmlCommand.ShortDescription=Create Credential by XML
+CreateCredentialsDomainByXmlCommand.ShortDescription=Create Credentials Domain by XML
+DeleteCredentialsCommand.ShortDescription=Delete a Credential
+DeleteCredentialsDomainCommand.ShortDescription=Delete a Credentials Domain
+GetCredentialsAsXmlCommand.ShortDescription=Get a Credentials as XML (secrets redacted)
+GetCredentialsDomainAsXmlCommand.ShortDescription=Get a Credentials Domain as XML
+ListCredentialsCommand.ShortDescription=Lists the Credentials in a specific Store
+ListCredentialsContextResolversCommand.ShortDescription=List Credentials Context Resolvers
+ListCredentialsProvidersCommand.ShortDescription=List Credentials Providers
+UpdateCredentialsByXmlCommand.ShortDescription=Update Credentials by XML
+UpdateCredentialsDomainByXmlCommand.ShortDescription=Update Credentials Domain by XML

--- a/src/test/java/com/cloudbees/plugins/credentials/cli/CLICommandsTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/cli/CLICommandsTest.java
@@ -24,21 +24,35 @@
 package com.cloudbees.plugins.credentials.cli;
 
 import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsSelectHelper;
+import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.domains.DomainSpecification;
+import com.cloudbees.plugins.credentials.domains.HostnameSpecification;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import hudson.cli.CLICommand;
 import hudson.cli.CLICommandInvoker;
+import hudson.model.Items;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.Charset;
+import java.util.Collections;
 import java.util.List;
+import jenkins.model.Jenkins;
 import org.hamcrest.Matcher;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.hamcrest.Matchers;
+import org.xmlunit.matchers.CompareMatcher;
 
+import static hudson.cli.CLICommandInvoker.Matcher.succeeded;
 import static hudson.cli.CLICommandInvoker.Matcher.succeededSilently;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.instanceOf;
@@ -51,12 +65,18 @@ public class CLICommandsTest {
     @Rule
     public JenkinsRule r = new JenkinsRule();
 
+    @Before
+    public void clearCredentials() {
+        SystemCredentialsProvider.getInstance().setDomainCredentialsMap(
+                Collections.singletonMap(Domain.global(), Collections.<Credentials>emptyList()));
+    }
+
     @Test
     public void createSmokes() {
         CLICommand cmd = new CreateCredentialsDomainByXmlCommand();
         CLICommandInvoker invoker = new CLICommandInvoker(r, cmd);
         assertThat(SystemCredentialsProvider.getInstance().getDomainCredentialsMap().keySet(),
-                (Matcher) not(hasItem(hasProperty("name",is("smokes")))));
+                (Matcher) not(hasItem(hasProperty("name", is("smokes")))));
         assertThat(invoker.withStdin(asStream(
                 "<com.cloudbees.plugins.credentials.domains.Domain>\n"
                         + "  <name>smokes</name>\n"
@@ -74,10 +94,10 @@ public class CLICommandsTest {
                         + "  <username>example-com-deployer</username>\n"
                         + "  <password>super-secret</password>\n"
                         + "</com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl>"))
-                .invokeWithArgs("system::system::jenkins", "smokes"),
+                        .invokeWithArgs("system::system::jenkins", "smokes"),
                 succeededSilently());
         Domain domain = null;
-        for (Domain d: SystemCredentialsProvider.getInstance().getDomainCredentialsMap().keySet()) {
+        for (Domain d : SystemCredentialsProvider.getInstance().getDomainCredentialsMap().keySet()) {
             if ("smokes".equals(d.getName())) {
                 domain = d;
                 break;
@@ -93,6 +113,100 @@ public class CLICommandsTest {
         assertThat(c.getDescription(), is("created from xml"));
         assertThat(c.getUsername(), is("example-com-deployer"));
         assertThat(c.getPassword().getPlainText(), is("super-secret"));
+    }
+
+    @Test
+    public void readSmokes() throws Exception {
+        Domain smokes = new Domain("smokes", "smoke test domain",
+                Collections.<DomainSpecification>singletonList(new HostnameSpecification("smokes.example.com", null)));
+        UsernamePasswordCredentialsImpl smokey =
+                new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "smokes-id", "smoke testing", "smoke",
+                        "smoke text");
+        CredentialsStore store = null;
+        for (CredentialsStore s : CredentialsProvider.lookupStores(Jenkins.getInstance())) {
+            if (s.getProvider() instanceof SystemCredentialsProvider.ProviderImpl) {
+                store = s;
+                break;
+            }
+        }
+        assertThat("The system credentials provider is enabled", store, notNullValue());
+        store.addDomain(smokes, smokey);
+        CLICommandInvoker invoker = new CLICommandInvoker(r, new GetCredentialsDomainAsXmlCommand());
+        CLICommandInvoker.Result result = invoker.invokeWithArgs("system::system::jenkins", "smokes");
+        assertThat(result, succeeded());
+        assertThat(result.stdout(), CompareMatcher.isIdenticalTo(Items.XSTREAM2.toXML(smokes))
+                .ignoreComments()
+                .ignoreWhitespace()
+        );
+        invoker = new CLICommandInvoker(r, new GetCredentialsAsXmlCommand());
+        result = invoker.invokeWithArgs("system::system::jenkins", "smokes", "smokes-id");
+        assertThat(result, succeeded());
+        assertThat("secrets are redacted", result.stdout(),
+                not(CompareMatcher.isIdenticalTo(Items.XSTREAM2.toXML(smokey))
+                        .ignoreComments()
+                        .ignoreWhitespace()
+                ));
+        assertThat("secrets are redacted", result.stdout(),
+                not(containsString(smokey.getPassword().getEncryptedValue())));
+        assertThat("secrets are redacted", result.stdout(),
+                not(containsString(smokey.getPassword().getPlainText())));
+        assertThat("secrets are redacted", result.stdout(), CompareMatcher.isIdenticalTo(
+                Items.XSTREAM2.toXML(smokey).replace(smokey.getPassword().getEncryptedValue(), "<secret-redacted/>"))
+                .ignoreComments()
+                .ignoreWhitespace()
+        );
+    }
+
+    @Test
+    public void listSmokes() throws Exception {
+        Domain smokes = new Domain("smokes", "smoke test domain",
+                Collections.<DomainSpecification>singletonList(new HostnameSpecification("smokes.example.com", null)));
+        UsernamePasswordCredentialsImpl smokey =
+                new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "smokes-id", "smoke testing", "smoke",
+                        "smoke text");
+        CredentialsStore store = null;
+        for (CredentialsStore s : CredentialsProvider.lookupStores(Jenkins.getInstance())) {
+            if (s.getProvider() instanceof SystemCredentialsProvider.ProviderImpl) {
+                store = s;
+                break;
+            }
+        }
+        assertThat("The system credentials provider is enabled", store, notNullValue());
+
+        // check getting the providers
+        CLICommandInvoker invoker = new CLICommandInvoker(r, new ListCredentialsProvidersCommand());
+        CLICommandInvoker.Result result = invoker.invoke();
+        assertThat(result, succeeded());
+        assertThat(result.stdout(), containsString("\nsystem "));
+        assertThat(result.stdout(), containsString("\nSystemCredentialsProvider "));
+        assertThat(result.stdout(), containsString("\n"+SystemCredentialsProvider.ProviderImpl.class.getName()+" "));
+
+        // now check getting the resolvers
+        invoker = new CLICommandInvoker(r, new ListCredentialsContextResolversCommand());
+        result = invoker.invoke();
+        assertThat(result, succeeded());
+        assertThat(result.stdout(), containsString("\nsystem "));
+        assertThat(result.stdout(), containsString("\nSystemContextResolver "));
+        assertThat(result.stdout(), containsString("\n" + CredentialsSelectHelper.SystemContextResolver.class.getName()+" "));
+
+        // now check listing credentials (expect empty)
+        invoker = new CLICommandInvoker(r, new ListCredentialsCommand());
+        result = invoker.invokeWithArgs("system::system::jenkins");
+        assertThat(result, succeeded());
+        assertThat(result.stdout().replaceAll("\\s+", " "), allOf(
+                containsString(" Domain (global) Description # of Credentials 0 "),
+                not(containsString(" Domain smokes "))
+        ));
+
+        store.addDomain(smokes, smokey);
+        invoker = new CLICommandInvoker(r, new ListCredentialsCommand());
+        result = invoker.invokeWithArgs("system::system::jenkins");
+        assertThat(result, succeeded());
+        assertThat(result.stdout().replaceAll("\\s+", " "), allOf(
+                containsString(" Domain (global) Description # of Credentials 0 "),
+                containsString(" Domain smokes Description smoke test domain # of Credentials 1 "),
+                containsString(" smokes-id smoke/****** (smoke testing) ")
+        ));
     }
 
     private static ByteArrayInputStream asStream(String text) {

--- a/src/test/java/com/cloudbees/plugins/credentials/cli/CLICommandsTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/cli/CLICommandsTest.java
@@ -1,0 +1,101 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc..
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.plugins.credentials.cli;
+
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import hudson.cli.CLICommand;
+import hudson.cli.CLICommandInvoker;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.Charset;
+import java.util.List;
+import org.hamcrest.Matcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static hudson.cli.CLICommandInvoker.Matcher.succeededSilently;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class CLICommandsTest {
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void createSmokes() {
+        CLICommand cmd = new CreateCredentialsDomainByXmlCommand();
+        CLICommandInvoker invoker = new CLICommandInvoker(r, cmd);
+        assertThat(SystemCredentialsProvider.getInstance().getDomainCredentialsMap().keySet(),
+                (Matcher) not(hasItem(hasProperty("name",is("smokes")))));
+        assertThat(invoker.withStdin(asStream(
+                "<com.cloudbees.plugins.credentials.domains.Domain>\n"
+                        + "  <name>smokes</name>\n"
+                        + "</com.cloudbees.plugins.credentials.domains.Domain>"))
+                .invokeWithArgs("system::system::jenkins"), succeededSilently());
+        assertThat(SystemCredentialsProvider.getInstance().getDomainCredentialsMap().keySet(),
+                (Matcher) hasItem(hasProperty("name", is("smokes"))));
+        cmd = new CreateCredentialsByXmlCommand();
+        invoker = new CLICommandInvoker(r, cmd);
+        assertThat(invoker.withStdin(asStream(
+                "<com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl>\n"
+                        + "  <scope>GLOBAL</scope>\n"
+                        + "  <id>smokey-id</id>\n"
+                        + "  <description>created from xml</description>\n"
+                        + "  <username>example-com-deployer</username>\n"
+                        + "  <password>super-secret</password>\n"
+                        + "</com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl>"))
+                .invokeWithArgs("system::system::jenkins", "smokes"),
+                succeededSilently());
+        Domain domain = null;
+        for (Domain d: SystemCredentialsProvider.getInstance().getDomainCredentialsMap().keySet()) {
+            if ("smokes".equals(d.getName())) {
+                domain = d;
+                break;
+            }
+        }
+        List<Credentials> credentials = SystemCredentialsProvider.getInstance().getDomainCredentialsMap().get(domain);
+        assertThat(credentials, notNullValue());
+        Credentials cred = credentials.isEmpty() ? null : credentials.get(0);
+        assertThat(cred, instanceOf(UsernamePasswordCredentialsImpl.class));
+        UsernamePasswordCredentialsImpl c = (UsernamePasswordCredentialsImpl) cred;
+        assertThat(c.getScope(), is(CredentialsScope.GLOBAL));
+        assertThat(c.getId(), is("smokey-id"));
+        assertThat(c.getDescription(), is("created from xml"));
+        assertThat(c.getUsername(), is("example-com-deployer"));
+        assertThat(c.getPassword().getPlainText(), is("super-secret"));
+    }
+
+    private static ByteArrayInputStream asStream(String text) {
+        return new ByteArrayInputStream(text.getBytes(Charset.forName("UTF-8")));
+    }
+}


### PR DESCRIPTION
[JENKINS-28407](https://issues.jenkins-ci.org/browse/JENKINS-28407)

- [x] CLI commands for CRUD of credentials
- [x] CLI commands for CRUD of credential domains
- [x] CLI commands to list credential stores
- [x] REST support for CRU of credentials
- [x] REST support for CRU of credential domains
- [x] Decide if we want REST support for D of credentials and credential domains
- [x] Happy path tests: C for credentials and credential domains via CLI
- [x] Happy path tests: R for credentials and credential domains via CLI
- [x] Happy path tests: U for credentials and credential domains via CLI
- [x] Happy path tests: D for credentials and credential domains via CLI
- [x] Happy path tests: C for credentials and credential domains via REST
- [x] Happy path tests: R for credentials and credential domains via REST
- [x] Happy path tests: U for credentials and credential domains via REST
- [x] Happy path tests: D for credentials and credential domains via REST
- [x] Happy path tests: listing credential stores via CLI
- [x] Some non-happy path tests