### PR TITLE
[JENKINS-62761] Certificate upload correction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
   </scm>
 
   <properties>
-    <revision>2.3.20</revision>
+    <revision>2.4</revision>
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.222.4</jenkins.version>
     <java.level>8</java.level>

--- a/src/main/resources/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl/UploadedKeyStoreSource/Upload/complete.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl/UploadedKeyStoreSource/Upload/complete.jelly
@@ -24,31 +24,13 @@
  ~ THE SOFTWARE.
  -->
 
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" >
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" >
   <l:layout>
     <l:main-panel>
-      <j:set var="instance" value="${it}"/>
-      <div style="display:none">
-        <f:form>
-          <f:entry>
-            <f:textbox id="content" field="uploadedKeystore" disabled="true"/>
-          </f:entry>
-        </f:form>
-      </div>
-      <script>
-        try {
-          var id = "${it.divId.replaceAll('[^id0-9]', '')}";
-          var newInput = document.getElementById('content');
-          var oldInput = window.opener.document.getElementById(id);
-          oldInput.value = newInput.value;
-          oldInput.onblur();
-          newInput = null;
-          oldInput = null;
-        } catch (e) {
-          // ignore
-        }
-        window.close();
-      </script>
+      View no longer required/supported due to the inlining of the file input.
+      If you came to this page due to another plugin, you will have to update that plugin to be compatible
+      with Credentials Plugin 2.4+
+      It will be deleted soon.
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl/UploadedKeyStoreSource/Upload/index.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl/UploadedKeyStoreSource/Upload/index.jelly
@@ -24,22 +24,13 @@
  ~ THE SOFTWARE.
  -->
 
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" >
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" >
   <l:layout norefresh="true">
     <l:main-panel>
