### PR TITLE
[JENKINS-37801] ViewCredentialsActionTest#smokes and CredentialsStoreActionTest are failing against stable-2.7

### DIFF
--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsStoreActionTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsStoreActionTest.java
@@ -15,7 +15,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import javax.servlet.http.HttpServletResponse;
-import jenkins.model.Jenkins;
+
 import org.apache.commons.lang.StringUtils;
 import org.junit.Before;
 import org.junit.Rule;
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.xmlunit.matchers.CompareMatcher;
 
+import static com.cloudbees.plugins.credentials.XmlMatchers.isSimilarToIgnoringPrivateAttrs;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -57,7 +58,7 @@ public class CredentialsStoreActionTest {
 
         JenkinsRule.WebClient wc = j.createWebClient();
         WebResponse response = wc.goTo("credentials/store/system/api/xml?depth=5", "application/xml").getWebResponse();
-        assertThat(response.getContentAsString(), CompareMatcher.isIdenticalTo("<userFacingAction>"
+        assertThat(response.getContentAsString(), isSimilarToIgnoringPrivateAttrs("<userFacingAction>"
                 + "<domains>"
                 + "<_>"
                 + "<description>"
@@ -83,7 +84,7 @@ public class CredentialsStoreActionTest {
                 new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, credentialId,
                         credentialDescription, credentialUsername, "test-secret"));
         response = wc.goTo("credentials/store/system/api/xml?depth=5", "application/xml").getWebResponse();
-        assertThat(response.getContentAsString(), CompareMatcher.isIdenticalTo("<userFacingAction>"
+        assertThat(response.getContentAsString(), isSimilarToIgnoringPrivateAttrs("<userFacingAction>"
                 + "<domains>"
                 + "<_>"
                 + "<description>"

--- a/src/test/java/com/cloudbees/plugins/credentials/ViewCredentialsActionTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/ViewCredentialsActionTest.java
@@ -9,12 +9,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
-import jenkins.model.Jenkins;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import static org.hamcrest.Matchers.is;
+import static com.cloudbees.plugins.credentials.XmlMatchers.isSimilarToIgnoringPrivateAttrs;
 import static org.junit.Assert.assertThat;
 
 public class ViewCredentialsActionTest {
@@ -41,7 +41,7 @@ public class ViewCredentialsActionTest {
 
         JenkinsRule.WebClient wc = j.createWebClient();
         WebResponse response = wc.goTo("credentials/api/xml?depth=5", "application/xml").getWebResponse();
-        assertThat(response.getContentAsString(), is("<rootActionImpl>"
+        assertThat(response.getContentAsString(), isSimilarToIgnoringPrivateAttrs("<rootActionImpl>"
                 + "<stores>"
                 + "<system>"
                 + "<domains>"
@@ -71,7 +71,7 @@ public class ViewCredentialsActionTest {
                 new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, credentialId,
                         credentialDescription, credentialUsername, "test-secret"));
         response = wc.goTo("credentials/api/xml?depth=5", "application/xml").getWebResponse();
-        assertThat(response.getContentAsString(), is("<rootActionImpl>"
+        assertThat(response.getContentAsString(), isSimilarToIgnoringPrivateAttrs("<rootActionImpl>"
                 + "<stores>"
                 + "<system>"
                 + "<domains>"

--- a/src/test/java/com/cloudbees/plugins/credentials/XmlMatchers.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/XmlMatchers.java
@@ -1,0 +1,22 @@
+package com.cloudbees.plugins.credentials;
+
+import org.w3c.dom.Attr;
+import org.xmlunit.matchers.CompareMatcher;
+import org.xmlunit.util.Predicate;
+
+public class XmlMatchers {
+    public static CompareMatcher isSimilarToIgnoringPrivateAttrs(String control) {
+        return CompareMatcher.isSimilarTo(control)
+                .normalizeWhitespace()
+                .ignoreComments()
+                .withAttributeFilter(new Predicate<Attr>() {
+                    @Override
+                    public boolean test(Attr attr) {
+                        if (attr.getName().startsWith("_")) {
+                            return false;
+                        }
+                        return true;
+                    }
+                });
+    }
+}


### PR DESCRIPTION
[JENKINS-37801](https://issues.jenkins-ci.org/browse/JENKINS-37801)

This PR relaxes the smoke tests in `ViewCredentialsActionTest` and `CredentialsStoreActionTest` changing from strict string comparison on XML results to XMLUnit's similar comparison ignoring attributes starting with "_"

This way we preserve backwards compatibility and the test is a little (IMHO) more robust to no relevant changes in the XML like adding a `_class` attribute    