### PR TITLE
[JENKINS-41946] Fix Stapler "IllegalArgumentException: Unable to convert to class com.cloudbees.plugins.credentials.SecretBytes"

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/SecretBytes.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/SecretBytes.java
@@ -45,6 +45,7 @@ import java.util.regex.Pattern;
 import javax.crypto.Cipher;
 import jcifs.util.Base64;
 import jenkins.security.ConfidentialStore;
+import org.apache.commons.lang.IllegalClassException;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.Stapler;
@@ -351,7 +352,20 @@ public class SecretBytes implements Serializable {
         }
     }
 
+    public static class StaplerConverterImpl implements org.apache.commons.beanutils.Converter {
+        public SecretBytes convert(Class type, Object value) {
+            if (value==null)
+                return null;
+            if (value instanceof String) {
+                return SecretBytes.fromString((String) value);
+            }
+            throw new IllegalClassException(SecretBytes.class, value.getClass());
+        }
+    }
+
     /*
+     * TODO why do we need this static registration if we have StaplerConverterImpl?
+     *
      * Register a converter for Stapler form binding.
      */
     static {


### PR DESCRIPTION
[JENKINS-41946] Fix Stapler "IllegalArgumentException: Unable to convert to class com.cloudbees.plugins.credentials.SecretBytes".

Add `com.cloudbees.plugins.credentials.SecretBytes$StaplerConverterImpl`.

@stephenc can we remove the static manual registration of the `SecretBytes` converter in `org.kohsuke.stapler.Stapler#CONVERT_UTILS` thanks to https://github.com/jenkinsci/credentials-plugin/blob/credentials-2.1.11/src/main/java/com/cloudbees/plugins/credentials/SecretBytes.java#L358 ?