### PR TITLE
Demonstrate adding findsecbugs to spotbugs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,10 +204,23 @@
           </execution>
         </executions>
       </plugin>
+        <plugin>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-maven-plugin</artifactId>
+            <configuration>
+                <plugins>
+                    <plugin>
+                        <groupId>com.h3xstream.findsecbugs</groupId>
+                        <artifactId>findsecbugs-plugin</artifactId>
+                        <version>1.10.1</version>
+                    </plugin>
+                </plugins>
+            </configuration>
+        </plugin>
     </plugins>
   </build>
 
-  <profiles>
+    <profiles>
     <profile>
       <id>pdfs</id>
       <properties>

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsConfidentialKey.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsConfidentialKey.java
@@ -32,6 +32,7 @@ You under the Apache License, Version 2.0.
  */
 package com.cloudbees.plugins.credentials;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.util.Secret;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -147,6 +148,7 @@ public class CredentialsConfidentialKey extends ConfidentialKey {
 
     // copied from https://github.com/codehaus-plexus/plexus-cipher/blob/6ab0e38df80beed9ab3227ffab938b21dcdf5505/src
     // /main/java/org/sonatype/plexus/components/cipher/PBECipher.java
+    @SuppressFBWarnings(value = "STATIC_IV", justification = "The IV is securely generated for each encrypted message. For decrypted messages it is pulled off the salt.")
     private Cipher createCipher(final byte[] pwdAsBytes, byte[] salt, final int mode)
             throws GeneralSecurityException {
         MessageDigest _digester = MessageDigest.getInstance(DIGEST_ALG);

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
@@ -32,6 +32,7 @@ import com.cloudbees.plugins.credentials.fingerprints.NodeCredentialsFingerprint
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.BulkChange;
 import hudson.DescriptorExtensionList;
 import hudson.ExtensionList;
@@ -1376,6 +1377,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @since 2.1.1
      */
     @CheckForNull
+    @SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_MD5", justification = "Used for tracking, not security.")
     public static Fingerprint getFingerprintOf(@NonNull Credentials c) throws IOException {
         try {
             MessageDigest md5 = MessageDigest.getInstance("MD5");
@@ -1400,6 +1402,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @since 2.1.1
      */
     @NonNull
+    @SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_MD5", justification = "Used for tracking, not security.")
     public static Fingerprint getOrCreateFingerprintOf(@NonNull Credentials c) throws IOException {
         String pseudoFilename = String.format("Credential id=%s name=%s",
                 c instanceof IdCredentials ? ((IdCredentials) c).getId() : "unknown", CredentialsNameProvider.name(c));

--- a/src/main/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl.java
@@ -29,6 +29,7 @@ import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
@@ -362,6 +363,7 @@ public class CertificateCredentialsImpl extends BaseStandardCredentials implemen
          */
         @NonNull
         @Override
+        @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Deprecated mechanism. Maintained only for migrating existing data without user input.")
         public byte[] getKeyStoreBytes() {
             try {
                 InputStream inputStream = new FileInputStream(new File(keyStoreFile));
@@ -380,6 +382,7 @@ public class CertificateCredentialsImpl extends BaseStandardCredentials implemen
          * {@inheritDoc}
          */
         @Override
+        @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Deprecated mechanism. Maintained only for migrating existing data without user input.")
         public long getKeyStoreLastModified() {
             return new File(keyStoreFile).lastModified();
         }


### PR DESCRIPTION
Demonstrate adding findsecbugs to spotbugs. This commit is a demonstration and is not intended to be merged as-is.

With no changes, findsecbugs reports several findings for this plugin. The MD5 warning is common in Jenkins and exists in core. In this case, it is used for tracking and not for security so it can be suppressed though even here it would be better to eventually upgrade to a better algorithm.

The PATH_TRAVERSAL_IN findings here are particularly interesting. These relate to [CVE-2019-10320](https://jenkins.io/security/advisory/2019-05-21/) from Jenkins Security Advisory 2019-05-21. At this time, these findings are only used for migrating old data and do not represent real vulnerabilities. As we approach a year since the release of the fix, we should consider removing the migration code to remove the suppression. If we had run findsecbugs on this plugin prior to 2019-05-21 it would have detected a valid security vulnerability.

---

My plan is to add findsecbugs at the plugin pom after sufficient testing and communication. At that point, it would make sense to add the suppressions, but not the pom file changes from this PR.