### PR TITLE
Refer to icons using classes instead of filenames

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
   <properties>
     <revision>2.6.3</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.289.1</jenkins.version>
+    <jenkins.version>2.303.1</jenkins.version>
     <java.level>8</java.level>
     <antlr4.version>4.9.2</antlr4.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
   <properties>
     <revision>2.6.3</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.308</jenkins.version>
+    <jenkins.version>2.289.1</jenkins.version>
     <java.level>8</java.level>
     <antlr4.version>4.9.2</antlr4.version>
   </properties>

--- a/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/CredentialsWrapper/sidepanel.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/CredentialsWrapper/sidepanel.jelly
@@ -27,9 +27,9 @@
   <l:side-panel>
     <l:tasks>
     <j:set var="url" value="${h.getNearestAncestorUrl(request,it)}"/>
-      <l:task icon="images/svgs/up.svg" href="../.." title="${%backto(it.domain.displayName)}" contextMenu="false"/>
-      <l:task icon="images/svgs/setting.svg" href="${url}/update" title="${%Update}" permission="${it.domain.parent.UPDATE}"/>
-      <l:task icon="images/svgs/edit-delete.svg" href="${url}/delete" title="${%Delete}" permission="${it.domain.parent.DELETE}"/>
+      <l:task icon="icon-up icon-md" href="../.." title="${%backto(it.domain.displayName)}" contextMenu="false"/>
+      <l:task icon="icon-setting icon-md" href="${url}/update" title="${%Update}" permission="${it.domain.parent.UPDATE}"/>
+      <l:task icon="icon-edit-delete icon-md" href="${url}/delete" title="${%Delete}" permission="${it.domain.parent.DELETE}"/>
       <l:task icon="plugin/credentials/images/move.svg" href="${url}/move" title="${%Move}" permission="${it.domain.parent.DELETE}"/>
     </l:tasks>
   </l:side-panel>

--- a/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/DomainWrapper/index.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/DomainWrapper/index.jelly
@@ -95,8 +95,8 @@
                 <td>
                   <j:if test="${h.hasPermission(c, it.parent.UPDATE)}">
                     <a href="credential/${c.urlName}/update">
-                      <img src="${resURL}/images/svgs/setting.svg" alt="${%Update}"
-                           tooltip="${%Update}" class="icon${iconSize}"/>
+                      <l:icon alt="${%Update}"
+                           tooltip="${%Update}" class="icon-setting ${icons.toNormalizedIconSizeClass(iconSize)}"/>
                     </a>
                   </j:if>
                 </td>

--- a/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/DomainWrapper/sidepanel.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/DomainWrapper/sidepanel.jelly
@@ -27,11 +27,11 @@
   <l:side-panel>
     <l:tasks>
     <j:set var="url" value="${h.getNearestAncestorUrl(request,it)}"/>
-    <l:task icon="images/svgs/up.svg" href="../.." title="${%Back to credential domains}" contextMenu="false"/>
+    <l:task icon="icon-up icon-md" href="../.." title="${%Back to credential domains}" contextMenu="false"/>
       <l:task icon="plugin/credentials/images/new-credential.svg" href="newCredentials" title="${%Add Credentials}" permission="${it.parent.CREATE}" />
       <j:if test="${!it.global and it.parent.domainsModifiable}">
-      <l:task icon="images/svgs/setting.svg" href="${url}/configure" title="${%Configure}" permission="${it.parent.MANAGE_DOMAINS}"/>
-      <l:task icon="images/svgs/edit-delete.svg" href="${url}/delete" title="${%Delete domain}" permission="${it.parent.MANAGE_DOMAINS}"/>
+      <l:task icon="icon-setting icon-md" href="${url}/configure" title="${%Configure}" permission="${it.parent.MANAGE_DOMAINS}"/>
+      <l:task icon="icon-edit-delete icon-md" href="${url}/delete" title="${%Delete domain}" permission="${it.parent.MANAGE_DOMAINS}"/>
       </j:if>
     </l:tasks>
   </l:side-panel>

--- a/src/main/webapp/images/credential.svg
+++ b/src/main/webapp/images/credential.svg
@@ -12,7 +12,6 @@
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    inkscape:export-ydpi="90"
    inkscape:export-xdpi="90"
-   inkscape:export-filename="/Users/stephenc/src/plugins/cloudbees-registration-plugin/src/main/webapp/images/48x48/credentials.png"
    sodipodi:docname="credentials.svg"
    inkscape:version="0.48.2 r9819"
    sodipodi:version="0.32"

--- a/src/main/webapp/images/credentials.svg
+++ b/src/main/webapp/images/credentials.svg
@@ -12,7 +12,6 @@
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    inkscape:export-ydpi="90"
    inkscape:export-xdpi="90"
-   inkscape:export-filename="/Users/stephenc/src/plugins/cloudbees-registration-plugin/src/main/webapp/images/48x48/credentials.png"
    sodipodi:docname="credentials.svg"
    inkscape:version="0.48.1 r9760"
    sodipodi:version="0.32"

--- a/src/main/webapp/images/folder-store.svg
+++ b/src/main/webapp/images/folder-store.svg
@@ -12,7 +12,6 @@
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    inkscape:export-ydpi="90"
    inkscape:export-xdpi="90"
