### PR TITLE
[JENKINS-49235] Prune fingerprints of nonexistent node credentials (and add ticket to fix tracking for ephemeral nodes)

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
@@ -1510,20 +1510,20 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     public static <C extends Credentials> List<C> trackAll(@NonNull Node node, @NonNull List<C> credentials) {
         long timestamp = System.currentTimeMillis();
         String nodeName = node.getNodeName();
+        // Create a list of all current node names. The credential will only be
+        // fingerprinted if it is one of these.
+        // TODO (JENKINS-51694): This breaks tracking for cloud agents. We should
+        // track those agents against the cloud instead of the node itself.
+        Set<String> jenkinsNodeNames = new HashSet<>();
+        // TODO: Switch to Jenkins.get() once 2.98+ is the baseline
+        for (Node n: Jenkins.getActiveInstance().getNodes()) {
+            jenkinsNodeNames.add(n.getNodeName());
+        }
         for (Credentials c : credentials) {
             if (c != null) {
                 try {
                     Fingerprint fingerprint = getOrCreateFingerprintOf(c);
                     BulkChange change = new BulkChange(fingerprint);
-
-                    // Create a list of all current node names, the
-                    // credential will only be fingerprinted if it is one of these
-                    Set<String> jenkinsNodeNames = new HashSet<>();
-                    // TODO: Switch to Jenkins.get() once 2.98+ is the baseline
-                    for (Node n: Jenkins.getActiveInstance().getNodes()) {
-                        jenkinsNodeNames.add(n.getNodeName());
-                    }
-
                     try {
                         Collection<FingerprintFacet> facets = fingerprint.getFacets();
                         // purge any old facets

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
@@ -1526,14 +1526,13 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                     try {
                         Collection<FingerprintFacet> facets = fingerprint.getFacets();
                         // purge any old facets
-                        // Current
                         long start = timestamp;
                         for (Iterator<FingerprintFacet> iterator = facets.iterator(); iterator.hasNext(); ) {
                             FingerprintFacet f = iterator.next();
                             // For all the node-tracking credentials, check to see if we can remove
                             // older instances of these credential fingerprints, or from nodes which no longer exist
                             if (f instanceof NodeCredentialsFingerprintFacet) {
-                                // Remove older instance
+                                // Remove older instances
                                 if (StringUtils.equals(nodeName, ((NodeCredentialsFingerprintFacet) f).getNodeName())) {
                                     start = Math.min(start, f.getTimestamp());
                                     iterator.remove();

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
@@ -1771,3 +1771,4 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
         }
     }
 }
+

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsProviderTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsProviderTest.java
@@ -295,6 +295,11 @@ public class CredentialsProviderTest {
         CredentialsProvider.track(addedSlave, globalCred);
         assertEquals(initialFingerprintSize+1, CredentialsProvider.getOrCreateFingerprintOf(globalCred).getFacets().size());
 
+        // Track the usage of the credential for a second time, this should
+        // not increase the number of fingerprints further
+        CredentialsProvider.track(addedSlave, globalCred);
+        assertEquals(initialFingerprintSize+1, CredentialsProvider.getOrCreateFingerprintOf(globalCred).getFacets().size());
+
         // Remove the added slave from Jenkins, and register the
         // slave again to flush any mapped credentials for nodes that no-longer
         // exist - including this one

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsProviderTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsProviderTest.java
@@ -28,20 +28,17 @@ import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.cloudbees.plugins.credentials.impl.DummyCredentials;
 import com.cloudbees.plugins.credentials.impl.DummyLegacyCredentials;
-import com.cloudbees.plugins.credentials.fingerprints.NodeCredentialsFingerprintFacet;
 import hudson.model.Descriptor;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.Node;
-import hudson.model.Node.Mode;
 import hudson.slaves.NodeProperty;
 import hudson.model.User;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.JNLPLauncher;
 import hudson.slaves.RetentionStrategy;
 import hudson.security.ACL;
-import jenkins.model.FingerprintFacet;
 import jenkins.model.Jenkins;
 import org.acegisecurity.Authentication;
 import org.acegisecurity.context.SecurityContext;
@@ -55,7 +52,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -300,11 +296,10 @@ public class CredentialsProviderTest {
         CredentialsProvider.track(addedSlave, globalCred);
         assertEquals(initialFingerprintSize+1, CredentialsProvider.getOrCreateFingerprintOf(globalCred).getFacets().size());
 
-        // Remove the added slave from Jenkins, and register the
-        // slave again to flush any mapped credentials for nodes that no-longer
-        // exist - including this one
+        // Remove the added slave from Jenkins, and track the non-added slave
+        // to flush any mapped credentials for nodes that no longer exist.
         Jenkins.getInstance().removeNode(addedSlave);
-        CredentialsProvider.track(addedSlave, globalCred);
+        CredentialsProvider.track(nonAddedSlave, globalCred);
         assertEquals(initialFingerprintSize, CredentialsProvider.getOrCreateFingerprintOf(globalCred).getFacets().size());
 
     }

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsProviderTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsProviderTest.java
@@ -68,7 +68,7 @@ public class CredentialsProviderTest {
 
     @Rule
     public JenkinsRule r = new JenkinsRule();
-
+    
     @Test
     public void testNoCredentialsUntilWeAddSome() throws Exception {
         FreeStyleProject project = r.createFreeStyleProject();
@@ -113,7 +113,7 @@ public class CredentialsProviderTest {
                 "manchu");
 
     }
-
+    
     @Test
     public void testNoCredentialsUntilWeAddSomeViaStore() throws Exception {
         FreeStyleProject project = r.createFreeStyleProject();
@@ -164,34 +164,34 @@ public class CredentialsProviderTest {
         DummyCredentials aliceCred1 = new DummyCredentials(CredentialsScope.USER, "aliceCred1", "pwd");
         DummyCredentials aliceCred2 = new DummyCredentials(CredentialsScope.USER, "aliceCred2", "pwd");
         DummyCredentials aliceCred3 = new DummyCredentials(CredentialsScope.USER, "aliceCred3", "pwd");
-
+        
         r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
-
+        
         CredentialsStore userStore;
         SecurityContext ctx = ACL.impersonate(alice.impersonate());
         userStore = CredentialsProvider.lookupStores(alice).iterator().next();
         userStore.addCredentials(Domain.global(), aliceCred1);
         userStore.addCredentials(Domain.global(), aliceCred2);
-
+    
         assertEquals(2, CredentialsProvider.lookupCredentials(DummyCredentials.class, (Item) null, alice.impersonate(), Collections.<DomainRequirement>emptyList()).size());
         assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, Collections.<DomainRequirement>emptyList()).isEmpty());
         assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, Jenkins.ANONYMOUS, Collections.<DomainRequirement>emptyList()).isEmpty());
 
         // Remove credentials
         userStore.removeCredentials(Domain.global(), aliceCred2);
-
+        
         assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, (Item) null, alice.impersonate(), Collections.<DomainRequirement>emptyList()).size());
         assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, Collections.<DomainRequirement>emptyList()).isEmpty());
         assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, Jenkins.ANONYMOUS, Collections.<DomainRequirement>emptyList()).isEmpty());
