### PR TITLE
Support credentials in Configuration as Code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 
   <properties>
     <jenkins.version>1.625.3</jenkins.version>
-    <java.level>7</java.level>
+    <java.level>8</java.level>
     <antlr4.version>4.5</antlr4.version>
   </properties>
 
@@ -89,6 +89,14 @@
       <artifactId>structs</artifactId>
       <version>1.7</version>
     </dependency>
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <version>1.1-20180926.061808-1</version>
+      <optional>true</optional>
+    </dependency>
+
+
     <!-- test dependencies -->
     <dependency>
       <groupId>org.mockito</groupId>

--- a/src/main/java/com/cloudbees/plugins/credentials/casc/CredentialsRootConfigurator.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/casc/CredentialsRootConfigurator.java
@@ -1,0 +1,92 @@
+/*
+ * The MIT License
+ *
+ *  Copyright (c) 2018, CloudBees, Inc.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ *
+ */
+
+package com.cloudbees.plugins.credentials.casc;
+
+import com.cloudbees.plugins.credentials.GlobalCredentialsConfiguration;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import hudson.Extension;
+import io.jenkins.plugins.casc.Attribute;
+import io.jenkins.plugins.casc.BaseConfigurator;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.RootElementConfigurator;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Mapping;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import javax.annotation.CheckForNull;
+import java.util.Collections;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import static io.jenkins.plugins.casc.Attribute.noop;
+
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+@Extension(optional = true)
+@Restricted(NoExternalUse.class)
+public class CredentialsRootConfigurator extends BaseConfigurator<GlobalCredentialsConfiguration> implements RootElementConfigurator<GlobalCredentialsConfiguration> {
+
+    @Override
+    public String getName() {
+        return "credentials";
+    }
+
+    @Override
+    public Class<GlobalCredentialsConfiguration> getTarget() {
+        return GlobalCredentialsConfiguration.class;
+    }
+
+    @Override
+    public GlobalCredentialsConfiguration getTargetComponent(ConfigurationContext context) {
+        return GlobalCredentialsConfiguration.all().get(GlobalCredentialsConfiguration.class);
+    }
+
+    @Override
+    public GlobalCredentialsConfiguration instance(Mapping mapping, ConfigurationContext context) {
+        return getTargetComponent(context);
+    }
+
+    @Override
+    public Set<Attribute<GlobalCredentialsConfiguration,?>> describe() {
+        return Collections.singleton(new Attribute<GlobalCredentialsConfiguration, SystemCredentialsProvider>("system", SystemCredentialsProvider.class)
+            .getter( t -> SystemCredentialsProvider.getInstance() )
+            .setter( noop() ));
+    }
+
+    @CheckForNull
+    @Override
+    public CNode describe(GlobalCredentialsConfiguration instance, ConfigurationContext context) throws Exception {
+        Mapping mapping = new Mapping();
+        for (Attribute attribute : describe()) {
+            mapping.put(attribute.getName(), attribute.describe(instance, context));
+        }
+        return mapping;
+    }
+
+}

--- a/src/main/java/com/cloudbees/plugins/credentials/casc/SystemCredentialsProviderConfigurator.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/casc/SystemCredentialsProviderConfigurator.java
@@ -1,0 +1,80 @@
+/*
+ * The MIT License
+ *
+ *  Copyright (c) 2018, CloudBees, Inc.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ *
+ */
+
+package com.cloudbees.plugins.credentials.casc;
+
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.DomainCredentials;
+import hudson.Extension;
+import io.jenkins.plugins.casc.Attribute;
+import io.jenkins.plugins.casc.BaseConfigurator;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.impl.attributes.MultivaluedAttribute;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Mapping;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+@Extension(optional = true)
+@Restricted(NoExternalUse.class)
+public class SystemCredentialsProviderConfigurator extends BaseConfigurator<SystemCredentialsProvider> {
+
+    @Override
+    public Class<SystemCredentialsProvider> getTarget() {
+        return SystemCredentialsProvider.class;
+    }
+
+    @Override
+    protected SystemCredentialsProvider instance(Mapping mapping, ConfigurationContext context) {
+        return SystemCredentialsProvider.getInstance();
+    }
+
+    @Nonnull
+    @Override
+    public Set<Attribute<SystemCredentialsProvider, ?>> describe() {
+        return Collections.singleton(
+            new MultivaluedAttribute<SystemCredentialsProvider, DomainCredentials>("domainCredentials", DomainCredentials.class)
+                .setter( (target, value) -> target.setDomainCredentialsMap(DomainCredentials.asMap(value)))
+        );
+    }
+
+    @CheckForNull
+    @Override
+    public CNode describe(SystemCredentialsProvider instance, ConfigurationContext context) throws Exception {
+        Mapping mapping = new Mapping();
+        for (Attribute attribute : describe()) {
+            mapping.put(attribute.getName(), attribute.describe(instance, context));
+        }
+        return mapping;
+    }
+}

--- a/src/test/java/com/cloudbees/plugins/credentials/casc/SystemCredentialsTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/casc/SystemCredentialsTest.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License
+ *
+ *  Copyright (c) 2018, CloudBees, Inc.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ *
+ */
+
+package com.cloudbees.plugins.credentials.casc;
+
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.domains.HostnameRequirement;
+import hudson.security.ACL;
+import io.jenkins.plugins.casc.ConfigurationAsCode;
+import io.jenkins.plugins.casc.yaml.YamlSource;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class SystemCredentialsTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void configure_system_credentials() throws Exception {
+        ConfigurationAsCode.get().configureWith(new YamlSource(getClass().getResourceAsStream("SystemCredentialsTest.yaml"), YamlSource.READ_FROM_INPUTSTREAM));
+        List<UsernamePasswordCredentials> ups = CredentialsProvider.lookupCredentials(
+                UsernamePasswordCredentials.class, j.jenkins, ACL.SYSTEM,
+                Collections.singletonList(new HostnameRequirement("api.test.com"))
+        );
+        assertThat(ups, hasSize(1));
+        final UsernamePasswordCredentials up = ups.get(0);
+        assertThat(up.getPassword().getPlainText(), equalTo("password"));
+    }
+}

--- a/src/test/resources/com/cloudbees/plugins/credentials/casc/SystemCredentialsTest.yaml
+++ b/src/test/resources/com/cloudbees/plugins/credentials/casc/SystemCredentialsTest.yaml
@@ -1,0 +1,21 @@
+credentials:
+  system:
+    domainCredentials:
+      - domain :
+          name: "test.com"
+          description: "test.com domain"
+          specifications:
+            - hostnameSpecification:
+                includes: "*.test.com"
+        credentials:
+          - usernamePassword:
+              scope:    SYSTEM
+              id:       sudo_password
+              username: root
+              password: "password"
+
+
+
+
+
+


### PR DESCRIPTION
Move configuration-as-code credentials support in job-dsl plugin

Configuration-as-Code [JEP-201](https://github.com/jenkinsci/jep/tree/master/jep/201) allow to configure a full jenkins master from a plain text definition. Managing credentials is delegated by most plugins to credentials-plugin, so we'd like this feature hosted by the implementor.

see jenkinsci/configuration-as-code-plugin#197