### PR TITLE
Drop mention of disabled GitHub issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,7 @@
 
 ## Bug Reports
 
-![NO GITHUB ISSUES](https://i.imgflip.com/18d2ou.jpg)
-
 File bug reports here: [In the JENKINS jira project with component `credentials-plugin`](https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20JENKINS%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened%2C%20%22In%20Review%22)%20AND%20component%20%3D%20credentials-plugin)
-
-**DO NOT USE GITHUB ISSUES** Any GitHub Issues will be ignored and closed as soon as they are spotted.
 
 ## Development
 


### PR DESCRIPTION
The README strongly words that GitHub issues will be ignored and closed. However, GitHub issues are disabled on this repository, so creating them is impossible. This makes this description obsolete.

Removing the image will also drop the dependency on an external hoster and image, and remove a silly meme image increasing perceived professionality.

Removing the strongly worded ticket ignoring notice improves perceived welcome-ness, decreasing perceived rejection/opposition.