### PR TITLE
Remove useless broken "Add" button on credentials-select-control.

### DIFF
--- a/src/main/resources/lib/credentials/select/select.js
+++ b/src/main/resources/lib/credentials/select/select.js
@@ -214,10 +214,7 @@ Behaviour.specify("BUTTON.credentials-add-menu", 'credentials-select', -99, func
     }
     e=null;
 });
-Behaviour.specify("BUTTON.credentials-add", 'credentials-select', 0, function (e) {
-    makeButton(e, e.disabled ? null : window.credentials.add);
-    e = null; // avoid memory leak
-});
+
 Behaviour.specify("DIV.credentials-select-control", 'credentials-select', 100, function (d) {
     d = $(d);
     var buttons = d.getElementsBySelector("INPUT.credentials-select-radio-control");


### PR DESCRIPTION
I don't know if there is a way to get a 'data-url' into the template to actually fix this button.

See this change that broke it: https://github.com/jenkinsci/credentials-plugin/commit/9c5bb72106824ea826ba0d5e4d63fe5d2a11aa91#diff-45693b8474f3341b5d603b463cd4c10f4ec301a1c8c1c89b67034ba81056dfc9R44

<!-- Please describe your pull request here. -->

- [x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x ] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
- [? ] Link to relevant issues in GitHub or Jira (there is no issues tab on github, and where is this Jira?)
- [x ] Link to relevant pull requests, esp. upstream and downstream changes
- [? ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
