### PR TITLE
[JENKINS-66639] adding explict jcasc symbol on CertificateCredentialImpl and UsernamePasswordCredentialsImpl classes

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl.java
@@ -62,6 +62,7 @@ import jenkins.model.Jenkins;
 import net.jcip.annotations.GuardedBy;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -198,6 +199,7 @@ public class CertificateCredentialsImpl extends BaseStandardCredentials implemen
      * Our descriptor.
      */
     @Extension(ordinal = -1)
+    @Symbol("certificate")
     public static class DescriptorImpl extends BaseStandardCredentialsDescriptor {
 
         /**

--- a/src/main/java/com/cloudbees/plugins/credentials/impl/UsernamePasswordCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/impl/UsernamePasswordCredentialsImpl.java
@@ -31,6 +31,8 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.Extension;
 import hudson.Util;
 import hudson.util.Secret;
+
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
@@ -114,6 +116,7 @@ public class UsernamePasswordCredentialsImpl extends BaseStandardCredentials imp
      * {@inheritDoc}
      */
     @Extension(ordinal = 1)
+    @Symbol("usernamePassword")
     public static class DescriptorImpl extends BaseStandardCredentialsDescriptor {
 
         /**

--- a/src/test/java/com/cloudbees/plugins/credentials/casc/CredentialsCategoryTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/casc/CredentialsCategoryTest.java
@@ -104,8 +104,7 @@ public class CredentialsCategoryTest {
                                                "credential-certificate",
                                                "Credential with certificate",
                                                "password",
-                                               new CertificateCredentialsImpl.UploadedKeyStoreSource(Base64.encode(
-                                                       "Testing not real certificate".getBytes())));
+                                               new CertificateCredentialsImpl.UploadedKeyStoreSource(Base64.getEncoder().encode("Testing not real certificate".getBytes())));
 
         SystemCredentialsProvider.getInstance().getCredentials().add(usernamePasswordCredentials);
         ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/src/test/java/com/cloudbees/plugins/credentials/casc/CredentialsCategoryTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/casc/CredentialsCategoryTest.java
@@ -1,13 +1,26 @@
 package com.cloudbees.plugins.credentials.casc;
 
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.GlobalCredentialsConfiguration;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+
 import hudson.Extension;
 import hudson.ExtensionList;
 import io.jenkins.plugins.casc.ConfigurationAsCode;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import jcifs.util.Base64;
+
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.GlobalConfigurationCategory;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.jenkinsci.Symbol;
 import org.junit.Rule;
 import org.junit.Test;
@@ -20,6 +33,8 @@ import java.io.ByteArrayOutputStream;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class CredentialsCategoryTest {
 
@@ -62,5 +77,42 @@ public class CredentialsCategoryTest {
         public void setConfig(String config) {
             this.config = config;
         }
+    }
+
+    @Test
+    public void exportUsernamePasswordCredentialsImplConfiguration() throws Exception {
+        UsernamePasswordCredentialsImpl usernamePasswordCredentials =
+                new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL,
+                                                    "username-pass",
+                                                    "Username / Password credential for testing",
+                                                    "my-user",
+                                                    "wonderfulPassword");
+
+        SystemCredentialsProvider.getInstance().getCredentials().add(usernamePasswordCredentials);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ConfigurationAsCode.get().export(out);
+
+        // UsernamePasswordCredentialsImpl should be jcasc exported as usernamePassword
+        assertThat(out.toString(), Matchers.containsString("usernamePassword:"));
+        assertThat(out.toString(), not(Matchers.containsString("usernamePasswordCredentialsImpl:")));
+    }
+
+    @Test
+    public void exportCertificateCredentialsImplConfiguration() throws Exception {
+        CertificateCredentialsImpl usernamePasswordCredentials =
+                new CertificateCredentialsImpl(CredentialsScope.GLOBAL,
+                                               "credential-certificate",
+                                               "Credential with certificate",
+                                               "password",
+                                               new CertificateCredentialsImpl.UploadedKeyStoreSource(Base64.encode(
+                                                       "Testing not real certificate".getBytes())));
+
+        SystemCredentialsProvider.getInstance().getCredentials().add(usernamePasswordCredentials);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ConfigurationAsCode.get().export(out);
+
+        // CertificateCredentialsImpl should be jcasc exported as certificate
+        assertThat(out.toString(), Matchers.containsString("certificate:"));
+        assertThat(out.toString(), not(Matchers.containsString("certificateCredentialsImpl:")));
     }
 }

--- a/src/test/java/com/cloudbees/plugins/credentials/casc/CredentialsCategoryTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/casc/CredentialsCategoryTest.java
@@ -4,6 +4,7 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.GlobalCredentialsConfiguration;
+import com.cloudbees.plugins.credentials.SecretBytes;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl;
@@ -14,7 +15,6 @@ import hudson.ExtensionList;
 import io.jenkins.plugins.casc.ConfigurationAsCode;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
-import jcifs.util.Base64;
 
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.GlobalConfigurationCategory;
@@ -99,14 +99,14 @@ public class CredentialsCategoryTest {
 
     @Test
     public void exportCertificateCredentialsImplConfiguration() throws Exception {
-        CertificateCredentialsImpl usernamePasswordCredentials =
+        CertificateCredentialsImpl certificateCredentials =
                 new CertificateCredentialsImpl(CredentialsScope.GLOBAL,
                                                "credential-certificate",
                                                "Credential with certificate",
                                                "password",
-                                               new CertificateCredentialsImpl.UploadedKeyStoreSource(Base64.getEncoder().encode("Testing not real certificate".getBytes())));
+                                               new CertificateCredentialsImpl.UploadedKeyStoreSource(SecretBytes.fromBytes("Testing not real certificate".getBytes())));
 
-        SystemCredentialsProvider.getInstance().getCredentials().add(usernamePasswordCredentials);
+        SystemCredentialsProvider.getInstance().getCredentials().add(certificateCredentials);
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         ConfigurationAsCode.get().export(out);
 

--- a/src/test/java/com/cloudbees/plugins/credentials/casc/SystemCredentialsTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/casc/SystemCredentialsTest.java
@@ -26,27 +26,40 @@
 package com.cloudbees.plugins.credentials.casc;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.domains.HostnameRequirement;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+
 import hudson.security.ACL;
 import hudson.util.Secret;
+
+import io.jenkins.plugins.casc.ConfigurationAsCode;
 import io.jenkins.plugins.casc.ConfigurationContext;
 import io.jenkins.plugins.casc.ConfiguratorRegistry;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import io.jenkins.plugins.casc.model.Mapping;
 import io.jenkins.plugins.casc.model.Sequence;
+
+import java.io.ByteArrayOutputStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import jenkins.model.Jenkins;
+
+import org.hamcrest.MatcherAssert;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 

--- a/src/test/java/com/cloudbees/plugins/credentials/casc/SystemCredentialsTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/casc/SystemCredentialsTest.java
@@ -26,40 +26,27 @@
 package com.cloudbees.plugins.credentials.casc;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
-import com.cloudbees.plugins.credentials.CredentialsScope;
-import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
-import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.domains.HostnameRequirement;
-import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
-
 import hudson.security.ACL;
 import hudson.util.Secret;
-
-import io.jenkins.plugins.casc.ConfigurationAsCode;
 import io.jenkins.plugins.casc.ConfigurationContext;
 import io.jenkins.plugins.casc.ConfiguratorRegistry;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import io.jenkins.plugins.casc.model.Mapping;
 import io.jenkins.plugins.casc.model.Sequence;
-
-import java.io.ByteArrayOutputStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import jenkins.model.Jenkins;
-
-import org.hamcrest.MatcherAssert;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-66639

For this specific feature, I have run test before and after adding the Symbol: both run are fine.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
