### PR TITLE
[JENKINS-66514] BaseStandardCredentials ID validation error

### DIFF
--- a/src/main/resources/com/cloudbees/plugins/credentials/impl/BaseStandardCredentials/id-and-description.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/impl/BaseStandardCredentials/id-and-description.jelly
@@ -31,7 +31,6 @@
     <f:textbox name="_.id"
                value="${instance != null ? instance.id : null}"
                readonly="${instance != null ? 'readonly' : null}"
-               checkUrl="${instance != null ? null : descriptor.getCheckUrl('id')}"
     />
   </f:entry>
   <f:entry title="${%Description}" field="description">


### PR DESCRIPTION
See details in [JENKINS-66514](https://issues.jenkins.io/browse/JENKINS-66514)

The fix is to remove the unnecessary explicit `checkUrl` so the legacy
validation method isn't used. The check URL will be calculated
automatically and the "new" (years old) mechanism kicks in.

The test is checking that the validation error shows up when needed (and
only when needed), so this change does not cause a regression.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
