### PR TITLE
Avoid confusion between UUID and ID

### DIFF
--- a/src/main/resources/com/cloudbees/plugins/credentials/CredentialsParameterDefinition/help.html
+++ b/src/main/resources/com/cloudbees/plugins/credentials/CredentialsParameterDefinition/help.html
@@ -1,9 +1,9 @@
 <div>
     Defines a credentials parameter, which you can use during a build.
     <p style="font-weight: bold; padding: 5px; background: darkred; color: white; text-align: center">
-    <i>For security reasons</i>, the credential is <i>NOT</i> directly exposed, the UUID of the credential is exposed.
+    <i>For security reasons</i>, the credential is <i>NOT</i> directly exposed, the ID of the credential is exposed.
     </p>
     However, the selected credential is available through variable substitution in some other parts of the configuration.
-    The string value will be the UUID of the credential. A supporting plugin can thus use the UUID to retrieve
+    The string value will be the ID of the credential. A supporting plugin can thus use the ID to retrieve
     the selected credential and expose it to the build in an appropriate way.
 </div>


### PR DESCRIPTION
This information is used multiple times, automatically in the jenkins.io doc.

@daniel-beck 