### PR TITLE
[JENKINS-41952] mismatch on the encoding of the keystore: sometimes as `Secret(base64(keystore))` and sometimes as `new SecretBytes(keystore).toString()`

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/SecretBytes.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/SecretBytes.java
@@ -352,6 +352,7 @@ public class SecretBytes implements Serializable {
         }
     }
 
+    @Restricted(NoExternalUse.class)
     public static class StaplerConverterImpl implements org.apache.commons.beanutils.Converter {
         public SecretBytes convert(Class type, Object value) {
             if (value==null)
@@ -361,21 +362,5 @@ public class SecretBytes implements Serializable {
             }
             throw new IllegalClassException(SecretBytes.class, value.getClass());
         }
-    }
-
-    /*
-     * TODO why do we need this static registration if we have StaplerConverterImpl?
-     *
-     * Register a converter for Stapler form binding.
-     */
-    static {
-        Stapler.CONVERT_UTILS.register(new org.apache.commons.beanutils.Converter() {
-            /**
-             * {@inheritDoc}
-             */
-            public SecretBytes convert(Class type, Object value) {
-                return SecretBytes.fromString(value.toString());
-            }
-        }, SecretBytes.class);
     }
 }

--- a/src/main/java/com/cloudbees/plugins/credentials/SecretBytes.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/SecretBytes.java
@@ -45,6 +45,7 @@ import java.util.regex.Pattern;
 import javax.crypto.Cipher;
 import jcifs.util.Base64;
 import jenkins.security.ConfidentialStore;
+import org.apache.commons.lang.IllegalClassException;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.Stapler;
@@ -351,7 +352,20 @@ public class SecretBytes implements Serializable {
         }
     }
 
+    public static class StaplerConverterImpl implements org.apache.commons.beanutils.Converter {
+        public SecretBytes convert(Class type, Object value) {
+            if (value==null)
+                return null;
+            if (value instanceof String) {
+                return SecretBytes.fromString((String) value);
+            }
+            throw new IllegalClassException(SecretBytes.class, value.getClass());
+        }
+    }
+
     /*
+     * TODO why do we need this static registration if we have StaplerConverterImpl?
+     *
      * Register a converter for Stapler form binding.
      */
     static {


### PR DESCRIPTION
[JENKINS-41952] mismatch on the encoding of the keystore: sometimes as `Secret(base64(keystore))` and sometimes as `new SecretBytes(keystore).toString()`

ℹ️  PR started from #82 