### PR TITLE
[JENKINS-60465] - add stapler converter for KeyStoreSource

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/SecretBytes.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/SecretBytes.java
@@ -27,6 +27,7 @@ You under the Apache License, Version 2.0.
  */
 package com.cloudbees.plugins.credentials;
 
+import com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl.KeyStoreSource;
 import com.thoughtworks.xstream.converters.Converter;
 import com.thoughtworks.xstream.converters.MarshallingContext;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
@@ -363,6 +364,9 @@ public class SecretBytes implements Serializable {
                 return null;
             if (value instanceof String) {
                 return SecretBytes.fromString((String) value);
+            }
+            if (value instanceof KeyStoreSource) {
+                return SecretBytes.fromBytes(((KeyStoreSource) value).getKeyStoreBytes());
             }
             throw new IllegalClassException(SecretBytes.class, value.getClass());
         }

--- a/src/main/java/com/cloudbees/plugins/credentials/SecretBytes.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/SecretBytes.java
@@ -27,6 +27,7 @@ You under the Apache License, Version 2.0.
  */
 package com.cloudbees.plugins.credentials;
 
+import com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl;
 import com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl.KeyStoreSource;
 import com.thoughtworks.xstream.converters.Converter;
 import com.thoughtworks.xstream.converters.MarshallingContext;
@@ -367,6 +368,9 @@ public class SecretBytes implements Serializable {
             }
             if (value instanceof KeyStoreSource) {
                 return SecretBytes.fromBytes(((KeyStoreSource) value).getKeyStoreBytes());
+            }
+            if (value instanceof CertificateCredentialsImpl) {
+                return SecretBytes.fromBytes(((CertificateCredentialsImpl) value).getKeyStoreSource().getKeyStoreBytes());
             }
             throw new IllegalClassException(SecretBytes.class, value.getClass());
         }


### PR DESCRIPTION
fixes [JENKINS-60465](https://issues.jenkins-ci.org/browse/JENKINS-60465)

Like to add a test to show export works

```yaml
credentials:
  system:
    domainCredentials:
    - credentials:
      - usernamePassword:
          description: "testing user pass"
          id: "testing.user.pass"
          password: "{AQAAABAAAAAQBNSp+lQPLqE9vM9tzbbf7vFHAM5zDVtPYizetEpo0Fo=}"
          scope: GLOBAL
          username: "test"
      - certificate:
          description: "testing certificate"
          id: "test.certificate"
          keyStoreSource: "FAILED TO EXPORT com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl#keyStoreSource:\
            \ org.apache.commons.lang.IllegalClassException: Expected: com.cloudbees.plugins.credentials.SecretBytes,\
            \ actual: com.cloudbees.plugins.credentials.SecretBytes\r  at com.cloudbees.plugins.credentials.SecretBytes$StaplerConverterImpl.convert(SecretBytes.java:367)\r\
            \  at com.cloudbees.plugins.credentials.SecretBytes$StaplerConverterImpl.convert(SecretBytes.java:359)\r\
            \  at org.apache.commons.beanutils.ConvertUtilsBean.convert(ConvertUtilsBean.java:544)\r\
            \  at io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator.describe(DataBoundConfigurator.java:239)\r\
            \  at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.lambda$convertToNode$de0cd4f8$1(HeteroDescribableConfigurator.java:233)\r\
            \  at io.vavr.CheckedFunction0.lambda$unchecked$52349c75$1(CheckedFunction0.java:201)\r\
            \  at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.convertToNode(HeteroDescribableConfigurator.java:233)\r\
            \  at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.lambda$describe$5(HeteroDescribableConfigurator.java:103)\r\
            \  at io.vavr.control.Option.map(Option.java:373)\r  at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.describe(HeteroDescribableConfigurator.java:103)\r\
            \  at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.describe(HeteroDescribableConfigurator.java:51)\r\
            \  at io.jenkins.plugins.casc.Attribute.describe(Attribute.java:197)\r\
            \  at io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator.describe(DataBoundConfigurator.java:255)\r\
            \  at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.lambda$convertToNode$de0cd4f8$1(HeteroDescribableConfigurator.java:233)\r\
            \  at io.vavr.CheckedFunction0.lambda$unchecked$52349c75$1(CheckedFunction0.java:201)\r\
            \  at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.convertToNode(HeteroDescribableConfigurator.java:233)\r\
            \  at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.lambda$describe$5(HeteroDescribableConfigurator.java:103)\r\
            \  at io.vavr.control.Option.map(Option.java:373)\r  at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.describe(HeteroDescribableConfigurator.java:103)\r\
            \  at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.describe(HeteroDescribableConfigurator.java:51)\r\
            \  at io.jenkins.plugins.casc.Attribute.describe(Attribute.java:193)\r\
            \  at io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator.describe(DataBoundConfigurator.java:255)\r\
            \  at io.jenkins.plugins.casc.Attribute.describe(Attribute.java:193)\r\
            \  at com.cloudbees.plugins.credentials.casc.SystemCredentialsProviderConfigurator.describe(SystemCredentialsProviderConfigurator.java:76)\r\
            \  at com.cloudbees.plugins.credentials.casc.SystemCredentialsProviderConfigurator.describe(SystemCredentialsProviderConfigurator.java:48)\r\
            \  at io.jenkins.plugins.casc.Attribute.describe(Attribute.java:197)\r\
            \  at com.cloudbees.plugins.credentials.casc.CredentialsRootConfigurator.describe(CredentialsRootConfigurator.java:90)\r\
            \  at com.cloudbees.plugins.credentials.casc.CredentialsRootConfigurator.describe(CredentialsRootConfigurator.java:52)"
          password: "{AQAAABAAAAAQj/YRHipPxGeU136Y+vu6Rjh9OUWRKnCwFg6Gf+A2SUQ=}"
          scope: GLOBAL
```