### PR TITLE
Bump plugin from 4.40 to 4.46 and accompanying changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.40</version>
+    <version>4.46</version>
     <relativePath />
   </parent>
 

--- a/src/main/resources/com/cloudbees/plugins/credentials/CredentialsSelectHelper/WrappedCredentialsStore/credential_it.properties
+++ b/src/main/resources/com/cloudbees/plugins/credentials/CredentialsSelectHelper/WrappedCredentialsStore/credential_it.properties
@@ -1,6 +1,6 @@
 # The MIT License
 #
-# Copyright © 2020 Alessandro Menti
+# Copyright (c) 2020 Alessandro Menti
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/com/cloudbees/plugins/credentials/common/Messages_it.properties
+++ b/src/main/resources/com/cloudbees/plugins/credentials/common/Messages_it.properties
@@ -1,6 +1,6 @@
 # The MIT License
 #
-# Copyright © 2020 Alessandro Menti
+# Copyright (c) 2020 Alessandro Menti
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The same as #355 but also fix test failures.
It is important to update to 4.46 to remove test flakiness in:
com.cloudbees.plugins.credentials.CredentialsParameterDefinitionTest.onlyIncludeUserCredentialsWhenChecked
