### PR TITLE
Return object in converter if is SecretBytes

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/SecretBytes.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/SecretBytes.java
@@ -364,6 +364,9 @@ public class SecretBytes implements Serializable {
             if (value instanceof String) {
                 return SecretBytes.fromString((String) value);
             }
+            if (value instanceof SecretBytes) {
+                return (SecretBytes) value;
+            }
             throw new IllegalClassException(SecretBytes.class, value.getClass());
         }
     }


### PR DESCRIPTION
Partially fixes https://github.com/jenkinsci/configuration-as-code-plugin/issues/1170

The other part is a null check in JCasC

Before this change, if one credential was a FileCredentialsImpl then no credentials could be exported (see the linked issue above), after this change and a null check in JCasC I can export all credentials including FileCredentialsImpl