### PR TITLE
Add config as code support for credentials configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
   <properties>
     <revision>2.6.2</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.222.4</jenkins.version>
+    <jenkins.version>2.249.1</jenkins.version>
     <java.level>8</java.level>
     <antlr4.version>4.9.2</antlr4.version>
   </properties>
@@ -89,8 +89,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.222.x</artifactId>
-        <version>887.vae9c8ac09ff7</version>
+        <artifactId>bom-2.249.x</artifactId>
+        <version>950.v396cb834de1e</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProviderFilter.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProviderFilter.java
@@ -31,6 +31,7 @@ import hudson.ExtensionPoint;
 import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -159,7 +160,7 @@ public abstract class CredentialsProviderFilter extends AbstractDescribableImpl<
     }
 
     /**
-     * A filter that implements a allowlist policy, "if you are not on the list you can't come in".
+     * A filter that implements an allow-list policy, "if you are not on the list you can't come in".
      *
      * @since 2.0
      */
@@ -199,11 +200,7 @@ public abstract class CredentialsProviderFilter extends AbstractDescribableImpl<
          */
         @NonNull
         public List<String> getClassNames() {
-            return ExtensionList.lookup(CredentialsDescriptor.class)
-                    .stream()
-                    .map(type -> type.getClass().getName())
-                    .filter(classNames::contains)
-                    .collect(Collectors.toList());
+            return new ArrayList<>(classNames);
         }
 
         /**
@@ -311,11 +308,7 @@ public abstract class CredentialsProviderFilter extends AbstractDescribableImpl<
          */
         @NonNull
         public List<String> getClassNames() {
-            return ExtensionList.lookup(CredentialsProvider.class)
-                    .stream()
-                    .map(provider -> provider.getClass().getName())
-                    .filter(classNames::contains)
-                    .collect(Collectors.toList());
+            return new ArrayList<>(classNames);
         }
 
         /**

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProviderManager.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProviderManager.java
@@ -50,8 +50,6 @@ import jenkins.model.GlobalConfigurationCategory;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.StaplerRequest;
 
 /**
@@ -349,7 +347,6 @@ public class CredentialsProviderManager extends DescriptorVisibilityFilter imple
          * @return the {@link CredentialsProviderFilter}.
          */
         @SuppressWarnings("unused") // jelly EL helper
