### PR TITLE
Use standard jelly help tag

### DIFF
--- a/src/main/resources/lib/credentials/select.jelly
+++ b/src/main/resources/lib/credentials/select.jelly
@@ -24,7 +24,7 @@
  -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout"
-         xmlns:f="/lib/form">
+         xmlns:f="/lib/form" xmlns:t="/lib/hudson">
   <st:documentation>
     A <code>select</code> control that supports the data binding and AJAX updates with support for adding credentials.
     Your descriptor should have the 'doFillXyzItems' method, which returns a StandardListBoxModel
@@ -90,7 +90,7 @@
             <span class="warning user-credentials-caution" hidden="hidden">
               ${%userCredentialsCaution}
             </span>
-            <a href="#" class="help-btn"><l:icon class="icon-help icon-sm" alt="${%Help}"/></a>
+            <span class="help-btn"><t:help href="#" /></span>
             <div class="help-content" hidden="hidden">
               <p>${%includeUserCredentialsHelp}</p>
               <div class="from-plugin">

--- a/src/main/resources/lib/credentials/select/select.js
+++ b/src/main/resources/lib/credentials/select/select.js
@@ -266,7 +266,7 @@ Behaviour.specify("DIV.include-user-credentials", 'include-user-credentials', 0,
         caution.hidden = !this.checked;
     };
     // simpler version of f:helpLink using inline help text
-    e.querySelector('a.help-btn').onclick = function (evt) {
+    e.querySelector('span.help-btn').onclick = function (evt) {
         var help = e.querySelector('.help-content');
         help.hidden = !help.hidden;
     };


### PR DESCRIPTION
Preparing for change in core to the icon, ref: https://github.com/jenkinsci/jenkins/pull/4663

Testing:
* Create a pipeline, 
* Tick this build is parameterised
* Add a credential parameter
* Save
* Click build with parameters

You should see no change before or after this change

cc @jvz