### PR TITLE
Prevent type error from loading non element

### DIFF
--- a/src/main/resources/lib/credentials/select/select.js
+++ b/src/main/resources/lib/credentials/select/select.js
@@ -231,7 +231,7 @@ Behaviour.specify("DIV.credentials-select-control", 'credentials-select', 100, f
                         this.addClassName('credentials-select-content-active');
                         this.removeClassName('credentials-select-content-inactive');
                         this.removeAttribute('field-disabled');
-                    } else {
+                    } else if (this instanceof HTMLElement) {
                         this.addClassName('credentials-select-content-inactive');
                         this.removeClassName('credentials-select-content-active');
                         this.setAttribute('field-disabled', 'true');


### PR DESCRIPTION
I haven't managed to track down why this happens but I get a type error when loading configure job screens (at least freestyle).

The changed function gets called 3 times for me and the third one is not a dom element, it's an array containing two functions.

this is a work around but shouldn't cause any harm

(this isn't the error from https://github.com/jenkinsci/bom/pull/1133 but it's the first error I saw loading the page)