### PR TITLE
Move app-bar to main panel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.340</jenkins.version>
+    <jenkins.version>2.367-rc32834.83151ee78b_12</jenkins.version> <!-- TODO https://github.com/jenkinsci/jenkins/pull/7051 -->
     <java.level>8</java.level>
     <antlr4.version>4.9.3</antlr4.version>
   </properties>
@@ -89,8 +89,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.332.x</artifactId>
-        <version>1246.va_b_50630c1d19</version>
+        <artifactId>bom-2.263.x</artifactId>
+        <version>1607.va_c1576527071</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/DomainWrapper/index.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/DomainWrapper/index.jelly
@@ -27,8 +27,8 @@
          xmlns:f="/lib/form" xmlns:c="/lib/credentials"  xmlns:t="/lib/hudson">
   <l:layout title="${it.fullDisplayName}" norefresh="true" permission="${it.parent.VIEW}">
     <st:include page="sidepanel.jelly"/>
-    <l:app-bar title="${it.displayName}" />
     <l:main-panel>
+      <l:app-bar title="${it.displayName}" />
       <div>
         <j:out value="${it.description!=null ? app.markupFormatter.translate(it.description) : ''}" />
       </div>

--- a/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/index.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/index.jelly
@@ -36,8 +36,8 @@
     <j:otherwise>
       <l:layout title="${it.fullDisplayName}" norefresh="true" permission="${it.VIEW}">
         <st:include it="${it.store.context}" page="sidepanel.jelly"/>
-        <l:app-bar title="${it.displayName}" />
         <l:main-panel>
+          <l:app-bar title="${it.displayName}" />
           <t:setIconSize/>
           <table class="jenkins-table ${iconSize == '16x16' ? 'jenkins-table--small' : iconSize == '24x24' ? 'jenkins-table--medium' : ''} sortable">
             <thead>

--- a/src/main/resources/com/cloudbees/plugins/credentials/ViewCredentialsAction/index.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/ViewCredentialsAction/index.jelly
@@ -27,8 +27,8 @@
          xmlns:t="/lib/hudson">
   <l:layout title="${it.fullDisplayName}" norefresh="true" permission="${it.VIEW}">
     <st:include it="${it.context}" page="sidepanel.jelly"/>
-    <l:app-bar title="${%Credentials}" />
     <l:main-panel>
+      <l:app-bar title="${%Credentials}" />
       <style>
         .masked-credential {
           filter: grayscale(100%); /* Real browsers */


### PR DESCRIPTION
Requires https://github.com/jenkinsci/jenkins/pull/7051

App-bar is getting a new feature to allow it to be in the sidepanel, it's now required to place it in the section you want it displayed.

_Note: no compatible way of doing this currently, it needs to be released when core is released, given there's only 3 plugins using it this should be fine_