### PR TITLE
[JENKINS-49235] Prune fingerprints of non existent node credentials

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
@@ -1526,14 +1526,13 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                     try {
                         Collection<FingerprintFacet> facets = fingerprint.getFacets();
                         // purge any old facets
-                        // Current
                         long start = timestamp;
                         for (Iterator<FingerprintFacet> iterator = facets.iterator(); iterator.hasNext(); ) {
                             FingerprintFacet f = iterator.next();
                             // For all the node-tracking credentials, check to see if we can remove
                             // older instances of these credential fingerprints, or from nodes which no longer exist
                             if (f instanceof NodeCredentialsFingerprintFacet) {
-                                // Remove older instance
+                                // Remove older instances
                                 if (StringUtils.equals(nodeName, ((NodeCredentialsFingerprintFacet) f).getNodeName())) {
                                     start = Math.min(start, f.getTimestamp());
                                     iterator.remove();

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
@@ -1771,3 +1771,4 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
         }
     }
 }
+

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsProviderTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsProviderTest.java
@@ -295,6 +295,11 @@ public class CredentialsProviderTest {
         CredentialsProvider.track(addedSlave, globalCred);
         assertEquals(initialFingerprintSize+1, CredentialsProvider.getOrCreateFingerprintOf(globalCred).getFacets().size());
 
+        // Track the usage of the credential for a second time, this should
+        // not increase the number of fingerprints further
+        CredentialsProvider.track(addedSlave, globalCred);
+        assertEquals(initialFingerprintSize+1, CredentialsProvider.getOrCreateFingerprintOf(globalCred).getFacets().size());
+
         // Remove the added slave from Jenkins, and register the
         // slave again to flush any mapped credentials for nodes that no-longer
         // exist - including this one

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsProviderTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsProviderTest.java
@@ -68,7 +68,7 @@ public class CredentialsProviderTest {
 
     @Rule
     public JenkinsRule r = new JenkinsRule();
-
+    
     @Test
     public void testNoCredentialsUntilWeAddSome() throws Exception {
         FreeStyleProject project = r.createFreeStyleProject();
@@ -113,7 +113,7 @@ public class CredentialsProviderTest {
                 "manchu");
 
     }
-
+    
     @Test
     public void testNoCredentialsUntilWeAddSomeViaStore() throws Exception {
         FreeStyleProject project = r.createFreeStyleProject();
@@ -164,34 +164,34 @@ public class CredentialsProviderTest {
         DummyCredentials aliceCred1 = new DummyCredentials(CredentialsScope.USER, "aliceCred1", "pwd");
         DummyCredentials aliceCred2 = new DummyCredentials(CredentialsScope.USER, "aliceCred2", "pwd");
         DummyCredentials aliceCred3 = new DummyCredentials(CredentialsScope.USER, "aliceCred3", "pwd");
-
+        
         r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
-
+        
         CredentialsStore userStore;
         SecurityContext ctx = ACL.impersonate(alice.impersonate());
         userStore = CredentialsProvider.lookupStores(alice).iterator().next();
         userStore.addCredentials(Domain.global(), aliceCred1);
         userStore.addCredentials(Domain.global(), aliceCred2);
-
+    
         assertEquals(2, CredentialsProvider.lookupCredentials(DummyCredentials.class, (Item) null, alice.impersonate(), Collections.<DomainRequirement>emptyList()).size());
         assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, Collections.<DomainRequirement>emptyList()).isEmpty());
         assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, Jenkins.ANONYMOUS, Collections.<DomainRequirement>emptyList()).isEmpty());
 
         // Remove credentials
         userStore.removeCredentials(Domain.global(), aliceCred2);
-
+        
         assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, (Item) null, alice.impersonate(), Collections.<DomainRequirement>emptyList()).size());
         assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, Collections.<DomainRequirement>emptyList()).isEmpty());
         assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, Jenkins.ANONYMOUS, Collections.<DomainRequirement>emptyList()).isEmpty());
-
+   
         // Update credentials
         userStore.updateCredentials(Domain.global(), aliceCred1, aliceCred3);
-
+        
         assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, (Item) null, alice.impersonate(), Collections.<DomainRequirement>emptyList()).size());
         assertEquals(aliceCred3.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, (Item) null, alice.impersonate(), Collections.<DomainRequirement>emptyList()).get(0).getUsername());
         SecurityContextHolder.setContext(ctx);
     }
-
+    
     @Test
     public void testUpdateAndDeleteCredentials() throws IOException {
         FreeStyleProject project = r.createFreeStyleProject();
@@ -201,26 +201,26 @@ public class CredentialsProviderTest {
         DummyCredentials modCredential = new DummyCredentials(CredentialsScope.GLOBAL, "modCredential", "pwd");
 
         CredentialsStore store = CredentialsProvider.lookupStores(Jenkins.getInstance()).iterator().next();
-
+        
         // Add credentials
         store.addCredentials(Domain.global(), systemCred);
         store.addCredentials(Domain.global(), systemCred2);
         store.addCredentials(Domain.global(), globalCred);
-
+        
         assertEquals(3, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, Collections.<DomainRequirement>emptyList()).size());
         assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, project, ACL.SYSTEM, Collections.<DomainRequirement>emptyList()).size());
         assertEquals(globalCred.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, project, ACL.SYSTEM, Collections.<DomainRequirement>emptyList()).get(0).getUsername());
-
+    
         // Update credentials
         store.updateCredentials(Domain.global(), globalCred, modCredential);
-
+        
         assertEquals(3, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, Collections.<DomainRequirement>emptyList()).size());
         assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, project, ACL.SYSTEM, Collections.<DomainRequirement>emptyList()).size());
         assertEquals(modCredential.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, project, ACL.SYSTEM, Collections.<DomainRequirement>emptyList()).get(0).getUsername());
-
+        
         // Remove credentials
         store.removeCredentials(Domain.global(), systemCred2);
-
+        
         assertEquals(2, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, Collections.<DomainRequirement>emptyList()).size());
         assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, project, ACL.SYSTEM, Collections.<DomainRequirement>emptyList()).size());
     }


### PR DESCRIPTION
[JENKINS-49235](https://issues.jenkins-ci.org/browse/JENKINS-49235)

  - Add a test to check that fingerprints aren't stored for nodes that aren't known
    - Checks that storing a fingerprint for a node that Jenkins doesn't know
      about is not saved
    - Checks that adding a fingerprint for a node that Jenkins does know about
      is saved
    - Checks that the fingerprint is removed when calling track() after
      the node has been removed
    - Check that tracking a credential on the same node again doesn't
      result in two entries

  - Add functionality for the above. When iterating the facets of the
    fingerprint any NodeCredentialsFingerprintFacet elements are checked
    in the iterator and removed if necessary. An additional check has been
    added around the eventual addition to skip the case where it doesn't
    exist at that point

cf. https://github.com/jenkinsci/ssh-slaves-plugin/pull/35