-   inkscape:export-filename="/Users/stephenc/src/plugins/cloudbees-registration-plugin/src/main/webapp/images/48x48/credentials.png"
    sodipodi:docname="folder-store.svg"
    inkscape:version="0.48.5 r10040"
    sodipodi:version="0.32"
@@ -1126,7 +1125,6 @@
         <g
            inkscape:export-ydpi="74.800003"
            inkscape:export-xdpi="74.800003"
-           inkscape:export-filename="/home/jimmac/ximian_art/icons/nautilus/suse93/gnome-fs-directory.png"
            transform="matrix(1.040764,0,0.05449252,1.040764,-8.670199,2.670594)"
            id="g220"
            style="fill:#ffffff;fill-opacity:0.75706213000000000;fill-rule:nonzero;stroke:none">
@@ -1140,7 +1138,6 @@
         <path
            inkscape:export-ydpi="74.800003"
            inkscape:export-xdpi="74.800003"
-           inkscape:export-filename="/home/jimmac/ximian_art/icons/nautilus/suse93/gnome-fs-directory.png"
            sodipodi:nodetypes="cscccscc"
            id="path233"
            d="m 39.783532,39.51062 c 1.143894,-0.04406 1.963076,-1.096299 2.047035,-2.321005 0.791787,-11.548687 1.65936,-21.231949 1.65936,-21.231949 0.07215,-0.247484 -0.167911,-0.494967 -0.48014,-0.494967 l -34.3711566,0 c 0,0 -1.8503191,21.866892 -1.8503191,21.866892 -0.1145551,0.982066 -0.4660075,1.804718 -1.5498358,2.183713 l 34.5450565,-0.0027 z"

--- a/src/main/webapp/images/move.svg
+++ b/src/main/webapp/images/move.svg
@@ -18,7 +18,6 @@
    width="48px"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.1"
-   inkscape:export-filename="/Users/stephenc/src/plugins/nectar-folder-plugin/src/main/webapp/images/48x48/move.png"
    inkscape:export-xdpi="90"
    inkscape:export-ydpi="90">
   <defs

--- a/src/main/webapp/images/new-credential.svg
+++ b/src/main/webapp/images/new-credential.svg
@@ -12,7 +12,6 @@
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    inkscape:export-ydpi="90"
    inkscape:export-xdpi="90"
-   inkscape:export-filename="/Users/stephenc/src/plugins/cloudbees-registration-plugin/src/main/webapp/images/48x48/credentials.png"
    sodipodi:docname="credential.svg"
    inkscape:version="0.48.2 r9819"
    sodipodi:version="0.32"
@@ -1195,7 +1194,6 @@
        sodipodi:ry="14.375"
        d="m 69.375,125 a 14.375,14.375 0 1 1 -28.75,0 14.375,14.375 0 1 1 28.75,0 z"
        transform="matrix(0.611127,0,0,0.611127,3.1927799,-65.014763)"
-       inkscape:export-filename="/home/jimmac/ximian_art/icons/nautilus/suse93/stock_new-16.png"
        inkscape:export-xdpi="33.852203"
        inkscape:export-ydpi="33.852203" />
   </g>

--- a/src/main/webapp/images/new-domain.svg
+++ b/src/main/webapp/images/new-domain.svg
@@ -917,7 +917,6 @@
     <path
        inkscape:export-ydpi="33.852203"
        inkscape:export-xdpi="33.852203"
-       inkscape:export-filename="/home/jimmac/ximian_art/icons/nautilus/suse93/stock_new-16.png"
        transform="matrix(0.611127,0,0,0.611127,4.4201313,937.16829)"
        d="m 69.375,125 a 14.375,14.375 0 1 1 -28.75,0 14.375,14.375 0 1 1 28.75,0 z"
        sodipodi:ry="14.375"

--- a/src/main/webapp/images/system-store.svg
+++ b/src/main/webapp/images/system-store.svg
@@ -12,7 +12,6 @@
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    inkscape:export-ydpi="90"
    inkscape:export-xdpi="90"
-   inkscape:export-filename="/Users/stephenc/src/plugins/cloudbees-registration-plugin/src/main/webapp/images/48x48/credentials.png"
    sodipodi:docname="system-store.svg"
    inkscape:version="0.48.5 r10040"
    sodipodi:version="0.32"

--- a/src/main/webapp/images/user-store.svg
+++ b/src/main/webapp/images/user-store.svg
@@ -12,7 +12,6 @@
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    inkscape:export-ydpi="90"
    inkscape:export-xdpi="90"
-   inkscape:export-filename="/Users/stephenc/src/plugins/cloudbees-registration-plugin/src/main/webapp/images/48x48/credentials.png"
    sodipodi:docname="user-store.svg"
    inkscape:version="0.48.5 r10040"
    sodipodi:version="0.32"


### PR DESCRIPTION
SVG icons from core (added in https://github.com/jenkinsci/credentials-plugin/pull/230 ) can be referenced by class instead of depending on file location in core. That should be more future-proof and seems to be the preferred way.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [n/a] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [n/a] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
