### PR TITLE
[JENKINS-67132] Fix NPE in isUsernameSecret

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/impl/UsernamePasswordCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/impl/UsernamePasswordCredentialsImpl.java
@@ -104,7 +104,7 @@ public class UsernamePasswordCredentialsImpl extends BaseStandardCredentials imp
 
     @Override
     public boolean isUsernameSecret() {
-        return usernameSecret;
+        return usernameSecret == null ? false : usernameSecret;
     }
 
     @DataBoundSetter


### PR DESCRIPTION
[JENKINS-67132](https://issues.jenkins.io/browse/JENKINS-67132) reports a  null pointer exception reading the nullable field isUsernameSecret.  Check the field for null before returning it as a boolean type.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Did not provide a test.  If one is required, will work on that later