### PR TITLE
[JENKINS-46859] Allow read-only credentials providers/stores

### DIFF
--- a/docs/implementation.adoc
+++ b/docs/implementation.adoc
@@ -756,8 +756,12 @@ The main work in an implementation will be the mapping to `CredentialStore` inst
 * Any "explicitly exposed" style implementation will have `CredentialsStore` instance for each context that persists the IDs of the credentials to be exposed and the credentials domains with which those credentials are to be associated.
 * A "read-only, implicitly exposed" style implementation can semi-dynamically create `CredentialsStore` instances for each context.
 +
+[TIP]
+====
+To prevent edit actions on a credentials store, you may extend `ReadOnlyCredentialsStore` instead and implement the `getCredentials(...)` of implementing `CredentialsStore()` and trying to hack your way around.
+====
 [NOTE]
 ====
-Technically, the "read-only, implicitly exposed" style credentials provider implementation does not need to interact with the `CredentialsStore` portion of the API as it can expose credentials directly using just the `CredentialsProvider.getCredentials(...)` and `CredentialsProvider.getCredentialIds(...)`, however, implementing the `CredentialsStore` contract is required in order for the credentials to be visible to users via the Credentials side action on the different Jenkins context objects.
+Technically, the "read-only, implicitly exposed" style credentials provider implementation does not need to interact with the `CredentialsStore` portion of the API as it can expose credentials directly using just the `CredentialsProvider.getCredentials(...)` and `CredentialsProvider.getCredentialIds(...)`, however, implementing the `ReadOnlyCredentialsStore` contract is required in order for the credentials to be visible to users via the Credentials side action on the different Jenkins context objects.
 ====
 * A "read-write, implicitly exposed" style implementation will need to semi-dynamically create `CredentialsStore` instances for each context in order to integrate with the Jenkins credentials management UI.

--- a/docs/implementation.adoc
+++ b/docs/implementation.adoc
@@ -758,7 +758,7 @@ The main work in an implementation will be the mapping to `CredentialStore` inst
 +
 [TIP]
 ====
-To prevent edit actions on a credentials store, you may extend `ReadOnlyCredentialsStore` instead and implement the `getCredentials(...)` of implementing `CredentialsStore()` and trying to hack your way around.
+To prevent edit actions on a credentials store, you may extend `ReadOnlyCredentialsStore` instead and implement the `getCredentials(...)` of extending `CredentialsStore` class and trying to hack your way around.
 ====
 [NOTE]
 ====

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
     <jenkins.version>1.625.3</jenkins.version>
     <java.level>7</java.level>
     <antlr4.version>4.5</antlr4.version>
