### PR TITLE
Fix button size of "+ Add"

### DIFF
--- a/src/main/resources/lib/credentials/select.jelly
+++ b/src/main/resources/lib/credentials/select.jelly
@@ -116,9 +116,9 @@
       <j:set var="storeItems" value="${selectHelper.getStoreItems(context, includeUser)}"/>
       <j:choose>
         <j:when test="${selectHelper.hasCreatePermission(context, includeUser) and storeItems != null and !storeItems.isEmpty()}">
-          <button type="button" class="credentials-add-menu hetero-list-add" menualign="${attrs.menuAlign}"
+          <button class="credentials-add-menu hetero-list-add jenkins-button jenkins-button--transparent" menualign="${attrs.menuAlign}"
                   suffix="${attrs.name}">
-            <l:icon class="symbol-add"/>
+            <l:icon src="symbol-add"/>
             ${%Add}
           </button>
           <div class="credentials-add-menu-items yuimenu">
@@ -149,8 +149,8 @@
           </div>
         </j:when>
         <j:otherwise>
-          <button class="credentials-add" type="button" disabled="disabled">
-            <l:icon class="symbol-add"/>
+          <button class="credentials-add jenkins-button jenkins-button--transparent">
+            <l:icon src="symbol-add"/>
             ${%Add}
           </button>
         </j:otherwise>


### PR DESCRIPTION
See [JENKINS-68163](https://issues.jenkins.io/browse/JENKINS-68163)

The button is now sized properly:
![](https://i.imgur.com/YoFai77.png)

This occurs in a parameterized build with credentials input. Other occasions are unaffected.