### PR TITLE
[JENKINS-37707] fix missing Behaviour in /lib/credentials:select

### DIFF
--- a/src/main/resources/lib/credentials/select/select.js
+++ b/src/main/resources/lib/credentials/select/select.js
@@ -248,6 +248,6 @@ window.setTimeout(function() {
     var controls = document.getElementsByClassName('credentials-select-control');
     var count = controls.length;
     for (var i = 0; i < count; i++) {
-        Behaviour.applySubtree(controls[i]);
+        Behaviour.applySubtree(controls[i], true);
     }
 },1);


### PR DESCRIPTION
When a credentials selector is dynamicaly added to the DOM and
no Behaviour was specified yet (for instance, in [JENKINS-37707],
when adding a first Credentials Binding wrapper, and we don't
have an other plugin, like Git, to ensure the credentials JS lib
is already loaded in the page), then some new Behaviours are
specified, and retro-applied to existing DOM elements (with
Behaviour.applySubtree in a timeout function).  It's a hack,
which almost works, but there was an issue with elements with
class 'credentials-select-control': there is a Behaviour specified
for them, but Behaviours are only applied to their children, not
themselves.  That's what this (rather obvious) patch fixes.
It seems to be enough to fix the error reported in [JENKINS-37707].