### PR TITLE
Use Eclipse Temurin for GitHub Action

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -47,7 +47,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set up JDK 8
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         distribution: 'adopt'
         java-version: 8

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -49,7 +49,7 @@ jobs:
     - name: Set up JDK 8
       uses: actions/setup-java@v3
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: 8
     - name: Release
       uses: jenkins-infra/jenkins-maven-cd-action@v1.2.0

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,5 +1,3 @@
-# Note: additional setup is required, see https://www.jenkins.io/redirect/continuous-delivery-of-plugins
-
 name: cd
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Use Eclipse Temurin in the action, not AdoptOpenJDK

See https://github.com/jenkinsci/jenkins/pull/6406 for more details

The 'adopt' distribution has moved to Eclipse Temurin and won't be updated at the AdoptOpenJDK location.  Switch to the Temurin distribution so that we use a current version of Java.

- Bump actions/setup-java from 2 to 3 (dependabot proposed in #300)
- Use Eclipse Temurin in the action, not AdoptOpenJDK
- Remove unnecessary comment from action

## Checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~
