### PR TITLE
Show credential ID in DomainWrapper view

### DIFF
--- a/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/DomainWrapper/index.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/DomainWrapper/index.jelly
@@ -39,6 +39,9 @@
             <st:nbsp/>
           </th>
           <th>
+            ${%ID}
+          </th>
+          <th>
             ${%Name}
           </th>
           <th>
@@ -78,7 +81,10 @@
                   </a>
                 </td>
                 <td>
-                  <a href="credential/${c.urlName}" class='model-link inside' tooltip="${safeDescription}">${c.displayName}</a>
+                  <a href="credential/${c.urlName}" class='model-link inside'>${c.id}</a>
+                </td>
+                <td>
+                  ${c.displayName}
                 </td>
                 <td>
                   ${c.typeName}


### PR DESCRIPTION
Currently the credential ID is shown in the global credentials screen (`/credentials`), but not in the domain-scoped credentials screen (`/credentials/store/system/domain/_/`), which makes it a little harder for users to work with domain-scoped credentials.

This PR adds the credential ID to the domain-scoped credentials screen, so that users no longer need to look at the path in their address bar to work out the credential ID they should paste into their Jenkinsfiles.