### PR TITLE
[JENKINS-65333] Sort credentials entries only for UI

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
@@ -438,7 +438,6 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                 }
             }
         }
-        result.sort(new CredentialsNameComparator());
         return result;
     }
 
@@ -575,8 +574,6 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                 }
             }
         }
-
-        result.sort(new CredentialsNameComparator());
         return result;
     }
 
@@ -1180,6 +1177,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
         return getCredentials(type, itemGroup, authentication, domainRequirements)
                 .stream()
                 .filter(matcher::matches)
+                .sorted(new CredentialsNameComparator())
                 .map(c -> new ListBoxModel.Option(CredentialsNameProvider.name(c), c.getId()))
                 .collect(Collectors.toCollection(ListBoxModel::new));
     }
@@ -1255,6 +1253,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
         return getCredentials(type, item, authentication, domainRequirements)
                 .stream()
                 .filter(matcher::matches)
+                .sorted(new CredentialsNameComparator())
                 .map(c -> new ListBoxModel.Option(CredentialsNameProvider.name(c), c.getId()))
                 .collect(Collectors.toCollection(ListBoxModel::new));
     }


### PR DESCRIPTION
This moves the sorting logic from `CredentialsProvider#lookupCredentials` to `CredentialsProvider#getCredentialIds`, so that it happens after applying matchers, and only when being pulled in a UI.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
