### PR TITLE
Replace esclave with agent in credentials plug-in (fr)

### DIFF
--- a/src/main/resources/com/cloudbees/plugins/credentials/Messages_fr.properties
+++ b/src/main/resources/com/cloudbees/plugins/credentials/Messages_fr.properties
@@ -22,8 +22,8 @@
 
 UserCredentialsProvider_DisplayName=Identifiants
 CredentialsScope.UserDisplayName=Utilisateur
-CredentialsScope.GlobalDisplayName=Global (Jenkins, esclaves, items, etc...)
-CredentialsScope.SystemDisplayName=Syst\u00e8me (Jenkins et esclaves seulement)
+CredentialsScope.GlobalDisplayName=Global (Jenkins, agents, items, etc...)
+CredentialsScope.SystemDisplayName=Syst\u00e8me (Jenkins et agents seulement)
 
 SystemCredentialsProvider.Description=Cr\u00e9er / supprimer / modifier les informations d''identifications qui peuvent \u00eatre utilis\u00e9s par Jenkins et par les jobs dans Jenkins pour se connecter \u00e0 des services tiers.
 SystemCredentialsProvider.DisplayName=G\u00e9rer les identifiants


### PR DESCRIPTION
The word `esclaves` appeared in the French documentation for the credentials plug-in. I changed it to `agents` (consistent with previous PR).