### PR TITLE
[JENKINS-52936] Fixes Add button overlap with down arrow

### DIFF
--- a/src/main/resources/lib/credentials/select.jelly
+++ b/src/main/resources/lib/credentials/select.jelly
@@ -83,7 +83,7 @@
       <j:set var="storeItems" value="${selectHelper.getStoreItems(context, includeUser)}"/>
       <j:choose>
         <j:when test="${selectHelper.hasCreatePermission(context, includeUser) and storeItems != null and !storeItems.isEmpty()}">
-          <button type="button" class="credentials-add-menu" menualign="${attrs.menuAlign}"
+          <button type="button" class="credentials-add-menu hetero-list-add" menualign="${attrs.menuAlign}"
                   suffix="${attrs.name}">
             <l:icon class="icon-credentials-new-credential icon-sm"/>
             ${%Add}


### PR DESCRIPTION

This PR fixes the misplaced down arrow on the credentials 'Add' button  [JENKINS-52936] .
The 'hetero-list-add' css class is basically added to the button  which provides the necessary 25px padding-right to push the arrow to the right.
![add-button-overlaps-arrow-fix jenkins](https://user-images.githubusercontent.com/7300877/43858594-70078c78-9b1c-11e8-91a7-d1c3f1acd031.png)