-
+   
         // Update credentials
         userStore.updateCredentials(Domain.global(), aliceCred1, aliceCred3);
-
+        
         assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, (Item) null, alice.impersonate(), Collections.<DomainRequirement>emptyList()).size());
         assertEquals(aliceCred3.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, (Item) null, alice.impersonate(), Collections.<DomainRequirement>emptyList()).get(0).getUsername());
         SecurityContextHolder.setContext(ctx);
     }
-
+    
     @Test
     public void testUpdateAndDeleteCredentials() throws IOException {
         FreeStyleProject project = r.createFreeStyleProject();
@@ -201,26 +201,26 @@ public class CredentialsProviderTest {
         DummyCredentials modCredential = new DummyCredentials(CredentialsScope.GLOBAL, "modCredential", "pwd");
 
         CredentialsStore store = CredentialsProvider.lookupStores(Jenkins.getInstance()).iterator().next();
-
+        
         // Add credentials
         store.addCredentials(Domain.global(), systemCred);
         store.addCredentials(Domain.global(), systemCred2);
         store.addCredentials(Domain.global(), globalCred);
-
+        
         assertEquals(3, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, Collections.<DomainRequirement>emptyList()).size());
         assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, project, ACL.SYSTEM, Collections.<DomainRequirement>emptyList()).size());
         assertEquals(globalCred.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, project, ACL.SYSTEM, Collections.<DomainRequirement>emptyList()).get(0).getUsername());
-
+    
         // Update credentials
         store.updateCredentials(Domain.global(), globalCred, modCredential);
-
+        
         assertEquals(3, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, Collections.<DomainRequirement>emptyList()).size());
         assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, project, ACL.SYSTEM, Collections.<DomainRequirement>emptyList()).size());
         assertEquals(modCredential.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, project, ACL.SYSTEM, Collections.<DomainRequirement>emptyList()).get(0).getUsername());
-
+        
         // Remove credentials
         store.removeCredentials(Domain.global(), systemCred2);
-
+        
         assertEquals(2, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, Collections.<DomainRequirement>emptyList()).size());
         assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, project, ACL.SYSTEM, Collections.<DomainRequirement>emptyList()).size());
     }


### PR DESCRIPTION
See [JENKINS-49235](https://issues.jenkins-ci.org/browse/JENKINS-49235). Subsumes #97.

This change removes fingerprints for nodes which do not currently exist in Jenkins. Notably, this makes credentials tracking for ephemeral, cloud-provisioned agents completely useless, so as requested in #97 I've created [JENKINS-51694](https://issues.jenkins-ci.org/browse/JENKINS-51694) as a tracking issue for adding that functionality back in and referenced it in a `TODO` comment in the code.

@reviewbybees 

CC @fraz3alpha