+    <jenkins-test-harness.version>2.28</jenkins-test-harness.version>
   </properties>
 
   <repositories>

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsStore.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsStore.java
@@ -261,7 +261,7 @@ public abstract class CredentialsStore implements AccessControlled, Saveable {
      * <li>{@link #updateDomain(Domain, Domain)} </li>
      * </ul>
      *
-     * @return {@code true} if {@link #addDomain(Domain, List)}
+     * @return {@code true} iff {@link #addDomain(Domain, List)}
      * {@link #addDomain(Domain, Credentials...)}, {@link #removeDomain(Domain)}
      * and {@link #updateDomain(Domain, Domain)} are expected to work
      */

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsStore.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsStore.java
@@ -81,11 +81,6 @@ public abstract class CredentialsStore implements AccessControlled, Saveable {
     private transient Boolean domainsModifiable;
 
     /**
-     * Cache for {@link #isCredentialsModifiable()}.
-     */
-    private transient Boolean credentialsModifiable;
-
-    /**
      * Constructor for use when the {@link CredentialsStore} is not an inner class of its {@link CredentialsProvider}.
      *
      * @param providerClass the {@link CredentialsProvider} class.

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsStore.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsStore.java
@@ -81,6 +81,11 @@ public abstract class CredentialsStore implements AccessControlled, Saveable {
     private transient Boolean domainsModifiable;
 
     /**
+     * Cache for {@link #isCredentialsModifiable()}.
+     */
+    private transient Boolean credentialsModifiable;
+
+    /**
      * Constructor for use when the {@link CredentialsStore} is not an inner class of its {@link CredentialsProvider}.
      *
      * @param providerClass the {@link CredentialsProvider} class.
@@ -256,7 +261,7 @@ public abstract class CredentialsStore implements AccessControlled, Saveable {
      * <li>{@link #updateDomain(Domain, Domain)} </li>
      * </ul>
      *
-     * @return {@code true} iff {@link #addDomain(Domain, List)}
+     * @return {@code true} if {@link #addDomain(Domain, List)}
      * {@link #addDomain(Domain, Credentials...)}, {@link #removeDomain(Domain)}
      * and {@link #updateDomain(Domain, Domain)} are expected to work
      */
@@ -273,6 +278,20 @@ public abstract class CredentialsStore implements AccessControlled, Saveable {
 
         }
         return domainsModifiable;
+    }
+
+    /**
+     * Identifies whether this {@link CredentialsStore} supports making changes to the credentials or
+     * whether it only supports a fixed set of credentials (i.e. read-only backend).
+     * <p>
+     * Note: in order for implementations to return {@code false} you simply need to extend {@link ReadOnlyCredentialsStore}:
+     * </p>
+     *
+     * @return {@code true} if {@link #addCredentials(Domain, Credentials)}, {@link #removeCredentials(Domain, Credentials)}
+     * and {@link #updateCredentials(Domain, Credentials, Credentials)} are not from {@link ReadOnlyCredentialsStore}
+     */
+    public final boolean isCredentialsModifiable() {
+        return !(this instanceof ReadOnlyCredentialsStore);
     }
 
     /**

--- a/src/main/java/com/cloudbees/plugins/credentials/ReadOnlyCredentialsStore.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/ReadOnlyCredentialsStore.java
@@ -40,37 +40,9 @@ import java.io.IOException;
  * or a user scoped {@link CredentialsProvider} may provide a {@link ReadOnlyCredentialsStore} for each user).
  *
  * @author Hosh Sadiq
- * @since 2.1.17
+ * @since TODO
  */
 public abstract class ReadOnlyCredentialsStore extends CredentialsStore {
-    /**
-     * The {@link CredentialsProvider} class.
-     *
-     * @since 2.0
-     */
-    private final Class<? extends CredentialsProvider> providerClass;
-
-    public ReadOnlyCredentialsStore(Class<? extends CredentialsProvider> providerClass) {
-        this.providerClass = providerClass;
-    }
-
-    public ReadOnlyCredentialsStore() {
-        // now let's infer our provider, Jesse will not like this evil
-        Class<?> clazz = getClass().getEnclosingClass();
-        while (clazz != null && !CredentialsProvider.class.isAssignableFrom(clazz)) {
-            clazz = clazz.getEnclosingClass();
-        }
-        if (clazz == null) {
-            throw new AssertionError(getClass() + " doesn't have an outer class. "
-                    + "Use the constructor that takes the Class object explicitly.");
-        }
-        if (!CredentialsProvider.class.isAssignableFrom(clazz)) {
-            throw new AssertionError(getClass() + " doesn't have an outer class implementing CredentialsProvider. "
-                    + "Use the constructor that takes the Class object explicitly");
-        }
-        providerClass = (Class<? extends CredentialsProvider>) clazz;
-    }
-
     /**
      * If this method is overridden, ensure permissions {@link CredentialsProvider#CREATE}, {@link CredentialsProvider#UPDATE},
      * {@link CredentialsProvider#DELETE} will return false

--- a/src/main/java/com/cloudbees/plugins/credentials/ReadOnlyCredentialsStore.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/ReadOnlyCredentialsStore.java
@@ -43,17 +43,38 @@ import java.io.IOException;
  * @since 2.1.17
  */
 public abstract class ReadOnlyCredentialsStore extends CredentialsStore {
+    /**
+     * The {@link CredentialsProvider} class.
+     *
+     * @since 2.0
+     */
+    private final Class<? extends CredentialsProvider> providerClass;
+
     public ReadOnlyCredentialsStore(Class<? extends CredentialsProvider> providerClass) {
-        super(providerClass);
+        this.providerClass = providerClass;
     }
 
     public ReadOnlyCredentialsStore() {
-        super();
+        // now let's infer our provider, Jesse will not like this evil
+        Class<?> clazz = getClass().getEnclosingClass();
+        while (clazz != null && !CredentialsProvider.class.isAssignableFrom(clazz)) {
+            clazz = clazz.getEnclosingClass();
+        }
+        if (clazz == null) {
+            throw new AssertionError(getClass() + " doesn't have an outer class. "
+                    + "Use the constructor that takes the Class object explicitly.");
+        }
+        if (!CredentialsProvider.class.isAssignableFrom(clazz)) {
+            throw new AssertionError(getClass() + " doesn't have an outer class implementing CredentialsProvider. "
+                    + "Use the constructor that takes the Class object explicitly");
+        }
+        providerClass = (Class<? extends CredentialsProvider>) clazz;
     }
 
     /**
      * If this method is overridden, ensure permissions {@link CredentialsProvider#CREATE}, {@link CredentialsProvider#UPDATE},
      * {@link CredentialsProvider#DELETE} will return false
+     *
      * @param a          the principle.
      * @param permission the permission.
      * @return boolean
@@ -83,12 +104,15 @@ public abstract class ReadOnlyCredentialsStore extends CredentialsStore {
     }
 
     @Override
-    public final boolean removeCredentials(@NonNull Domain domain, @NonNull Credentials credentials) throws IOException {
+    public final boolean removeCredentials(@NonNull Domain domain, @NonNull Credentials credentials
+    ) throws IOException {
         throw new UnsupportedOperationException("Cannot remove items to read-only credentials store");
     }
 
     @Override
-    public final boolean updateCredentials(@NonNull Domain domain, @NonNull Credentials current, @NonNull Credentials replacement) throws IOException {
+    public final boolean updateCredentials(@NonNull Domain domain, @NonNull Credentials current,
+                                           @NonNull Credentials replacement
+    ) throws IOException {
         throw new UnsupportedOperationException("Cannot update items to read-only credentials store");
     }
 }

--- a/src/main/java/com/cloudbees/plugins/credentials/ReadOnlyCredentialsStore.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/ReadOnlyCredentialsStore.java
@@ -1,0 +1,94 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016, CloudBees, Inc., Stephen Connolly.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.plugins.credentials;
+
+import com.cloudbees.plugins.credentials.domains.Domain;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.security.ACL;
+import hudson.security.Permission;
+import jenkins.model.Jenkins;
+import org.acegisecurity.Authentication;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+
+/**
+ * A read only store of {@link Credentials}. Each {@link ReadOnlyCredentialsStore} is associated with one and only one
+ * {@link CredentialsProvider} though a {@link CredentialsProvider} may provide multiple {@link ReadOnlyCredentialsStore}s
+ * (for example a folder scoped {@link CredentialsProvider} may provide a {@link ReadOnlyCredentialsStore} for each folder
+ * or a user scoped {@link CredentialsProvider} may provide a {@link ReadOnlyCredentialsStore} for each user).
+ *
+ * @author Hosh Sadiq
+ * @since 2.1.17
+ */
+public abstract class ReadOnlyCredentialsStore extends CredentialsStore {
+    public ReadOnlyCredentialsStore(Class<? extends CredentialsProvider> providerClass) {
+        super(providerClass);
+    }
+
+    public ReadOnlyCredentialsStore() {
+        super();
+    }
+
+    /**
+     * If this method is overridden, ensure permissions {@link CredentialsProvider#CREATE}, {@link CredentialsProvider#UPDATE},
+     * {@link CredentialsProvider#DELETE} will return false
+     * @param a          the principle.
+     * @param permission the permission.
+     * @return boolean
+     */
+    @Override
+    public boolean hasPermission(@NonNull Authentication a, @NonNull Permission permission) {
+        return getACL().hasPermission(a, permission);
+    }
+
+    @NonNull
+    public ACL getACL() {
+        return new ACL() {
+            @Override
+            public boolean hasPermission(@Nonnull Authentication a, @Nonnull Permission permission) {
+                if (permission.equals(CredentialsProvider.CREATE) || permission.equals(CredentialsProvider.UPDATE) || permission.equals(CredentialsProvider.DELETE)) {
+                    return false;
+                }
+
+                return Jenkins.getInstance().getACL().hasPermission(a, permission);
+            }
+        };
+    }
+
+    @Override
+    public final boolean addCredentials(@NonNull Domain domain, @NonNull Credentials credentials) throws IOException {
+        throw new UnsupportedOperationException("Cannot add items to read-only credentials store");
+    }
+
+    @Override
+    public final boolean removeCredentials(@NonNull Domain domain, @NonNull Credentials credentials) throws IOException {
+        throw new UnsupportedOperationException("Cannot remove items to read-only credentials store");
+    }
+
+    @Override
+    public final boolean updateCredentials(@NonNull Domain domain, @NonNull Credentials current, @NonNull Credentials replacement) throws IOException {
+        throw new UnsupportedOperationException("Cannot update items to read-only credentials store");
+    }
+}

--- a/src/main/java/com/cloudbees/plugins/credentials/ReadOnlyCredentialsStore.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/ReadOnlyCredentialsStore.java
@@ -43,6 +43,14 @@ import java.io.IOException;
  * @since TODO
  */
 public abstract class ReadOnlyCredentialsStore extends CredentialsStore {
+    public ReadOnlyCredentialsStore(Class<? extends CredentialsProvider> providerClass) {
+        super(providerClass);
+    }
+
+    public ReadOnlyCredentialsStore() {
+        super();
+    }
+
     /**
      * If this method is overridden, ensure permissions {@link CredentialsProvider#CREATE}, {@link CredentialsProvider#UPDATE},
      * {@link CredentialsProvider#DELETE} will return false

--- a/src/main/java/com/cloudbees/plugins/credentials/ReadOnlyCredentialsStore.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/ReadOnlyCredentialsStore.java
@@ -93,7 +93,13 @@ public abstract class ReadOnlyCredentialsStore extends CredentialsStore {
                     return false;
                 }
 
-                return Jenkins.getInstance().getACL().hasPermission(a, permission);
+                // todo this shouldn't be necessary, but findbugs is failing.
+                Jenkins jenkins = Jenkins.getInstance();
+                if(jenkins != null) {
+                    return jenkins.getACL().hasPermission(a, permission);
+                }
+
+                return false;
             }
         };
     }

--- a/src/main/resources/com/cloudbees/plugins/credentials/CredentialsSelectHelper/WrappedCredentialsStore/dialog.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/CredentialsSelectHelper/WrappedCredentialsStore/dialog.jelly
@@ -30,32 +30,34 @@
         <l:icon class="${it.iconClassName} icon-xlg"/> ${it.description}: ${it.displayName}
       </h2>
     </div>
-    <div class="bd">
-      <h3>
-      <l:icon class="icon-credentials-new-credential icon-md"/>
-      ${%Add Credentials}
-      </h3>
-      <form action="${it.url}/addCredentials" method="POST" id="credentials-dialog-form">
-        <table width="100%">
-          <f:entry title="${%Domain}">
-            <select class="setting-input" name="_.domain">
-              <j:forEach var="domain" items="${it.wrappers.entrySet()}">
-                <f:option value="${domain.key}" selected="${domain.key=='_'}">${domain.value.displayName}</f:option>
-              </j:forEach>
-            </select>
-          </f:entry>
-          <f:block>
-            <j:set var="descriptors" value="${it.credentialsDescriptors}"/>
-            <st:include page="credential"/>
-          </f:block>
-          <f:block>
-            <input id="credentials-add-submit" class="yui-button" value="${%Add}"
-                   onclick="return window.credentials.addSubmit(this);"/>
-            <input id="credentials-add-abort" class="yui-button"
-                   onclick="window.credentials.dialog.hide(); return false;" value="${%Cancel}"/>
-          </f:block>
-        </table>
-      </form>
-    </div>
+    <j:if test="${it.credentialsModifiable}">
+      <div class="bd">
+        <h3>
+        <l:icon class="icon-credentials-new-credential icon-md"/>
+        ${%Add Credentials}
+        </h3>
+        <form action="${it.url}/addCredentials" method="POST" id="credentials-dialog-form">
+          <table width="100%">
+            <f:entry title="${%Domain}">
+              <select class="setting-input" name="_.domain">
+                <j:forEach var="domain" items="${it.wrappers.entrySet()}">
+                  <f:option value="${domain.key}" selected="${domain.key=='_'}">${domain.value.displayName}</f:option>
+                </j:forEach>
+              </select>
+            </f:entry>
+            <f:block>
+              <j:set var="descriptors" value="${it.credentialsDescriptors}"/>
+              <st:include page="credential"/>
+            </f:block>
+            <f:block>
+              <input id="credentials-add-submit" class="yui-button" value="${%Add}"
+                     onclick="return window.credentials.addSubmit(this);"/>
+              <input id="credentials-add-abort" class="yui-button"
+                     onclick="window.credentials.dialog.hide(); return false;" value="${%Cancel}"/>
+            </f:block>
+          </table>
+        </form>
+      </div>
+    </j:if>
   </l:ajax>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/CredentialsWrapper/move.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/CredentialsWrapper/move.jelly
@@ -1,31 +1,38 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.fullDisplayName}" norefresh="true" permission="${it.domain.parent.DELETE}">
-		<st:include page="sidepanel.jelly" />
-		<l:main-panel>
+    <st:include page="sidepanel.jelly" />
+    <l:main-panel>
       <h1><img src="${resURL}/plugin/credentials/images/48x48/move.png" alt=""/>${%Move}</h1>
-      <form method="post" action="doMove">
-        ${%blurb(it.displayName,it.typeName)}
-        <br />
-        <select name="destination" class="select setting-input" style="width:auto;">
-          <j:forEach var="destination" items="${it.domain.parent.domains.values()}">
-            <j:choose>
-              <j:when test="${destination.domain == it.domain.domain}">
-                <option selected="yes" value="${destination.fullName}">
+      <j:choose>
+        <j:when test="${it.credentialsModifiable}">
+          <form method="post" action="doMove">
+            ${%blurb(it.displayName,it.typeName)}
+            <br />
+            <select name="destination" class="select setting-input" style="width:auto;">
+              <j:forEach var="destination" items="${it.domain.parent.domains.values()}">
+                <j:choose>
+                  <j:when test="${destination.domain == it.domain.domain}">
+                    <option selected="yes" value="${destination.fullName}">
                   ${app.displayName} &#187; ${destination.fullDisplayName}
-                </option>
-              </j:when>
-              <j:otherwise>
-                <option value="${destination.fullName}">
+                    </option>
+                  </j:when>
+                  <j:otherwise>
+                    <option value="${destination.fullName}">
                   ${app.displayName} &#187; ${destination.fullDisplayName}
-                </option>
-              </j:otherwise>
-            </j:choose>
-          </j:forEach>
-        </select>
-        <br />
-        <f:submit value="${%Move}"/>
-      </form>
+                    </option>
+                  </j:otherwise>
+                </j:choose>
+              </j:forEach>
+            </select>
+            <br />
+            <f:submit value="${%Move}"/>
+        </form>
+      </j:when>
+      <j:otherwise>
+        <p>The credentials provider is not modifiable and therefore cannot be moved</p>
+      </j:otherwise>
+    </j:choose>
     </l:main-panel>
-	</l:layout>
+  </l:layout>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/DomainWrapper/index.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/DomainWrapper/index.jelly
@@ -31,9 +31,19 @@
       <h1><l:icon class="icon-credentials-domain icon-xlg"/>${it.displayName}</h1>
       <div>
         <j:out value="${it.description!=null ? app.markupFormatter.translate(it.description) : ''}" />
+        <j:if test="${!it.store.credentialsModifiable}">
+          <br />This is a read-only credentials provider. Please see the docs to find out how to add/edit/remove credentials
+        </j:if>
       </div>
       <t:setIconSize/>
       <table class="sortable pane bigtable">
+        <colgroup>
+          <col width="5%" />
+          <col width="20%" />
+          <col width="20%" />
+          <col width="50%;" />
+          <col width="5%;" />
+        </colgroup>
         <tr style="border-top: 0px;">
           <th>
             <st:nbsp/>
@@ -58,7 +68,7 @@
             <tr>
                <td colspan="5" align="center">
                  <j:choose>
-                   <j:when test="${it.store.hasPermission(it.parent.CREATE)}">
+                   <j:when test="${it.store.credentialsModifiable and it.store.hasPermission(it.parent.CREATE)}">
                      ${%noCredentialsAddSome}
                    </j:when>
                    <j:otherwise>
@@ -87,7 +97,7 @@
                   ${safeDescription}
                 </td>
                 <td>
-                  <j:if test="${h.hasPermission(c, it.parent.UPDATE)}">
+                  <j:if test="${it.credentialsModifiable and h.hasPermission(c, it.parent.UPDATE)}">
                     <a href="credential/${c.urlName}/update">
                       <img src="${resURL}/images/${iconSize}/setting.png" alt="${%Update}"
                            tooltip="${%Update}" class="icon${iconSize}"/>

--- a/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/DomainWrapper/newCredentials.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/DomainWrapper/newCredentials.jelly
@@ -25,57 +25,59 @@
  -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout"
          xmlns:f="/lib/form" xmlns:c="/lib/credentials" xmlns:t="/lib/hudson">
-  <l:layout title="${%New Credentials}" norefresh="true" permission="${it.parent.CREATE}">
-    <st:include page="sidepanel.jelly"/>
-    <l:main-panel>
-      <j:set var="descriptor" value="${it.credentialDescriptor}"/>
-      <j:set var="instance" value="${null}"/>
-      <f:form action="createCredentials" method="POST" name="newCredentials">
-        <j:set var="descriptors" value="${it.store.credentialsDescriptors}" />
-        <j:choose>
-          <j:when test="${descriptors.size()==1}">
-            <f:entry title="${%Kind}" help="${descriptor.getHelpFile('credentials')}">
-              <i>${descriptors[0].displayName}</i>
-            </f:entry>
-            <f:rowSet name="credentials">
-              <j:set var="descriptor" value="${descriptors[0]}"/>
-              <j:set var="instance" value="${null}"/>
-              <f:class-entry descriptor="${descriptor}"/>
-              <st:include from="${descriptor}" page="${descriptor.configPage}"/>
-            </f:rowSet>
-          </j:when>
-          <j:otherwise>
-            <j:local>
-              <j:set var="it" value="${it.store}"/>
-              <!-- TODO revert to dropdownDescriptorSelector when baseline is 1.645+ which supports `capture` attribute -->
-              <f:dropdownList name="credentials" title="${%Kind}" help="${descriptor.getHelpFile('credentials')}">
-                <j:set var="current" value="${instance[credentials]}"/>
-                <j:set var="current" value="${current!=null ? current : null}"/>
-                <j:forEach var="descriptor" items="${descriptors}" varStatus="loop">
-                  <f:dropdownListBlock value="${loop.index}" title="${descriptor.displayName}"
-                                       selected="${current.descriptor==descriptor || (current==null and descriptor==attrs.default)}"
-                                       staplerClass="${descriptor.clazz.name}"
-                                       lazy="descriptor,it">
-                    <l:ajax>
-                      <j:set var="instance" value="${current.descriptor==descriptor ? current : null}"/>
-                      <st:include from="${descriptor}" page="${descriptor.configPage}"/>
-                    </l:ajax>
-                  </f:dropdownListBlock>
-                </j:forEach>
-              </f:dropdownList>
-              <!--f:dropdownDescriptorSelector field="credentials" title="${%Kind}" lazy="it"/-->
-            </j:local>
-          </j:otherwise>
-        </j:choose>
+  <j:if test="${it.credentialsModifiable}">
+    <l:layout title="${%New Credentials}" norefresh="true" permission="${it.parent.CREATE}">
+      <st:include page="sidepanel.jelly"/>
+      <l:main-panel>
+        <j:set var="descriptor" value="${it.credentialDescriptor}"/>
+        <j:set var="instance" value="${null}"/>
+        <f:form action="createCredentials" method="POST" name="newCredentials">
+          <j:set var="descriptors" value="${it.store.credentialsDescriptors}" />
+          <j:choose>
+            <j:when test="${descriptors.size()==1}">
+              <f:entry title="${%Kind}" help="${descriptor.getHelpFile('credentials')}">
+                <i>${descriptors[0].displayName}</i>
+              </f:entry>
+              <f:rowSet name="credentials">
+                <j:set var="descriptor" value="${descriptors[0]}"/>
+                <j:set var="instance" value="${null}"/>
+                <f:class-entry descriptor="${descriptor}"/>
+                <st:include from="${descriptor}" page="${descriptor.configPage}"/>
+              </f:rowSet>
+            </j:when>
+            <j:otherwise>
+              <j:local>
+                <j:set var="it" value="${it.store}"/>
+                <!-- TODO revert to dropdownDescriptorSelector when baseline is 1.645+ which supports `capture` attribute -->
+                <f:dropdownList name="credentials" title="${%Kind}" help="${descriptor.getHelpFile('credentials')}">
+                  <j:set var="current" value="${instance[credentials]}"/>
+                  <j:set var="current" value="${current!=null ? current : null}"/>
+                  <j:forEach var="descriptor" items="${descriptors}" varStatus="loop">
+                    <f:dropdownListBlock value="${loop.index}" title="${descriptor.displayName}"
+                                         selected="${current.descriptor==descriptor || (current==null and descriptor==attrs.default)}"
+                                         staplerClass="${descriptor.clazz.name}"
+                                         lazy="descriptor,it">
+                      <l:ajax>
+                        <j:set var="instance" value="${current.descriptor==descriptor ? current : null}"/>
+                        <st:include from="${descriptor}" page="${descriptor.configPage}"/>
+                      </l:ajax>
+                    </f:dropdownListBlock>
+                  </j:forEach>
+                </f:dropdownList>
+                <!--f:dropdownDescriptorSelector field="credentials" title="${%Kind}" lazy="it"/-->
+              </j:local>
+            </j:otherwise>
+          </j:choose>
 
-        <f:bottomButtonBar>
-          <f:submit value="${%OK}"/>
-        </f:bottomButtonBar>
-      </f:form>
-      <script>
-        // TODO remove this JENKINS-24662 workaround when baseline core has fix for root cause
-        window.setTimeout(function(){layoutUpdateCallback.call();}, 1000);
-      </script>
-    </l:main-panel>
-  </l:layout>
+          <f:bottomButtonBar>
+            <f:submit value="${%OK}"/>
+          </f:bottomButtonBar>
+        </f:form>
+        <script>
+          // TODO remove this JENKINS-24662 workaround when baseline core has fix for root cause
+          window.setTimeout(function(){layoutUpdateCallback.call();}, 1000);
+        </script>
+      </l:main-panel>
+    </l:layout>
+  </j:if>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/DomainWrapper/sidepanel.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/DomainWrapper/sidepanel.jelly
@@ -28,7 +28,9 @@
     <l:tasks>
     <j:set var="url" value="${h.getNearestAncestorUrl(request,it)}"/>
     <l:task icon="images/24x24/up.png" href="../.." title="${%Back to credential domains}" contextMenu="false"/>
+      <j:if test="${it.parent.credentialsModifiable}">
       <l:task icon="plugin/credentials/images/24x24/new-credential.png" href="newCredentials" title="${%Add Credentials}" permission="${it.parent.CREATE}" />
+      </j:if>
       <j:if test="${!it.global and it.parent.domainsModifiable}">
       <l:task icon="images/24x24/setting.png" href="${url}/configure" title="${%Configure}" permission="${it.parent.MANAGE_DOMAINS}"/>
       <l:task icon="images/24x24/edit-delete.png" href="${url}/delete" title="${%Delete domain}" permission="${it.parent.MANAGE_DOMAINS}"/>

--- a/src/test/java/com/cloudbees/plugins/credentials/ReadOnlyCredentialsStoreTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/ReadOnlyCredentialsStoreTest.java
@@ -38,6 +38,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class ReadOnlyCredentialsStoreTest {
@@ -53,7 +54,7 @@ public class ReadOnlyCredentialsStoreTest {
         public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
                                                               @Nullable Authentication authentication
         ) {
-            return null;
+            return Collections.emptyList();
         }
 
         static class ReadOnlyStoreImpl extends ReadOnlyCredentialsStore {

--- a/src/test/java/com/cloudbees/plugins/credentials/ReadOnlyCredentialsStoreTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/ReadOnlyCredentialsStoreTest.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011-2012, CloudBees, Inc., Stephen Connolly.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.plugins.credentials;
+
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.ModelObject;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ReadOnlyCredentialsStoreTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    private Domain testDomain = new Domain("some-domain", "some description", null);
+
+    CredentialsStore credentialsStore = new ReadOnlyCredentialsStore() {
+        @NonNull
+        @Override
+        public ModelObject getContext() {
+            return j.getInstance();
+        }
+
+        @NonNull
+        @Override
+        public List<Credentials> getCredentials(@NonNull Domain domain) {
+            ArrayList<Credentials> credentials = new ArrayList<>();
+            credentials.add(createRandomCredentials("some-id"));
+            return credentials;
+        }
+    };
+
+    private Credentials createRandomCredentials(String id) {
+        return new UsernamePasswordCredentialsImpl(
+                CredentialsScope.GLOBAL,
+                id,
+                "some-desc",
+                "username",
+                "password"
+        );
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void cannotAddCredentials() throws IOException {
+        credentialsStore.addCredentials(testDomain, createRandomCredentials("new-id"));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void cannotUpdateCredentials() throws IOException {
+        credentialsStore.updateCredentials(testDomain, createRandomCredentials("old-id"), createRandomCredentials("new-id"));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void cannotRemoveCredentials() throws IOException {
+        credentialsStore.removeCredentials(testDomain, createRandomCredentials("old-id"));
+    }
+}


### PR DESCRIPTION
Simply allows ReadOnly credentials provider to be implemented more simpler. Closes [JENKINS-46859](https://issues.jenkins-ci.org/browse/JENKINS-46859).

This should be revisited in stages, however, as it stands it's to do a better implementation (an attempt is PR #92). After discussing with @stephenc, this seemed a simpler and less risky solution.

Docs yet to be updated.