### PR TITLE
[JENKINS-61880] GlobalCredentialsConfiguration JCasC compatibility

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/GlobalCredentialsConfiguration.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/GlobalCredentialsConfiguration.java
@@ -42,6 +42,7 @@ import javax.servlet.ServletException;
 import jenkins.model.GlobalConfigurationCategory;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.HttpResponse;
@@ -221,6 +222,7 @@ public class GlobalCredentialsConfiguration extends ManagementLink
      * Security related configurations.
      */
     @Extension
+    @Symbol("globalCredentialsConfiguration")
     public static class Category extends GlobalConfigurationCategory {
         /**
          * {@inheritDoc}

--- a/src/test/java/com/cloudbees/plugins/credentials/casc/CredentialsCategoryTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/casc/CredentialsCategoryTest.java
@@ -1,0 +1,57 @@
+package com.cloudbees.plugins.credentials.casc;
+
+import com.cloudbees.plugins.credentials.GlobalCredentialsConfiguration;
+import hudson.Extension;
+import hudson.ExtensionList;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import jenkins.model.GlobalConfiguration;
+import jenkins.model.GlobalConfigurationCategory;
+import org.jenkinsci.Symbol;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.TestExtension;
+
+import javax.annotation.Nonnull;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class CredentialsCategoryTest {
+
+    @Rule
+    public JenkinsConfiguredWithCodeRule r = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    @ConfiguredWithCode("credentials-category.yaml")
+    public void globalCredentialsConfigurationCategory() {
+        assertThat(ExtensionList.lookupSingleton(TestGlobalConfiguration.class).getConfig(), equalTo("hello"));
+    }
+
+    @TestExtension
+    @Symbol("testGlobalConfiguration")
+    public static class TestGlobalConfiguration extends GlobalConfiguration {
+
+        private String config;
+
+        @Nonnull
+        @Override
+        public GlobalConfigurationCategory getCategory() {
+            return GlobalConfigurationCategory.get(GlobalCredentialsConfiguration.Category.class);
+        }
+
+        @Nonnull
+        @Override
+        public String getDisplayName() {
+            return "Test Global Configuration";
+        }
+
+        public String getConfig() {
+            return config;
+        }
+
+        public void setConfig(String config) {
+            this.config = config;
+        }
+    }
+}

--- a/src/test/java/com/cloudbees/plugins/credentials/casc/CredentialsCategoryTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/casc/CredentialsCategoryTest.java
@@ -3,6 +3,7 @@ package com.cloudbees.plugins.credentials.casc;
 import com.cloudbees.plugins.credentials.GlobalCredentialsConfiguration;
 import hudson.Extension;
 import hudson.ExtensionList;
+import io.jenkins.plugins.casc.ConfigurationAsCode;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import jenkins.model.GlobalConfiguration;
@@ -14,6 +15,9 @@ import org.jvnet.hudson.test.TestExtension;
 
 import javax.annotation.Nonnull;
 
+import java.io.ByteArrayOutputStream;
+
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -24,8 +28,13 @@ public class CredentialsCategoryTest {
 
     @Test
     @ConfiguredWithCode("credentials-category.yaml")
-    public void globalCredentialsConfigurationCategory() {
+    public void globalCredentialsConfigurationCategory() throws Exception {
         assertThat(ExtensionList.lookupSingleton(TestGlobalConfiguration.class).getConfig(), equalTo("hello"));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ConfigurationAsCode.get().export(out);
+        assertThat(out.toString(), containsString("globalCredentialsConfiguration:\n" +
+                "  testGlobalConfiguration:\n" +
+                "    config: \"hello\""));
     }
 
     @TestExtension

--- a/src/test/resources/com/cloudbees/plugins/credentials/casc/credentials-category.yaml
+++ b/src/test/resources/com/cloudbees/plugins/credentials/casc/credentials-category.yaml
@@ -1,0 +1,3 @@
+globalCredentialsConfiguration:
+  testGlobalConfiguration:
+    config: "hello"


### PR DESCRIPTION
See [JENKINS-61880](https://issues.jenkins-ci.org/browse/JENKINS-61880)

Add a `@Symbol` to the category so it's rendered properly in JCasC YAML.