### PR TITLE
Remove deprecated `java.level` property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,6 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <jenkins.version>2.340</jenkins.version>
-    <java.level>8</java.level>
     <antlr4.version>4.9.3</antlr4.version>
   </properties>
 


### PR DESCRIPTION
The `java.level` property was deprecated in [plugin parent POM 4.40](https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.40) and should be removed from this plugin's POM. In the future this warning will be changed to an error and will break the build. See https://github.com/jenkinsci/plugin-pom/pull/522 for details.