### PR TITLE
[JENKINS-68791] Missing icon for global credential store

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/SystemCredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/SystemCredentialsProvider.java
@@ -629,7 +629,7 @@ public class SystemCredentialsProvider extends AbstractDescribableImpl<SystemCre
         @Override
         public String getIconFileName() {
             return isVisible()
-                    ? "/jenkins/plugin/credentials/images/system-store.svg"
+                    ? "/plugin/credentials/images/system-store.svg"
                     : null;
         }
 
@@ -639,7 +639,7 @@ public class SystemCredentialsProvider extends AbstractDescribableImpl<SystemCre
         @Override
         public String getIconClassName() {
             return isVisible()
-                    ? "symbol-jenkins"
+                    ? "icon-credentials-system-store icon-sm"
                     : null;
         }
 

--- a/src/main/java/com/cloudbees/plugins/credentials/SystemCredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/SystemCredentialsProvider.java
@@ -629,7 +629,7 @@ public class SystemCredentialsProvider extends AbstractDescribableImpl<SystemCre
         @Override
         public String getIconFileName() {
             return isVisible()
-                    ? "symbol-jenkins"
+                    ? "/jenkins/plugin/credentials/images/system-store.svg"
                     : null;
         }
 


### PR DESCRIPTION
See [JENKINS-68791](https://issues.jenkins.io/browse/JENKINS-68791).
### Before
<img width="381" alt="image" src="https://user-images.githubusercontent.com/92412722/195055671-61c60790-ec71-42e3-9833-a532cd3c227a.png">

### After
<img width="376" alt="image" src="https://user-images.githubusercontent.com/92412722/195055889-884bc6da-1642-4e21-8c32-58819ea78ff4.png">


<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
