### PR TITLE
Bump parent pom from jenkins:2.10 to jenkins:2.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.10</version>
+    <version>2.21</version>
   </parent>
 
   <artifactId>credentials</artifactId>
@@ -68,8 +68,6 @@
   </scm>
 
   <properties>
-    <jenkins.version>1.609</jenkins.version>
-    <java.level>6</java.level>
     <antlr4.version>4.5</antlr4.version>
   </properties>
 


### PR DESCRIPTION
Prepare the fix for https://issues.jenkins-ci.org/browse/JENKINS-41946

Bump parent pom from jenkins:2.10 to jenkins:2.21