### PR TITLE
Fix Javadoc Error using @link byte[]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.43</version>
+    <version>3.47</version>
     <relativePath />
   </parent>
 

--- a/src/main/java/com/cloudbees/plugins/credentials/SecretBytes.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/SecretBytes.java
@@ -49,7 +49,7 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
- * An analogue of {@link Secret} to be used for efficient storage of {@link byte[]}. The serialized form will embed the
+ * An analogue of {@link Secret} to be used for efficient storage of {@code byte[]}. The serialized form will embed the
  * salt and padding so no two invocations of {@link #getEncryptedData()} will return the same result, but all will
  * decrypt to the same {@link #getPlainData()}. XStream serialization and Stapler form-binding will assume that
  * the {@link #toString()} representation is used (i.e. the Base64 encoded secret bytes wrapped with <code>{</code>
@@ -121,7 +121,7 @@ public class SecretBytes implements Serializable {
     }
 
     /**
-     * Returns the raw unencrypted data. The caller is responsible for zeroing out the returned {@link byte[]} after
+     * Returns the raw unencrypted data. The caller is responsible for zeroing out the returned {@code byte[]} after
      * use.
      *
      * @return the raw unencrypted data.
@@ -240,7 +240,7 @@ public class SecretBytes implements Serializable {
      * <p>
      * Useful for recovering a value from a form field.
      * If the supplied bytes are known to be unencrypted then the caller is responsible for zeroing out the supplied
-     * {@link byte[]} afterwards.
+     * {@code byte[]} afterwards.
      *
      * @param data the data to wrap or decrypt.
      * @return never null

--- a/src/main/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl.java
@@ -235,9 +235,9 @@ public class CertificateCredentialsImpl extends BaseStandardCredentials implemen
     public static abstract class KeyStoreSource extends AbstractDescribableImpl<KeyStoreSource> {
 
         /**
-         * Returns the {@link byte[]} content of the {@link KeyStore}.
+         * Returns the {@code byte[]} content of the {@link KeyStore}.
          *
-         * @return the {@link byte[]} content of the {@link KeyStore}.
+         * @return the {@code byte[]} content of the {@link KeyStore}.
          */
         @NonNull
         public abstract byte[] getKeyStoreBytes();
@@ -287,7 +287,7 @@ public class CertificateCredentialsImpl extends BaseStandardCredentials implemen
          * Helper method that performs form validation on a {@link KeyStore}.
          *
          * @param type          the type of keystore to instantiate, see {@link KeyStore#getInstance(String)}.
-         * @param keystoreBytes the {@link byte[]} content of the {@link KeyStore}.
+         * @param keystoreBytes the {@code byte[]} content of the {@link KeyStore}.
          * @param password      the password to use when loading the {@link KeyStore} and recovering the key from the
          *                      {@link KeyStore}.
          * @return the validation results.


### PR DESCRIPTION
Using `{@link byte[]}` on JDK11 crashes, cf. https://bugs.openjdk.java.net/browse/JDK-8200432

So we change this construct to move forward. (To unblock https://github.com/jenkinsci/credentials-plugin/pull/119)