### PR TITLE
Update UserCredentialsProvider.java

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/UserCredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/UserCredentialsProvider.java
@@ -448,11 +448,11 @@ public class UserCredentialsProvider extends CredentialsProvider {
          * @param p the permission to checl.
          */
         private void checkPermission(Permission p) {
-            if (user.equals(User.current())) {
+           // if (user.equals(User.current())) {
                 user.checkPermission(p);
-            } else {
-                throw new AccessDeniedException2(Jenkins.getAuthentication(), p);
-            }
+          //  } else {
+            //    throw new AccessDeniedException2(Jenkins.getAuthentication(), p);
+            //}
         }
 
         /**


### PR DESCRIPTION
User.current() will always return SYSTEM during running pipeline steps, this will cause checkpermission failing for pipeline step because the login user will not be SYSTEM