### PR TITLE
Introduce `Credentials.forRun` to contextualize secrets

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/Credentials.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/Credentials.java
@@ -27,6 +27,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ExtensionPoint;
 import hudson.model.Describable;
+import hudson.model.Run;
 import java.io.Serializable;
 
 /**
@@ -54,4 +55,16 @@ public interface Credentials extends Describable<Credentials>, Serializable, Ext
     @NonNull
     @SuppressWarnings("unchecked")
     CredentialsDescriptor getDescriptor();
+
+    /**
+     * Optionally produce a special value when used in the context of a particular build.
+     * @param context a build wishing to consume these credentials
+     * @return contextualized credentials, preferably implementing the same interfaces (if not of the same concrete type); by default, {@code this}
+     * @see CredentialsProvider#findCredentialById(java.lang.String, java.lang.Class, hudson.model.Run, com.cloudbees.plugins.credentials.domains.DomainRequirement...)
+     */
+    @NonNull
+    default Credentials forRun(@NonNull Run<?, ?> context) {
+        return this;
+    }
+
 }

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
@@ -955,15 +955,18 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
             }
         }
         C result = CredentialsMatchers.firstOrNull(candidates, CredentialsMatchers.withId(id));
+        // if the run has not completed yet then we can safely assume that the credential is being used for this run
+        // so we will track it's usage. We use isLogUpdated() as it could be used during post production
+        if (run.isLogUpdated()) {
+            track(run, result);
+        }
         if (result != null) {
             Credentials contextualized = result.forRun(run);
             if (type.isInstance(contextualized)) {
-                result = type.cast(contextualized);
+                return type.cast(contextualized);
             }
         }
-        // if the run has not completed yet then we can safely assume that the credential is being used for this run
-        // so we will track it's usage. We use isLogUpdated() as it could be used during post production
-        return run.isLogUpdated() ? track(run, result) : result;
+        return result;
     }
 
     /**

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
@@ -964,6 +964,8 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
             Credentials contextualized = result.forRun(run);
             if (type.isInstance(contextualized)) {
                 return type.cast(contextualized);
+            } else {
+                LOGGER.warning(() -> "Ignoring " + contextualized.getClass().getName() + " return value of " + result.getClass().getName() + ".forRun since it is not assignable to " + type.getName());
             }
         }
         return result;

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
@@ -955,6 +955,10 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
             }
         }
         C result = CredentialsMatchers.firstOrNull(candidates, CredentialsMatchers.withId(id));
+        Credentials contextualized = result.forRun(run);
+        if (type.isInstance(contextualized)) {
+            result = type.cast(contextualized);
+        }
         // if the run has not completed yet then we can safely assume that the credential is being used for this run
         // so we will track it's usage. We use isLogUpdated() as it could be used during post production
         return run.isLogUpdated() ? track(run, result) : result;

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
@@ -955,9 +955,11 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
             }
         }
         C result = CredentialsMatchers.firstOrNull(candidates, CredentialsMatchers.withId(id));
-        Credentials contextualized = result.forRun(run);
-        if (type.isInstance(contextualized)) {
-            result = type.cast(contextualized);
+        if (result != null) {
+            Credentials contextualized = result.forRun(run);
+            if (type.isInstance(contextualized)) {
+                result = type.cast(contextualized);
+            }
         }
         // if the run has not completed yet then we can safely assume that the credential is being used for this run
         // so we will track it's usage. We use isLogUpdated() as it could be used during post production


### PR DESCRIPTION
https://github.com/jenkinsci/github-branch-source-plugin/pull/527 is a demonstrated use case, and https://github.com/jenkinsci/conjur-credentials-plugin/issues/21 a proposed one.

This new SPI requires use of the `CredentialsProvider.findCredentialById` method, which passes a (mandatory) `Run` argument and is the normal way to look up a particular credential during a build. (`credentials-binding` has long used it—https://github.com/jenkinsci/credentials-binding-plugin/pull/169 is the integration test—and the revised version of https://github.com/jenkinsci/git-plugin/pull/1242 is able to use it consistently as well.) There are other lookup methods which take an `Item` (~ `Job`) or even `ItemGroup` (~ `Jenkins` / `Folder` / `MultiBranchProject` / `OrganizationFolder`) context, which would suffice for https://github.com/jenkinsci/github-branch-source-plugin/pull/527 (which would usually be inspecting a `MultiBranchProject` though I left in support for standalone `Job` projects using the `github` plugin’s project property as well). If and when such an SPI becomes desirable, it should be possible to compatibly introduce `Credentials.forItem` (defaulting to `this`, rewrite the default of `forRun` to delegate to `forItem(run.getParent())`) or even `forItemGroup` (similar delegation chain).