-      <h1>${%Upload PKCS#12 certificate}</h1>
-      <f:form action="upload" method="post" name="upload">
-        <f:entry>
-          <input type="file" name="certificate.file" size="40"/>
-        </f:entry>
-        <f:block>
-          <f:submit value="${%Upload}"/>
-          <st:nbsp/>
-          <input type="button" value="${%Cancel}"
-                 onclick="window.close(); return false;"
-                 class="submit-button"/>
-        </f:block>
-      </f:form>
+      View no longer required/supported due to the inlining of the file input.
+      If you came to this page due to another plugin, you will have to update that plugin to be compatible
+      with Credentials Plugin 2.4+
+      It will be deleted soon.
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl/UploadedKeyStoreSource/config.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl/UploadedKeyStoreSource/config.jelly
@@ -24,23 +24,70 @@
  ~ THE SOFTWARE.
  -->
 
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
-  <j:set var="divId" value="${h.generateId()}"/>
-  <f:entry field="uploadedKeystore">
-    <f:textbox id="${divId}" style="display:none" checkMethod="post"/>
-  </f:entry>
-  <tr>
-    <td/>
-    <td>
-    </td>
-    <td align="right">
-      <input type="button" value="${%Upload certificate}..."
-             onclick="window.open('${rootURL}/descriptor/${descriptor.clazz.name}/upload/${divId}', 'upload-cert-${divId}','width=640,height=400').opener=window; return false;"
-             class="submit-button"/>
-    </td>
-  </tr>
-  <script> // workaround for JENKINS-19124
-      window.setTimeout(function(){
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <j:set var="divId" value="${h.generateId()}"/>
+    <j:set var="fileId" value="${h.generateId()}"/>
+    <f:entry field="uploadedKeystore">
+        <!-- 
+        We have to use a custom behavior as the ../password is not completely supported, 
+        the registerValidator being called before applyNameRef in hudson-behavior, we cannot rely on the built-in feature 
+        -->
+        
+        <!-- $$ => $ after jelly interpretation -->
+        <f:textbox id="${divId}" style="display:none" default="${descriptor.DEFAULT_VALUE}" checkMethod="post"
+                   checkUrl="'${rootURL}/descriptorByName/com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl$$UploadedKeyStoreSource/checkUploadedKeystore?'+fillValues_${divId}(this)"
+                   />
+    </f:entry>
+    <f:entry field="uploadedCertFile">
+        <input id="${fileId}" type="file" name="uploadedCertFile" class="setting-input" jsonAware="true" />
+    </f:entry>
+  <script><![CDATA[
+    var uploadedCertFile_${fileId} = '';
+    (function(){
+      // Adding a onChange method on the file input to retrieve the value of the file content in a variable
+      var uploadedCertFileInput = window.document.getElementById("${fileId}");
+      var _onchange = uploadedCertFileInput.onchange;
+      if(typeof _onchange === "function") {
+        uploadedCertFileInput.onchange = function() { fileOnChange(this); _onchange.call(this); }
+      } else {
+        uploadedCertFileInput.onchange = fileOnChange.bind(uploadedCertFileInput);
+      }
+      function fileOnChange() {
+        try { // inspired by https://stackoverflow.com/a/754398
+          var uploadedCertFileInputFile = uploadedCertFileInput.files[0];
+          var reader = new FileReader();
+          reader.onload = function (evt) {
+            uploadedCertFile_${fileId} = btoa(evt.target.result);
+            var uploadedKeystore = document.getElementById("${divId}");
+            uploadedKeystore.onchange(uploadedKeystore);
+          }
+          reader.onerror = function (evt) {
+            if (window.console !== null) {
+              console.warn("Error during loading uploadedCertFile content", evt);
+            }
+            uploadedCertFile_${fileId} = '';
+          }
+
+          reader.readAsBinaryString(uploadedCertFileInputFile);
+        }
+        catch(e){
+          if (window.console !== null) {
+            console.warn("Unable to retrieve uploadedCertFile content");
+          }
+        }
+      }
+    })();
+    
+    function fillValues_${divId}(el) {
+      var value = el.value;
+      var password = findNextFormItem(el, 'password').value;
+      var uploadedCertFile = uploadedCertFile_${fileId};
+      return "value="+encodeURIComponent(value)+"&password="+encodeURIComponent(password)+"&uploadedCertFile="+encodeURIComponent(uploadedCertFile);
+    }
+    
+    // workaround for JENKINS-19124
+    // without this script, the password changes will be not trigger the check on the uploadedKeystore
+    window.setTimeout(function(){
       var r = window.document.getElementById("${divId}");
       var p = findNextFormItem(r, 'password');
       if (p) {
@@ -51,10 +98,9 @@
         } else {
             p.onchange = function() { _field.onchange(_field); };
         }
-        _field.onchange(_field);
       }
       r = null;
       p = null;
     }, 500);
-  </script>
+  ]]></script>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl/UploadedKeyStoreSource/config.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl/UploadedKeyStoreSource/config.jelly
@@ -29,8 +29,9 @@
     <j:set var="fileId" value="${h.generateId()}"/>
     <f:entry field="uploadedKeystore">
         <!-- 
-        We have to use a custom behavior as the ../password is not completely supported, 
-        the registerValidator being called before applyNameRef in hudson-behavior, we cannot rely on the built-in feature 
+        TODO We have to use a custom behavior as the ../password is not completely supported, 
+        the registerValidator being called before applyNameRef in hudson-behavior, we cannot rely on the built-in feature
+        Could be simplified when https://issues.jenkins.io/browse/JENKINS-65616 is corrected. 
         -->
         
         <!-- $$ => $ after jelly interpretation -->

--- a/src/test/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImplTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImplTest.java
@@ -209,7 +209,7 @@ public class CertificateCredentialsImplTest {
     }
 
     @Test
-    @Issue("SECURITY-2349")
+    @Issue("JENKINS-64542")
     public void doCheckUploadedKeystore_uploadedFileValid() throws Exception {
         String content = getContentFrom_doCheckUploadedKeystore("", getValidP12_base64(), VALID_PASSWORD);
         assertThat(content, containsString("ok"));
@@ -217,6 +217,7 @@ public class CertificateCredentialsImplTest {
     }
 
     @Test
+    @Issue("JENKINS-64542")
     public void doCheckUploadedKeystore_uploadedFileValid_encryptedPassword() throws Exception {
         String content = getContentFrom_doCheckUploadedKeystore("", getValidP12_base64(), Secret.fromString(VALID_PASSWORD).getEncryptedValue());
         assertThat(content, containsString("ok"));
@@ -224,6 +225,7 @@ public class CertificateCredentialsImplTest {
     }
 
     @Test
+    @Issue("JENKINS-64542")
     public void doCheckUploadedKeystore_uploadedFileValid_butMissingPassword() throws Exception {
         String content = getContentFrom_doCheckUploadedKeystore("", getValidP12_base64(), "");
         assertThat(content, containsString("warning"));
@@ -231,6 +233,7 @@ public class CertificateCredentialsImplTest {
     }
 
     @Test
+    @Issue("JENKINS-64542")
     public void doCheckUploadedKeystore_uploadedFileValid_butInvalidPassword() throws Exception {
         String content = getContentFrom_doCheckUploadedKeystore("", getValidP12_base64(), INVALID_PASSWORD);
         assertThat(content, containsString("warning"));
@@ -238,6 +241,7 @@ public class CertificateCredentialsImplTest {
     }
 
     @Test
+    @Issue("JENKINS-64542")
     public void doCheckUploadedKeystore_uploadedFileInvalid() throws Exception {
         String content = getContentFrom_doCheckUploadedKeystore("", getInvalidP12_base64(), VALID_PASSWORD);
         assertThat(content, containsString("warning"));
@@ -245,6 +249,7 @@ public class CertificateCredentialsImplTest {
     }
 
     @Test
+    @Issue("JENKINS-64542")
     public void doCheckUploadedKeystore_keyStoreBlank() throws Exception {
         String content = getContentFrom_doCheckUploadedKeystore("", "", VALID_PASSWORD);
         assertThat(content, containsString("error"));
@@ -252,12 +257,14 @@ public class CertificateCredentialsImplTest {
     }
 
     @Test
+    @Issue("JENKINS-64542")
     public void doCheckUploadedKeystore_keyStoreDefault() throws Exception {
         String content = getContentFrom_doCheckUploadedKeystore(CertificateCredentialsImpl.UploadedKeyStoreSource.DescriptorImpl.DEFAULT_VALUE, "", VALID_PASSWORD);
         assertThat(content, not(allOf(containsString("warning"), containsString("error"))));
     }
 
     @Test
+    @Issue("JENKINS-64542")
     public void doCheckUploadedKeystore_keyStoreInvalidSecret() throws Exception {
         String content = getContentFrom_doCheckUploadedKeystore("", "", VALID_PASSWORD);
         assertThat(content, containsString("error"));
@@ -265,6 +272,7 @@ public class CertificateCredentialsImplTest {
     }
 
     @Test
+    @Issue("JENKINS-64542")
     public void doCheckUploadedKeystore_keyStoreValid() throws Exception {
         String content = getContentFrom_doCheckUploadedKeystore(getValidP12_secretBytes(), "", VALID_PASSWORD);
         assertThat(content, containsString("ok"));
@@ -272,6 +280,7 @@ public class CertificateCredentialsImplTest {
     }
 
     @Test
+    @Issue("JENKINS-64542")
     public void doCheckUploadedKeystore_keyStoreValid_encryptedPassword() throws Exception {
         String content = getContentFrom_doCheckUploadedKeystore(getValidP12_secretBytes(), "", Secret.fromString(VALID_PASSWORD).getEncryptedValue());
         assertThat(content, containsString("ok"));
@@ -279,6 +288,7 @@ public class CertificateCredentialsImplTest {
     }
 
     @Test
+    @Issue("JENKINS-64542")
     public void doCheckUploadedKeystore_keyStoreValid_butMissingPassword() throws Exception {
         String content = getContentFrom_doCheckUploadedKeystore(getValidP12_secretBytes(), "", "");
         assertThat(content, containsString("warning"));
@@ -286,6 +296,7 @@ public class CertificateCredentialsImplTest {
     }
 
     @Test
+    @Issue("JENKINS-64542")
     public void doCheckUploadedKeystore_keyStoreInvalid() throws Exception {
         String content = getContentFrom_doCheckUploadedKeystore(getInvalidP12_secretBytes(), "", VALID_PASSWORD);
         assertThat(content, containsString("warning"));
@@ -293,6 +304,7 @@ public class CertificateCredentialsImplTest {
     }
 
     @Test
+    @Issue("JENKINS-63761")
     public void fullSubmitOfUploadedKeystore() throws Exception {
         String certificateDisplayName = r.jenkins.getDescriptor(CertificateCredentialsImpl.class).getDisplayName();
         

--- a/src/test/resources/com/cloudbees/plugins/credentials/impl/invalid.p12
+++ b/src/test/resources/com/cloudbees/plugins/credentials/impl/invalid.p12
@@ -1,0 +1,2 @@
+0�
+blablabla


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [n/a] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->

Jira tickets: [JENKINS-63761](https://issues.jenkins.io/browse/JENKINS-63761) and [JENKINS-64542](https://issues.jenkins.io/browse/JENKINS-64542) (at least)

⁉️ There are multiple things corrected here. The main one is the bug introduced since 2.254 in https://github.com/jenkinsci/jenkins/pull/4910. Due to the COOP header, the new window approach to upload certificate is no longer working. The second problem was about the warning/error message when you are uploading the certificate.
The second part about the validation was filed as a bug in the tracker: [JENKINS-65616](https://issues.jenkins.io/browse/JENKINS-65616).

✔️ Both are resolved by putting the file input field "inline" inside the form instead of using a window. Then, by adding some magic from Jelly/hudson-behavior.js, we are able to trigger the validation at the correct moment.

Tested with:
- 2.253 (before the COOP header)
- 2.254 (just after the COOP header)
- 2.277.4 (current LTS)
- 2.292 (current weekly)

<details>

<summary>Gifs of the behavior</summary>

## 2.253 Create
![creds_2 253_new](https://user-images.githubusercontent.com/2662497/117939715-a38d7880-b308-11eb-9b4b-9bcc4556d294.gif)

----

## 2.253 Update
![creds_2 253_update](https://user-images.githubusercontent.com/2662497/117939717-a4260f00-b308-11eb-91a9-d01fab1de016.gif)

----

## 2.292 Create
![creds_2 292_new](https://user-images.githubusercontent.com/2662497/117939719-a4bea580-b308-11eb-8478-e2a208f8bfe6.gif)

----

## 2.292 Update
![creds_2 292_update](https://user-images.githubusercontent.com/2662497/117939720-a4bea580-b308-11eb-810c-63a25fb4c8b2.gif)

----

</details>