### PR TITLE
Remove folder-store from array

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/PluginImpl.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/PluginImpl.java
@@ -51,7 +51,6 @@ public class PluginImpl extends Plugin {
                 "userpass",
                 "system-store",
                 "user-store",
-                "folder-store",
         }) {
             IconSet.icons.addIcon(new Icon(
                     String.format("icon-credentials-%s icon-sm", name),


### PR DESCRIPTION
Post cleanup to https://github.com/jenkinsci/credentials-plugin/pull/321.
The icon lives on in the folders plugin and shouldn't be registered under the credentials namespace any longer.