### PR TITLE
Add snapshot taker for special `StandardUsernamePasswordCredentials` impls

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/impl/UsernamePasswordCredentialsSnapshotTaker.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/impl/UsernamePasswordCredentialsSnapshotTaker.java
@@ -25,6 +25,8 @@ public class UsernamePasswordCredentialsSnapshotTaker extends CredentialsSnapsho
         if (credentials instanceof UsernamePasswordCredentialsImpl) {
             return credentials;
         }
-        return new UsernamePasswordCredentialsImpl(credentials.getScope(), credentials.getId(), credentials.getDescription(), credentials.getUsername(), Secret.toString(credentials.getPassword()));
+        UsernamePasswordCredentialsImpl snapshot = new UsernamePasswordCredentialsImpl(credentials.getScope(), credentials.getId(), credentials.getDescription(), credentials.getUsername(), Secret.toString(credentials.getPassword()));
+        snapshot.setUsernameSecret(credentials.isUsernameSecret());
+        return snapshot;
     }
 }

--- a/src/main/java/com/cloudbees/plugins/credentials/impl/UsernamePasswordCredentialsSnapshotTaker.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/impl/UsernamePasswordCredentialsSnapshotTaker.java
@@ -1,0 +1,27 @@
+package com.cloudbees.plugins.credentials.impl;
+
+import com.cloudbees.plugins.credentials.CredentialsSnapshotTaker;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+
+import hudson.Extension;
+import hudson.util.Secret;
+
+@Extension
+public class UsernamePasswordCredentialsSnapshotTaker extends CredentialsSnapshotTaker<StandardUsernamePasswordCredentials> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Class<StandardUsernamePasswordCredentials> type() {
+        return StandardUsernamePasswordCredentials.class;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public StandardUsernamePasswordCredentials snapshot(StandardUsernamePasswordCredentials credentials) {
+        return new UsernamePasswordCredentialsImpl(credentials.getScope(), credentials.getId(), credentials.getDescription(), credentials.getUsername(), Secret.toString(credentials.getPassword()));
+    }
+}

--- a/src/main/java/com/cloudbees/plugins/credentials/impl/UsernamePasswordCredentialsSnapshotTaker.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/impl/UsernamePasswordCredentialsSnapshotTaker.java
@@ -22,6 +22,9 @@ public class UsernamePasswordCredentialsSnapshotTaker extends CredentialsSnapsho
      */
     @Override
     public StandardUsernamePasswordCredentials snapshot(StandardUsernamePasswordCredentials credentials) {
+        if (credentials instanceof UsernamePasswordCredentialsImpl) {
+            return credentials;
+        }
         return new UsernamePasswordCredentialsImpl(credentials.getScope(), credentials.getId(), credentials.getDescription(), credentials.getUsername(), Secret.toString(credentials.getPassword()));
     }
 }


### PR DESCRIPTION
This adds a snapshot taker for StandardUsernamePasswordCredentials.  This is needed to fix an issue in hashicorp-vault plugin which currently prevents ssh keys being sent to agents which is being developed in https://github.com/jenkinsci/hashicorp-vault-plugin/pull/218

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue


