### PR TITLE
Fix SecretBytesTest.isSecretBytes for 2.235.x PCT

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/SecretBytes.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/SecretBytes.java
@@ -300,7 +300,7 @@ public class SecretBytes implements Serializable {
             byte[] decoded;
             try {
                 decoded = Base64.decodeBase64(data.substring(1, len - 1));
-            } catch (StringIndexOutOfBoundsException e) {
+            } catch (StringIndexOutOfBoundsException | IllegalArgumentException e) {
                 // invalid Base64
                 return false;
             }


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/4636#issuecomment-640883683, detected in https://github.com/jenkinsci/bom/pull/240

Otherwise against 2.231+ you get

```
java.lang.IllegalArgumentException: Last encoded character (before the paddings if any) is a valid base 64 alphabet but not a possible value. Expected the discarded bits to be zero.
	at org.apache.commons.codec.binary.Base64.validateCharacter(Base64.java:803)
	at org.apache.commons.codec.binary.Base64.decode(Base64.java:477)
	at org.apache.commons.codec.binary.BaseNCodec.decode(BaseNCodec.java:482)
	at org.apache.commons.codec.binary.BaseNCodec.decode(BaseNCodec.java:465)
	at org.apache.commons.codec.binary.Base64.decodeBase64(Base64.java:699)
	at com.cloudbees.plugins.credentials.SecretBytes.isSecretBytes(SecretBytes.java:302)
	at com.cloudbees.plugins.credentials.SecretBytesTest.isSecretBytes(SecretBytesTest.java:84)
```

Theoretically it could break production uses, not just PCT.