-        @Restricted(NoExternalUse.class)
         public CredentialsProviderFilter getProviderFilter() {
             CredentialsProviderManager manager = getInstance();
             return manager == null ? new CredentialsProviderFilter.None() : manager.getProviderFilter();
@@ -362,7 +359,6 @@ public class CredentialsProviderManager extends DescriptorVisibilityFilter imple
          * @param providerFilter the {@link CredentialsProviderFilter}.
          */
         @SuppressWarnings("unused") // jelly form binding
-        @Restricted(NoExternalUse.class)
         public void setProviderFilter(CredentialsProviderFilter providerFilter) {
             CredentialsProviderManager manager = getInstance();
             if (manager != null) {
@@ -376,7 +372,6 @@ public class CredentialsProviderManager extends DescriptorVisibilityFilter imple
          * @return the {@link CredentialsTypeFilter}.
          */
         @SuppressWarnings("unused") // jelly EL helper
-        @Restricted(NoExternalUse.class)
         public CredentialsTypeFilter getTypeFilter() {
             CredentialsProviderManager manager = getInstance();
             return manager == null ? new CredentialsTypeFilter.None() : manager.getTypeFilter();
@@ -389,7 +384,6 @@ public class CredentialsProviderManager extends DescriptorVisibilityFilter imple
          * @param typeFilter the {@link CredentialsTypeFilter}.
          */
         @SuppressWarnings("unused") // jelly form binding
-        @Restricted(NoExternalUse.class)
         public void setTypeFilter(CredentialsTypeFilter typeFilter) {
             CredentialsProviderManager manager = getInstance();
             if (manager != null) {
@@ -403,7 +397,6 @@ public class CredentialsProviderManager extends DescriptorVisibilityFilter imple
          * @return the {@link CredentialsProviderTypeRestriction} instances.
          */
         @SuppressWarnings("unused") // jelly EL helper
-        @Restricted(NoExternalUse.class)
         public List<CredentialsProviderTypeRestriction> getRestrictions() {
             CredentialsProviderManager manager = getInstance();
             return manager == null
@@ -418,7 +411,6 @@ public class CredentialsProviderManager extends DescriptorVisibilityFilter imple
          * @param restrictions the {@link CredentialsProviderTypeRestriction} instances.
          */
         @SuppressWarnings("unused") // jelly form binding
-        @Restricted(NoExternalUse.class)
         public void setRestrictions(List<CredentialsProviderTypeRestriction> restrictions) {
             CredentialsProviderManager manager = getInstance();
             if (manager != null) {

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsTypeFilter.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsTypeFilter.java
@@ -35,7 +35,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -199,11 +198,7 @@ public abstract class CredentialsTypeFilter extends AbstractDescribableImpl<Cred
          */
         @NonNull
         public List<String> getClassNames() {
-            return ExtensionList.lookup(CredentialsDescriptor.class)
-                    .stream()
-                    .map(type -> type.getClass().getName())
-                    .filter(classNames::contains)
-                    .collect(Collectors.toList());
+            return new ArrayList<>(classNames);
         }
 
         /**
@@ -311,11 +306,7 @@ public abstract class CredentialsTypeFilter extends AbstractDescribableImpl<Cred
          */
         @NonNull
         public List<String> getClassNames() {
-            return ExtensionList.lookup(CredentialsDescriptor.class)
-                    .stream()
-                    .map(type -> type.getClass().getName())
-                    .filter(classNames::contains)
-                    .collect(Collectors.toList());
+            return new ArrayList<>(classNames);
         }
 
         /**

--- a/src/test/java/com/cloudbees/plugins/credentials/casc/ConfigurationAsCodeCategoryRoot.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/casc/ConfigurationAsCodeCategoryRoot.java
@@ -1,0 +1,18 @@
+package com.cloudbees.plugins.credentials.casc;
+
+import com.cloudbees.plugins.credentials.GlobalCredentialsConfiguration;
+import hudson.ExtensionList;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.impl.configurators.GlobalConfigurationCategoryConfigurator;
+import io.jenkins.plugins.casc.model.Mapping;
+
+import java.util.Objects;
+
+public class ConfigurationAsCodeCategoryRoot {
+
+    public static Mapping getConfiguration(ConfigurationContext context) throws Exception {
+        GlobalCredentialsConfiguration.Category category = ExtensionList.lookupSingleton(GlobalCredentialsConfiguration.Category.class);
+        GlobalConfigurationCategoryConfigurator configurator = new GlobalConfigurationCategoryConfigurator(category);
+        return Objects.requireNonNull(configurator.describe(configurator.getTargetComponent(context), context)).asMapping();
+    }
+}

--- a/src/test/java/com/cloudbees/plugins/credentials/casc/CredentialsProviderManagerTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/casc/CredentialsProviderManagerTest.java
@@ -1,0 +1,70 @@
+package com.cloudbees.plugins.credentials.casc;
+
+import com.cloudbees.plugins.credentials.CredentialsProviderFilter;
+import com.cloudbees.plugins.credentials.CredentialsProviderManager;
+import com.cloudbees.plugins.credentials.CredentialsProviderTypeRestriction;
+import com.cloudbees.plugins.credentials.CredentialsTypeFilter;
+import com.cloudbees.plugins.credentials.GlobalCredentialsConfiguration;
+import hudson.ExtensionList;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorRegistry;
+import io.jenkins.plugins.casc.impl.configurators.GlobalConfigurationCategoryConfigurator;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Mapping;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.Objects;
+
+import static io.jenkins.plugins.casc.misc.Util.toStringFromYamlFile;
+import static io.jenkins.plugins.casc.misc.Util.toYamlString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class CredentialsProviderManagerTest {
+
+    @ClassRule
+    @ConfiguredWithCode("credentialsProviderManager.yaml")
+    public static JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    public void importConfig() {
+        CredentialsProviderManager manager = CredentialsProviderManager.getInstance();
+
+        assertThat(manager, notNullValue());
+        assertThat(manager.getProviderFilter(), instanceOf(CredentialsProviderFilter.Excludes.class));
+        CredentialsProviderFilter.Excludes excludesFilter = (CredentialsProviderFilter.Excludes) manager.getProviderFilter();
+        assertThat(excludesFilter.getClassNames(), contains("com.cloudbees.plugins.credentials.UserCredentialsProvider"));
+
+        assertThat(manager.getRestrictions(), hasSize(1));
+        CredentialsProviderTypeRestriction restriction = manager.getRestrictions().get(0);
+        assertThat(restriction, instanceOf(CredentialsProviderTypeRestriction.Includes.class));
+        CredentialsProviderTypeRestriction.Includes restrictionIncludes = (CredentialsProviderTypeRestriction.Includes) restriction;
+        assertThat(restrictionIncludes.getProvider(), equalTo("com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider"));
+        assertThat(restrictionIncludes.getType(), equalTo("com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl$DescriptorImpl"));
+
+        assertThat(manager.getTypeFilter(), instanceOf(CredentialsTypeFilter.Excludes.class));
+        CredentialsTypeFilter.Excludes excludesTypeFilter = (CredentialsTypeFilter.Excludes) manager.getTypeFilter();
+        assertThat(excludesTypeFilter.getClassNames(), contains("com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl$DescriptorImpl"));
+    }
+
+    @Test
+    public void exportConfig() throws Exception {
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        ConfigurationContext context = new ConfigurationContext(registry);
+        CNode yourAttribute = ConfigurationAsCodeCategoryRoot.getConfiguration(context).get("configuration");
+
+        String exported = toYamlString(yourAttribute);
+
+        String expected = toStringFromYamlFile(this, "credentialsProviderManagerExport.yaml");
+
+        assertThat(exported, is(expected));
+    }
+}

--- a/src/test/java/com/cloudbees/plugins/credentials/casc/CredentialsProviderTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/casc/CredentialsProviderTest.java
@@ -6,7 +6,6 @@ import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.HostnameRequirement;
 import com.cloudbees.plugins.credentials.impl.DummyCredentials;
-import com.google.common.collect.Lists;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.ExtensionList;

--- a/src/test/resources/com/cloudbees/plugins/credentials/casc/credentials-category-export.yaml
+++ b/src/test/resources/com/cloudbees/plugins/credentials/casc/credentials-category-export.yaml
@@ -1,0 +1,1 @@
+config: "hello"

--- a/src/test/resources/com/cloudbees/plugins/credentials/casc/credentials-category.yaml
+++ b/src/test/resources/com/cloudbees/plugins/credentials/casc/credentials-category.yaml
@@ -1,3 +1,3 @@
 globalCredentialsConfiguration:
-  testGlobalConfiguration:
+  test:
     config: "hello"

--- a/src/test/resources/com/cloudbees/plugins/credentials/casc/credentialsProviderManager.yaml
+++ b/src/test/resources/com/cloudbees/plugins/credentials/casc/credentialsProviderManager.yaml
@@ -1,0 +1,14 @@
+globalCredentialsConfiguration:
+  configuration:
+    providerFilter:
+      excludes:
+        classNames:
+          - "com.cloudbees.plugins.credentials.UserCredentialsProvider"
+    restrictions:
+      - includes:
+          provider: "com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider"
+          type: "com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl$DescriptorImpl"
+    typeFilter:
+      excludes:
+        classNames:
+          - "com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl$DescriptorImpl"

--- a/src/test/resources/com/cloudbees/plugins/credentials/casc/credentialsProviderManagerExport.yaml
+++ b/src/test/resources/com/cloudbees/plugins/credentials/casc/credentialsProviderManagerExport.yaml
@@ -1,0 +1,12 @@
+providerFilter:
+  excludes:
+    classNames:
+    - "com.cloudbees.plugins.credentials.UserCredentialsProvider"
+restrictions:
+- includes:
+    provider: "com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider"
+    type: "com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl$DescriptorImpl"
+typeFilter:
+  excludes:
+    classNames:
+    - "com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl$DescriptorImpl"


### PR DESCRIPTION
Pending incremental from jcasc for the `export` test to pass
Importing works fine with this PR alone

some minor jcasc testing cleanup done as well