### PR TITLE
[JENKINS-68616] Enable field validation checks

### DIFF
--- a/src/main/resources/lib/credentials/select.jelly
+++ b/src/main/resources/lib/credentials/select.jelly
@@ -107,8 +107,6 @@
           <input type="hidden" name="includeUser" value="${includeUser}"/>
         </j:otherwise>
       </j:choose>
-      <!-- Placing this in a div will block the field validation. The attrs.checkMethod is not called -->
-      <!-- https://issues.jenkins.io/browse/JENKINS-68616 -->
       <f:select clazz="${attrs.clazz} credentials-select" field="${attrs.field}"
                 default="${paramDefault?'':attrs.default}" value="${paramValue?(paramDefault?'':attrs.default):value}"
                 checkMethod="${attrs.checkMethod}"/>
@@ -116,7 +114,7 @@
       <j:set var="storeItems" value="${selectHelper.getStoreItems(context, includeUser)}"/>
       <j:choose>
         <j:when test="${selectHelper.hasCreatePermission(context, includeUser) and storeItems != null and !storeItems.isEmpty()}">
-          <button class="credentials-add-menu hetero-list-add jenkins-button jenkins-button--transparent" menualign="${attrs.menuAlign}"
+          <button class="credentials-add-menu hetero-list-add jenkins-button jenkins-button--transparent jenkins-!-margin-top-2" menualign="${attrs.menuAlign}"
                   suffix="${attrs.name}">
             <l:icon src="symbol-add"/>
             ${%Add}
@@ -149,7 +147,7 @@
           </div>
         </j:when>
         <j:otherwise>
-          <button class="credentials-add jenkins-button jenkins-button--transparent">
+          <button class="credentials-add jenkins-button jenkins-button--transparent jenkins-!-margin-top-2">
             <l:icon src="symbol-add"/>
             ${%Add}
           </button>

--- a/src/main/resources/lib/credentials/select.jelly
+++ b/src/main/resources/lib/credentials/select.jelly
@@ -107,11 +107,11 @@
           <input type="hidden" name="includeUser" value="${includeUser}"/>
         </j:otherwise>
       </j:choose>
-      <div class="form-group jenkins-form-item jenkins-form-item--tight">
-        <f:select clazz="${attrs.clazz} credentials-select" field="${attrs.field}"
-                  default="${paramDefault?'':attrs.default}" value="${paramValue?(paramDefault?'':attrs.default):value}"
-                  checkMethod="${attrs.checkMethod}"/>
-      </div>
+      <!-- Placing this in a div will block the field validation. The attrs.checkMethod is not called -->
+      <!-- https://issues.jenkins.io/browse/JENKINS-68616 -->
+      <f:select clazz="${attrs.clazz} credentials-select" field="${attrs.field}"
+                default="${paramDefault?'':attrs.default}" value="${paramValue?(paramDefault?'':attrs.default):value}"
+                checkMethod="${attrs.checkMethod}"/>
       <!-- TODO  add support for checking permissions against stores in request path -->
       <j:set var="storeItems" value="${selectHelper.getStoreItems(context, includeUser)}"/>
       <j:choose>


### PR DESCRIPTION
## [[JENKINS-68616](https://issues.jenkins.io/browse/JENKINS-68616)] Enable field validation checks

Regression in [1105 release](https://github.com/jenkinsci/credentials-plugin/releases/tag/1105.vb_4e24a_c78b_81).  The `div` that was added to surround the `select` seems to prevent calls to the `attrs.checkMethod`.

When using a GitHub branch source, an empty credentials field no longer displays the warning that a credential is recommended.  Other uses of credentials seem to have the same behavior.  Validation checks are no longer called.

When the `div` is included in the page, the credential validation callback is not invoked. When the `div` is removed from the page, the credential validation callback is invoked.

It is unclear to me why the addition of a `div` would change the validation behavior.

Review the differences with [white space changes](https://github.com/jenkinsci/credentials-plugin/pull/316/files?w=1) suppressed so that it is clear the difference is only in the deletion of the `div` tags that wrapped the `select`.

Not sure how to create a viable test that confirms the fix is behaving correctly.

Revert one HTML `div` from "Minor improvements"

This reverts part of commit 6dee9b8602f4ba355209f46ddd642d6daca3b448.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
