### PR TITLE
Revive ability to snapshot() the CertificateCredentials so they can be used on remote agents

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,24 @@
       <artifactId>workflow-basic-steps</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>job-dsl</artifactId>
+        <version>1.81</version>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>command-launcher</artifactId>
+        <version>1.6</version>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>script-security</artifactId>
+        <version>1218.v39ca_7f7ed0a_c</version>
+        <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -173,12 +173,6 @@
         <version>1.6</version>
         <scope>test</scope>
     </dependency>
-    <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>script-security</artifactId>
-        <version>1218.v39ca_7f7ed0a_c</version>
-        <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,13 @@
         <version>523.vd859a_4b_122e6</version>
         <scope>test</scope>
     </dependency>
+    <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>http_request</artifactId>
+        <!-- Note: testCertHttpRequestOnNodeRemote() fails for 1.16 -->
+        <version>1.16</version>
+        <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,12 @@
         <version>1.6</version>
         <scope>test</scope>
     </dependency>
+    <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>credentials-binding</artifactId>
+        <version>523.vd859a_4b_122e6</version>
+        <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsInPipelineTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsInPipelineTest.java
@@ -425,7 +425,7 @@ public class CredentialsInPipelineTest {
                 "        aliasVariable: 'myKeyAlias')\n" +
                 "]) {\n" +
                 "    echo \"Keystore bytes (len): \" + (new File(keystoreName)).length()\n" +
-                "    echo \"Got expected password? ${keyPassword == password}\"\n" +
+                "    echo \"Got expected key pass? ${keyPassword == password}\"\n" +
                 "    def keystoreFormat = \"PKCS12\"\n" +
                 "    def keyValue = getKeyValue(keystoreName, keystoreFormat, keyPassword, (env?.myKeyAlias ? env?.myKeyAlias : alias))\n" +
                 "    println \"-----BEGIN PRIVATE KEY-----\"\n" +

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsInPipelineTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsInPipelineTest.java
@@ -1,0 +1,392 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2022 Jim Klimov.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cloudbees.plugins.credentials;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+import com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider;
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsNameProvider;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.SecretBytes;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.common.CertificateCredentials;
+import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl;
+import com.cloudbees.plugins.credentials.impl.CertificateCredentialsImplTest;
+import com.gargoylesoftware.htmlunit.FormEncodingType;
+import com.gargoylesoftware.htmlunit.HttpMethod;
+import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.WebRequest;
+import com.gargoylesoftware.htmlunit.html.DomNode;
+import com.gargoylesoftware.htmlunit.html.DomNodeList;
+import com.gargoylesoftware.htmlunit.html.HtmlElementUtil;
+import com.gargoylesoftware.htmlunit.html.HtmlFileInput;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlOption;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.html.HtmlRadioButtonInput;
+import hudson.FilePath;
+import hudson.Util;
+import hudson.cli.CLICommandInvoker;
+import hudson.cli.UpdateJobCommand;
+import hudson.model.Descriptor;
+import hudson.model.ItemGroup;
+import hudson.model.Job;
+import hudson.model.Node;
+import hudson.model.Result;
+import hudson.model.Slave;
+import hudson.security.ACL;
+import hudson.slaves.CommandLauncher;
+import hudson.slaves.ComputerLauncher;
+import hudson.slaves.DumbSlave;
+import hudson.slaves.RetentionStrategy;
+import hudson.util.Secret;
+import jenkins.model.Jenkins;
+import org.apache.commons.io.FileUtils;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.LocalData;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+
+import static hudson.cli.CLICommandInvoker.Matcher.failedWith;
+import static hudson.cli.CLICommandInvoker.Matcher.succeeded;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assume.assumeThat;
+
+public class CredentialsInPipelineTest {
+    /**
+     * The CredentialsInPipelineTest suite prepares pipeline scripts to
+     * retrieve some previously saved credentials, on the controller,
+     * on a node provided by it, and on a worker agent in separate JVM.
+     * This picks known-working test cases and their setup from other
+     * test classes which address those credential types in more detail.
+     * Initially tied to JENKINS-70101 research.
+     */
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    // Data for build agent setup
+    @Rule
+    public TemporaryFolder tmpAgent = new TemporaryFolder();
+    @Rule
+    public TemporaryFolder tmpWorker = new TemporaryFolder();
+    // Where did we save that file?..
+    private File agentJar = null;
+    // Can this be reused for many test cases?
+    private Slave agent = null;
+    // Unknown/started/not usable
+    private Boolean agentUsable = null;
+
+    // From CertificateCredentialImplTest
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+    private File p12;
+
+    @Before
+    public void setup() {
+        r.jenkins.setCrumbIssuer(null);
+    }
+
+    Boolean isAvailableAgent() {
+        // Can be used to skip optional tests if we know we could not set up an agent
+        if (agentJar == null)
+            return false;
+        if (agent == null)
+            return false;
+        return agentUsable;
+    }
+
+    Boolean setupAgent() throws IOException, InterruptedException, OutOfMemoryError {
+        // Note we anticipate this might fail; it should not block the whole test suite from running
+        // Loosely inspired by
+        // https://docs.cloudbees.com/docs/cloudbees-ci-kb/latest/client-and-managed-masters/create-agent-node-from-groovy
+
+        // Is it known-impossible to start the agent?
+        if (agentUsable != null && agentUsable == false)
+            return agentUsable; // quickly for re-runs
+
+        // Did we download this file for earlier test cases?
+        if (agentJar == null) {
+            try {
+                URL url = new URL(r.jenkins.getRootUrl() + "jnlpJars/agent.jar");
+                agentJar = tmpAgent.newFile("agent.jar");
+                FileOutputStream out = new FileOutputStream(agentJar);
+                out.write(url.openStream().readAllBytes());
+                out.close();
+            } catch (IOException | OutOfMemoryError e) {
+                agentJar = null;
+                agentUsable = false;
+
+                System.out.println("Failed to download agent.jar from test instance: " +
+                        e.toString());
+
+                return agentUsable;
+            }
+        }
+
+        // This CLI spelling and quoting should play well with both Windows
+        // (including spaces in directory names) and Unix/Linux
+        ComputerLauncher launcher = new CommandLauncher(
+                "\"" + System.getProperty("java.home") + File.separator + "bin" +
+                File.separator + "java\" -jar \"" + agentJar.getAbsolutePath().toString() + "\""
+        );
+
+        try {
+            // Define a "Permanent Agent"
+            agent = new DumbSlave(
+                    "worker",
+                    tmpWorker.getRoot().getAbsolutePath().toString(),
+                    launcher);
+            agent.setNodeDescription("Worker in another JVM, remoting used");
+            agent.setNumExecutors(1);
+            agent.setLabelString("worker");
+            agent.setMode(Node.Mode.EXCLUSIVE);
+            agent.setRetentionStrategy(new RetentionStrategy.Always());
+
+/*
+            // Add node envvars
+            List<Entry> env = new ArrayList<Entry>();
+            env.add(new Entry("key1","value1"));
+            env.add(new Entry("key2","value2"));
+            EnvironmentVariablesNodeProperty envPro = new EnvironmentVariablesNodeProperty(env);
+            agent.getNodeProperties().add(envPro);
+*/
+
+            r.jenkins.addNode(agent);
+
+            String agentLog = null;
+            agentUsable = false;
+            for (long i = 0; i < 5; i++) {
+                Thread.sleep(1000);
+                agentLog = agent.getComputer().getLog();
+                if (i == 2 && (agentLog == null || agentLog.isEmpty())) {
+                    // Give it a little time to autostart, then kick it up if needed:
+                    agent.getComputer().connect(true); // "always" should have started it; avoid duplicate runs
+                }
+                if (agentLog != null && agentLog.contains("Agent successfully connected and online")) {
+                    agentUsable = true;
+                    break;
+                }
+            }
+            System.out.println("Spawned build agent " +
+                    "usability: " + agentUsable.toString() +
+                    "; connection log:" + (agentLog == null ? " <null>" : "\n" + agentLog));
+        } catch (Descriptor.FormException | NullPointerException e) {
+            agentUsable = false;
+        }
+
+        return agentUsable;
+    }
+
+    /////////////////////////////////////////////////////////////////
+    // Certificate credentials tests
+    /////////////////////////////////////////////////////////////////
+
+    // Partially from CertificateCredentialImplTest setup()
+    private void prepareUploadedKeystore() throws IOException {
+        prepareUploadedKeystore("myCert", "password");
+    }
+
+    private void prepareUploadedKeystore(String id, String password) throws IOException {
+        if (p12 == null) {
+            p12 = tmp.newFile("test.p12");
+            FileUtils.copyURLToFile(CertificateCredentialsImplTest.class.getResource("test.p12"), p12);
+        }
+
+        SecretBytes uploadedKeystore = SecretBytes.fromBytes(Files.readAllBytes(p12.toPath()));
+        CertificateCredentialsImpl.UploadedKeyStoreSource storeSource = new CertificateCredentialsImpl.UploadedKeyStoreSource(uploadedKeystore);
+        CertificateCredentialsImpl credentials = new CertificateCredentialsImpl(null, id, null, password, storeSource);
+        SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
+        SystemCredentialsProvider.getInstance().save();
+    }
+
+    String cpsScriptCredentialTestImports() {
+        return  "import com.cloudbees.plugins.credentials.CredentialsMatchers;\n" +
+                "import com.cloudbees.plugins.credentials.CredentialsProvider;\n" +
+                "import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;\n" +
+                "import com.cloudbees.plugins.credentials.common.StandardCredentials;\n" +
+                "import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;\n" +
+                "import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;\n" +
+                "import com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl;\n" +
+                "import com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl.KeyStoreSource;\n" +
+                "import hudson.security.ACL;\n" +
+                "import java.security.KeyStore;\n" +
+                "\n" +
+                "@NonCPS\n" +
+                "def getKey(def keystoreName, def keystoreFormat, def keyPassword, def alias) {\n" +
+                "    def p12file = new FileInputStream(keystoreName)\n" +
+                "    def keystore = KeyStore.getInstance(keystoreFormat)\n" +
+                "    keystore.load(p12file, keyPassword.toCharArray())\n" +
+                "    def key = keystore.getKey(alias, keyPassword.toCharArray())\n" +
+                "    return key.getEncoded().encodeBase64().toString()\n" +
+                "}\n" +
+                "\n";
+    }
+
+    String cpsScriptCredentialTest(String runnerTag) {
+        return cpsScriptCredentialTest("myCert", "password", runnerTag);
+    }
+
+    String cpsScriptCredentialTest(String id, String password, String runnerTag) {
+        return  "def authentication='" + id + "';\n" +
+                "def password='" + password + "';\n" +
+                "StandardCredentials credential = CredentialsMatchers.firstOrNull(\n" +
+                "    CredentialsProvider.lookupCredentials(\n" +
+                "        StandardCredentials.class,\n" +
+                "        Jenkins.instance, null, null),\n" +
+                "    CredentialsMatchers.withId(authentication));\n" +
+                "StandardCredentials credentialSnap = CredentialsProvider.snapshot(credential);\n\n" +
+                "\n" +
+                "echo \"CRED ON " + runnerTag + ":\"\n" +
+                "echo credential.toString()\n" +
+                "KeyStore keyStore = credential.getKeyStore();\n" +
+                "KeyStoreSource kss = ((CertificateCredentialsImpl) credential).getKeyStoreSource();\n" +
+                "echo \"KSS: \" + kss.toString()\n" +
+                "byte[] kssb = kss.getKeyStoreBytes();\n" +
+                "echo \"KSS bytes (len): \" + kssb.length\n" +
+                "\n" +
+                "echo \"CRED-SNAP ON " + runnerTag + ":\"\n" +
+                "echo credentialSnap.toString()\n" +
+                "KeyStore keyStoreSnap = credentialSnap.getKeyStore();\n" +
+                "KeyStoreSource kssSnap = ((CertificateCredentialsImpl) credentialSnap).getKeyStoreSource();\n" +
+                "echo \"KSS-SNAP: \" + kssSnap.toString()\n" +
+                "byte[] kssbSnap = kssSnap.getKeyStoreBytes();\n" +
+                "echo \"KSS-SNAP bytes (len): \" + kssbSnap.length\n" +
+                "\n" +
+                "echo \"WITH-CREDENTIAL ON " + runnerTag + ":\"\n" + // https://groups.google.com/g/jenkinsci-users/c/evyx0O3bMWE
+                "withCredentials([certificate(\n" +
+                "        credentialsId: authentication,\n" +
+                "        keystoreVariable: 'keystoreName',\n" +
+                "        passwordVariable: 'keyPassword',\n" +
+                "        aliasVariable: 'myKeyAlias')\n" +
+                "]) {\n" +
+                "    echo \"Keystore bytes (len): \" + (new File(keystoreName)).length()\n" +
+                "    def keystoreFormat = \"PKCS12\"\n" +
+                "    def keyValue = '' //getKeyValue(keystoreName, keystoreFormat, keyPassword, myKeyAlias)\n" +
+                "    println \"-----BEGIN PRIVATE KEY-----\"\n" +
+                "    println keyValue\n" +
+                "    println \"-----END PRIVATE KEY-----\"\n" +
+                "}\n" +
+                "\n";
+    }
+
+    @Test
+    @Issue("JENKINS-70101")
+    public void keyStoreReadableOnController() throws Exception {
+        // Check that credentials are usable with pipeline script
+        // running without a node{}
+        prepareUploadedKeystore();
+
+        // Configure the build to use the credential
+        WorkflowJob proj = r.jenkins.createProject(WorkflowJob.class, "proj");
+        String script = cpsScriptCredentialTestImports() +
+                cpsScriptCredentialTest("CONTROLLER BUILT-IN");
+        proj.setDefinition(new CpsFlowDefinition(script, false));
+
+        // Execute the build
+        WorkflowRun run = proj.scheduleBuild2(0).get();
+
+        // Check expectations
+        r.assertBuildStatus(Result.SUCCESS, run);
+        // Got to the end?
+        r.assertLogContains("KSS-SNAP bytes", run);
+    }
+
+    @Test
+    @Issue("JENKINS-70101")
+    public void keyStoreReadableOnNodeLocal() throws Exception {
+        // Check that credentials are usable with pipeline script
+        // running on a node{} (provided by the controller)
+        prepareUploadedKeystore();
+
+        // Configure the build to use the credential
+        WorkflowJob proj = r.jenkins.createProject(WorkflowJob.class, "proj");
+        String script = cpsScriptCredentialTestImports() +
+                "node {\n" +
+                cpsScriptCredentialTest("CONTROLLER NODE") +
+                "}\n";
+        proj.setDefinition(new CpsFlowDefinition(script, false));
+
+        // Execute the build
+        WorkflowRun run = proj.scheduleBuild2(0).get();
+
+        // Check expectations
+        r.assertBuildStatus(Result.SUCCESS, run);
+        // Got to the end?
+        r.assertLogContains("KSS-SNAP bytes", run);
+    }
+
+    @Test
+    @Issue("JENKINS-70101")
+    public void keyStoreReadableOnNodeRemote() throws Exception {
+        // Check that credentials are usable with pipeline script
+        // running on a remote node{} with separate JVM (check
+        // that remoting/snapshot work properly)
+        assumeThat("This test needs a separate build agent", this.setupAgent(), is(true));
+
+        prepareUploadedKeystore();
+
+        // Configure the build to use the credential
+        WorkflowJob proj = r.jenkins.createProject(WorkflowJob.class, "proj");
+        String script = cpsScriptCredentialTestImports() +
+                "node(\"worker\") {\n" +
+                cpsScriptCredentialTest("REMOTE NODE") +
+                "}\n";
+        proj.setDefinition(new CpsFlowDefinition(script, false));
+
+        // Execute the build
+        WorkflowRun run = proj.scheduleBuild2(0).get();
+
+        // Check expectations
+        r.assertBuildStatus(Result.SUCCESS, run);
+        // Got to the end?
+        r.assertLogContains("KSS-SNAP bytes", run);
+    }
+
+}

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsInPipelineTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsInPipelineTest.java
@@ -296,6 +296,10 @@ public class CredentialsInPipelineTest {
                 "echo \"KSS: \" + kss.toString()\n" +
                 "byte[] kssb = kss.getKeyStoreBytes();\n" +
                 "echo \"KSS bytes (len): \" + kssb.length\n" +
+                "String keyValue = keyStore.getKey(alias, password.toCharArray()).getEncoded().encodeBase64().toString()\n" +
+                "echo  \"-----BEGIN PRIVATE KEY-----\"\n" +
+                "echo keyValue\n" +
+                "echo \"-----END PRIVATE KEY-----\"\n" +
                 "\n" +
                 "echo \"CRED-SNAP ON " + runnerTag + ":\"\n" +
                 "echo credentialSnap.toString()\n" +
@@ -304,6 +308,10 @@ public class CredentialsInPipelineTest {
                 "echo \"KSS-SNAP: \" + kssSnap.toString()\n" +
                 "byte[] kssbSnap = kssSnap.getKeyStoreBytes();\n" +
                 "echo \"KSS-SNAP bytes (len): \" + kssbSnap.length\n" +
+                "String keyValueSnap = keyStoreSnap.getKey(alias, password.toCharArray()).getEncoded().encodeBase64().toString()\n" +
+                "echo  \"-----BEGIN PRIVATE KEY-----\"\n" +
+                "echo keyValueSnap\n" +
+                "echo \"-----END PRIVATE KEY-----\"\n" +
                 "\n";
     }
 

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsInPipelineTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsInPipelineTest.java
@@ -274,11 +274,11 @@ public class CredentialsInPipelineTest {
     // Certificate credentials retrievability in (trusted) pipeline
     /////////////////////////////////////////////////////////////////
 
-    String cpsScriptCredentialTest(String runnerTag) {
-        return cpsScriptCredentialTest("myCert", "password", "1", runnerTag);
+    String cpsScriptCertCredentialTestScriptedPipeline(String runnerTag) {
+        return cpsScriptCertCredentialTestScriptedPipeline("myCert", "password", "1", runnerTag);
     }
 
-    String cpsScriptCredentialTest(String id, String password, String alias, String runnerTag) {
+    String cpsScriptCertCredentialTestScriptedPipeline(String id, String password, String alias, String runnerTag) {
         return  "def authentication='" + id + "';\n" +
                 "def password='" + password + "';\n" +
                 "def alias='" + alias + "';\n" +
@@ -325,7 +325,7 @@ public class CredentialsInPipelineTest {
         // Configure the build to use the credential
         WorkflowJob proj = r.jenkins.createProject(WorkflowJob.class, "proj");
         String script = cpsScriptCredentialTestImports() +
-                cpsScriptCredentialTest("CONTROLLER BUILT-IN");
+                cpsScriptCertCredentialTestScriptedPipeline("CONTROLLER BUILT-IN");
         proj.setDefinition(new CpsFlowDefinition(script, false));
 
         // Execute the build
@@ -349,7 +349,7 @@ public class CredentialsInPipelineTest {
         WorkflowJob proj = r.jenkins.createProject(WorkflowJob.class, "proj");
         String script = cpsScriptCredentialTestImports() +
                 "node {\n" +
-                cpsScriptCredentialTest("CONTROLLER NODE") +
+                cpsScriptCertCredentialTestScriptedPipeline("CONTROLLER NODE") +
                 "}\n";
         proj.setDefinition(new CpsFlowDefinition(script, false));
 
@@ -377,7 +377,7 @@ public class CredentialsInPipelineTest {
         WorkflowJob proj = r.jenkins.createProject(WorkflowJob.class, "proj");
         String script = cpsScriptCredentialTestImports() +
                 "node(\"worker\") {\n" +
-                cpsScriptCredentialTest("REMOTE NODE") +
+                cpsScriptCertCredentialTestScriptedPipeline("REMOTE NODE") +
                 "}\n";
         proj.setDefinition(new CpsFlowDefinition(script, false));
 
@@ -395,7 +395,7 @@ public class CredentialsInPipelineTest {
     // Certificate credentials retrievability by withCredentials() step
     /////////////////////////////////////////////////////////////////
 
-    String cpsScriptCredentialTestGetKeyValue() {
+    String cpsScriptCertCredentialTestGetKeyValue() {
         return  "@NonCPS\n" +
                 "def getKeyValue(def keystoreName, def keystoreFormat, def keyPassword, def alias) {\n" +
                 "    def p12file = new FileInputStream(keystoreName)\n" +
@@ -408,11 +408,11 @@ public class CredentialsInPipelineTest {
                 "\n";
     }
 
-    String cpsScriptCredentialTestWithCredentials(String runnerTag) {
-        return cpsScriptCredentialTestWithCredentials("myCert", "password", "1", runnerTag);
+    String cpsScriptCertCredentialTestWithCredentials(String runnerTag) {
+        return cpsScriptCertCredentialTestWithCredentials("myCert", "password", "1", runnerTag);
     }
 
-    String cpsScriptCredentialTestWithCredentials(String id, String password, String alias, String runnerTag) {
+    String cpsScriptCertCredentialTestWithCredentials(String id, String password, String alias, String runnerTag) {
         // Note: for some reason does not pass (env?.)myKeyAlias to closure
         return  "def authentication='" + id + "';\n" +
                 "def password='" + password + "';\n" +
@@ -446,8 +446,8 @@ public class CredentialsInPipelineTest {
         // Configure the build to use the credential
         WorkflowJob proj = r.jenkins.createProject(WorkflowJob.class, "proj");
         String script = cpsScriptCredentialTestImports() +
-                cpsScriptCredentialTestGetKeyValue() +
-                cpsScriptCredentialTestWithCredentials("CONTROLLER BUILT-IN");
+                cpsScriptCertCredentialTestGetKeyValue() +
+                cpsScriptCertCredentialTestWithCredentials("CONTROLLER BUILT-IN");
         proj.setDefinition(new CpsFlowDefinition(script, false));
 
         // Execute the build
@@ -470,9 +470,9 @@ public class CredentialsInPipelineTest {
         // Configure the build to use the credential
         WorkflowJob proj = r.jenkins.createProject(WorkflowJob.class, "proj");
         String script = cpsScriptCredentialTestImports() +
-                cpsScriptCredentialTestGetKeyValue() +
+                cpsScriptCertCredentialTestGetKeyValue() +
                 "node {\n" +
-                cpsScriptCredentialTestWithCredentials("CONTROLLER NODE") +
+                cpsScriptCertCredentialTestWithCredentials("CONTROLLER NODE") +
                 "}\n";
         proj.setDefinition(new CpsFlowDefinition(script, false));
 
@@ -499,9 +499,9 @@ public class CredentialsInPipelineTest {
         // Configure the build to use the credential
         WorkflowJob proj = r.jenkins.createProject(WorkflowJob.class, "proj");
         String script = cpsScriptCredentialTestImports() +
-                cpsScriptCredentialTestGetKeyValue() +
+                cpsScriptCertCredentialTestGetKeyValue() +
                 "node(\"worker\") {\n" +
-                cpsScriptCredentialTestWithCredentials("REMOTE NODE") +
+                cpsScriptCertCredentialTestWithCredentials("REMOTE NODE") +
                 "}\n";
         proj.setDefinition(new CpsFlowDefinition(script, false));
 

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsInPipelineTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsInPipelineTest.java
@@ -414,7 +414,9 @@ public class CredentialsInPipelineTest {
     }
 
     String cpsScriptCertCredentialTestWithCredentials(String id, String password, String alias, String runnerTag) {
-        // Note: for some reason does not pass (env?.)myKeyAlias to closure
+        // Note: does not pass a(ny) useful (env?.)myKeyAlias to closure
+        // https://issues.jenkins.io/browse/JENKINS-59331
+        // https://github.com/jenkinsci/credentials-binding-plugin/blob/fcd22059ac48b87d0924ef17d5b351a3b7a89a97/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/CertificateMultiBinding.java#L80-L81
         return  "def authentication='" + id + "';\n" +
                 "def password='" + password + "';\n" +
                 "def alias='" + alias + "';\n" +

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsInPipelineTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsInPipelineTest.java
@@ -275,12 +275,13 @@ public class CredentialsInPipelineTest {
     /////////////////////////////////////////////////////////////////
 
     String cpsScriptCredentialTest(String runnerTag) {
-        return cpsScriptCredentialTest("myCert", "password", runnerTag);
+        return cpsScriptCredentialTest("myCert", "password", "1", runnerTag);
     }
 
-    String cpsScriptCredentialTest(String id, String password, String runnerTag) {
+    String cpsScriptCredentialTest(String id, String password, String alias, String runnerTag) {
         return  "def authentication='" + id + "';\n" +
                 "def password='" + password + "';\n" +
+                "def alias='" + alias + "';\n" +
                 "StandardCredentials credential = CredentialsMatchers.firstOrNull(\n" +
                 "    CredentialsProvider.lookupCredentials(\n" +
                 "        StandardCredentials.class,\n" +
@@ -393,19 +394,21 @@ public class CredentialsInPipelineTest {
                 "    def keystore = KeyStore.getInstance(keystoreFormat)\n" +
                 "    keystore.load(p12file, keyPassword.toCharArray())\n" +
                 "    p12file.close()\n" +
-                "    def key = keystore.getKey(alias ? alias : \"1\", keyPassword.toCharArray())\n" +
+                "    def key = keystore.getKey(alias, keyPassword.toCharArray())\n" +
                 "    return key.getEncoded().encodeBase64().toString()\n" +
                 "}\n" +
                 "\n";
     }
 
     String cpsScriptCredentialTestWithCredentials(String runnerTag) {
-        return cpsScriptCredentialTestWithCredentials("myCert", "password", runnerTag);
+        return cpsScriptCredentialTestWithCredentials("myCert", "password", "1", runnerTag);
     }
 
-    String cpsScriptCredentialTestWithCredentials(String id, String password, String runnerTag) {
+    String cpsScriptCredentialTestWithCredentials(String id, String password, String alias, String runnerTag) {
+        // Note: for some reason does not pass (env?.)myKeyAlias to closure
         return  "def authentication='" + id + "';\n" +
                 "def password='" + password + "';\n" +
+                "def alias='" + alias + "';\n" +
                 "echo \"WITH-CREDENTIALS ON " + runnerTag + ":\"\n" +
                 "withCredentials([certificate(\n" +
                 "        credentialsId: authentication,\n" +
@@ -416,7 +419,7 @@ public class CredentialsInPipelineTest {
                 "    echo \"Keystore bytes (len): \" + (new File(keystoreName)).length()\n" +
                 "    echo \"Got expected password? ${keyPassword == password}\"\n" +
                 "    def keystoreFormat = \"PKCS12\"\n" +
-                "    def keyValue = getKeyValue(keystoreName, keystoreFormat, keyPassword, env?.myKeyAlias)\n" +
+                "    def keyValue = getKeyValue(keystoreName, keystoreFormat, keyPassword, (env?.myKeyAlias ? env?.myKeyAlias : alias))\n" +
                 "    println \"-----BEGIN PRIVATE KEY-----\"\n" +
                 "    println keyValue\n" +
                 "    println \"-----END PRIVATE KEY-----\"\n" +

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsInPipelineTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsInPipelineTest.java
@@ -80,6 +80,7 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.recipes.LocalData;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -225,6 +226,12 @@ public class CredentialsInPipelineTest {
         return agentUsable;
     }
 
+    String getLogAsStringPlaintext(WorkflowRun f) throws java.io.IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        f.getLogText().writeLogTo(0, baos);
+        return baos.toString();
+    }
+
     /////////////////////////////////////////////////////////////////
     // Certificate credentials tests
     /////////////////////////////////////////////////////////////////
@@ -314,6 +321,7 @@ public class CredentialsInPipelineTest {
 
         // Execute the build
         WorkflowRun run = proj.scheduleBuild2(0).get();
+        System.out.println(getLogAsStringPlaintext(run));
 
         // Check expectations
         r.assertBuildStatus(Result.SUCCESS, run);
@@ -338,6 +346,7 @@ public class CredentialsInPipelineTest {
 
         // Execute the build
         WorkflowRun run = proj.scheduleBuild2(0).get();
+        System.out.println(getLogAsStringPlaintext(run));
 
         // Check expectations
         r.assertBuildStatus(Result.SUCCESS, run);
@@ -365,6 +374,7 @@ public class CredentialsInPipelineTest {
 
         // Execute the build
         WorkflowRun run = proj.scheduleBuild2(0).get();
+        System.out.println(getLogAsStringPlaintext(run));
 
         // Check expectations
         r.assertBuildStatus(Result.SUCCESS, run);
@@ -431,6 +441,7 @@ public class CredentialsInPipelineTest {
 
         // Execute the build
         WorkflowRun run = proj.scheduleBuild2(0).get();
+        System.out.println(getLogAsStringPlaintext(run));
 
         // Check expectations
         r.assertBuildStatus(Result.SUCCESS, run);
@@ -456,6 +467,7 @@ public class CredentialsInPipelineTest {
 
         // Execute the build
         WorkflowRun run = proj.scheduleBuild2(0).get();
+        System.out.println(getLogAsStringPlaintext(run));
 
         // Check expectations
         r.assertBuildStatus(Result.SUCCESS, run);
@@ -484,6 +496,7 @@ public class CredentialsInPipelineTest {
 
         // Execute the build
         WorkflowRun run = proj.scheduleBuild2(0).get();
+        System.out.println(getLogAsStringPlaintext(run));
 
         // Check expectations
         r.assertBuildStatus(Result.SUCCESS, run);

--- a/src/test/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImplTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImplTest.java
@@ -541,6 +541,15 @@ public class CertificateCredentialsImplTest {
                 "import com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl.KeyStoreSource;\n" +
                 "import hudson.security.ACL;\n" +
                 "import java.security.KeyStore;\n" +
+                "\n" +
+                "@NonCPS\n" +
+                "def getKey(def keystoreName, def keystoreFormat, def keyPassword, def alias) {\n" +
+                "    def p12file = new FileInputStream(keystoreName)\n" +
+                "    def keystore = KeyStore.getInstance(keystoreFormat)\n" +
+                "    keystore.load(p12file, keyPassword.toCharArray())\n" +
+                "    def key = keystore.getKey(alias, keyPassword.toCharArray())\n" +
+                "    return key.getEncoded().encodeBase64().toString()\n" +
+                "}\n" +
                 "\n";
     }
 
@@ -573,6 +582,21 @@ public class CertificateCredentialsImplTest {
                 "echo \"KSS-SNAP: \" + kssSnap.toString()\n" +
                 "byte[] kssbSnap = kssSnap.getKeyStoreBytes();\n" +
                 "echo \"KSS-SNAP bytes (len): \" + kssbSnap.length\n" +
+                "\n" +
+                "echo \"WITH-CREDENTIAL ON " + runnerTag + ":\"\n" + // https://groups.google.com/g/jenkinsci-users/c/evyx0O3bMWE
+                "withCredentials([certificate(\n" +
+                "        credentialsId: authentication,\n" +
+                "        keystoreVariable: 'keystoreName',\n" +
+                "        passwordVariable: 'keyPassword',\n" +
+                "        aliasVariable: 'myKeyAlias')\n" +
+                "]) {\n" +
+                "    echo \"Keystore bytes (len): \" + (new File(keystoreName)).length()\n" +
+                "    def keystoreFormat = \"PKCS12\"\n" +
+                "    def keyValue = '' //getKeyValue(keystoreName, keystoreFormat, keyPassword, myKeyAlias)\n" +
+                "    println \"-----BEGIN PRIVATE KEY-----\"\n" +
+                "    println keyValue\n" +
+                "    println \"-----END PRIVATE KEY-----\"\n" +
+                "}\n" +
                 "\n";
     }
 

--- a/src/test/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImplTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImplTest.java
@@ -51,24 +51,12 @@ import hudson.FilePath;
 import hudson.Util;
 import hudson.cli.CLICommandInvoker;
 import hudson.cli.UpdateJobCommand;
-import hudson.model.Descriptor;
 import hudson.model.ItemGroup;
 import hudson.model.Job;
-import hudson.model.Node;
-import hudson.model.Result;
-import hudson.model.Slave;
 import hudson.security.ACL;
-import hudson.slaves.CommandLauncher;
-import hudson.slaves.ComputerLauncher;
-import hudson.slaves.DumbSlave;
-import hudson.slaves.RetentionStrategy;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.FileUtils;
-import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
-import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -78,7 +66,6 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.recipes.LocalData;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLEncoder;
@@ -94,7 +81,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assume.assumeThat;
 
 public class CertificateCredentialsImplTest {
 
@@ -110,18 +96,6 @@ public class CertificateCredentialsImplTest {
     private static final String INVALID_PASSWORD = "blabla";
     private static final String EXPECTED_DISPLAY_NAME = "EMAILADDRESS=me@myhost.mydomain, CN=pkcs12, O=Fort-Funston, L=SanFrancisco, ST=CA, C=US";
 
-    // See setupAgent() below
-    @Rule
-    public TemporaryFolder tmpAgent = new TemporaryFolder();
-    @Rule
-    public TemporaryFolder tmpWorker = new TemporaryFolder();
-    // Where did we save that file?..
-    private File agentJar = null;
-    // Can this be reused for many test cases?
-    private Slave agent = null;
-    // Unknown/started/not usable
-    private Boolean agentUsable = null;
-
     @Before
     public void setup() throws IOException {
         p12 = tmp.newFile("test.p12");
@@ -130,99 +104,6 @@ public class CertificateCredentialsImplTest {
         FileUtils.copyURLToFile(CertificateCredentialsImplTest.class.getResource("invalid.p12"), p12Invalid);
 
         r.jenkins.setCrumbIssuer(null);
-    }
-
-    // Helpers for some of the test cases (initially tied to JENKINS-70101 research)
-    // TODO: Offload to some class many tests can call upon?
-    Boolean isAvailableAgent() {
-        // Can be used to skip optional tests if we know we could not set up an agent
-        if (agentJar == null)
-            return false;
-        if (agent == null)
-            return false;
-        return agentUsable;
-    }
-
-    Boolean setupAgent() throws IOException, InterruptedException, OutOfMemoryError {
-        // Note we anticipate this might fail; it should not block the whole test suite from running
-        // Loosely inspired by
-        // https://docs.cloudbees.com/docs/cloudbees-ci-kb/latest/client-and-managed-masters/create-agent-node-from-groovy
-
-        // Is it known-impossible to start the agent?
-        if (agentUsable != null && agentUsable == false)
-            return agentUsable; // quickly for re-runs
-
-        // Did we download this file for earlier test cases?
-        if (agentJar == null) {
-            try {
-                URL url = new URL(r.jenkins.getRootUrl() + "jnlpJars/agent.jar");
-                agentJar = tmpAgent.newFile("agent.jar");
-                FileOutputStream out = new FileOutputStream(agentJar);
-                out.write(url.openStream().readAllBytes());
-                out.close();
-            } catch (IOException | OutOfMemoryError e) {
-                agentJar = null;
-                agentUsable = false;
-
-                System.out.println("Failed to download agent.jar from test instance: " +
-                    e.toString());
-
-                return agentUsable;
-            }
-        }
-
-        // This CLI spelling and quoting should play well with both Windows
-        // (including spaces in directory names) and Unix/Linux
-        ComputerLauncher launcher = new CommandLauncher(
-            "\"" + System.getProperty("java.home") + File.separator + "bin" +
-            File.separator + "java\" -jar \"" + agentJar.getAbsolutePath().toString() + "\""
-        );
-
-        try {
-            // Define a "Permanent Agent"
-            agent = new DumbSlave(
-                    "worker",
-                    tmpWorker.getRoot().getAbsolutePath().toString(),
-                    launcher);
-            agent.setNodeDescription("Worker in another JVM, remoting used");
-            agent.setNumExecutors(1);
-            agent.setLabelString("worker");
-            agent.setMode(Node.Mode.EXCLUSIVE);
-            agent.setRetentionStrategy(new RetentionStrategy.Always());
-
-/*
-            // Add node envvars
-            List<Entry> env = new ArrayList<Entry>();
-            env.add(new Entry("key1","value1"));
-            env.add(new Entry("key2","value2"));
-            EnvironmentVariablesNodeProperty envPro = new EnvironmentVariablesNodeProperty(env);
-            agent.getNodeProperties().add(envPro);
-*/
-
-            r.jenkins.addNode(agent);
-
-            String agentLog = null;
-            agentUsable = false;
-            for (long i = 0; i < 5; i++) {
-                Thread.sleep(1000);
-                agentLog = agent.getComputer().getLog();
-                if (i == 2 && (agentLog == null || agentLog.isEmpty())) {
-                    // Give it a little time to autostart, then kick it up if needed:
-                    agent.getComputer().connect(true); // "always" should have started it; avoid duplicate runs
-                }
-                if (agentLog != null && agentLog.contains("Agent successfully connected and online")) {
-                    agentUsable = true;
-                    break;
-                }
-            }
-            System.out.println("Spawned build agent " +
-                "usability: " + agentUsable.toString() +
-                "; connection log:" + (agentLog == null ? " <null>" : "\n" + agentLog));
-        } catch (Descriptor.FormException | NullPointerException e) {
-            agentUsable = false;
-        }
-
-        return agentUsable;
     }
 
     @Test
@@ -516,160 +397,4 @@ public class CertificateCredentialsImplTest {
         return folderStore;
     }
 
-    // Helper for a few tests below
-    // Roughly follows what tests above were proven to succeed doing
-    private void prepareUploadedKeystore() throws IOException {
-        prepareUploadedKeystore("myCert", "password");
-    }
-
-    private void prepareUploadedKeystore(String id, String password) throws IOException {
-        SecretBytes uploadedKeystore = SecretBytes.fromBytes(Files.readAllBytes(p12.toPath()));
-        CertificateCredentialsImpl.UploadedKeyStoreSource storeSource = new CertificateCredentialsImpl.UploadedKeyStoreSource(uploadedKeystore);
-        CertificateCredentialsImpl credentials = new CertificateCredentialsImpl(null, id, null, password, storeSource);
-        SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
-        SystemCredentialsProvider.getInstance().save();
-    }
-
-    String cpsScriptCredentialTestImports() {
-        return  "import com.cloudbees.plugins.credentials.CredentialsMatchers;\n" +
-                "import com.cloudbees.plugins.credentials.CredentialsProvider;\n" +
-                "import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;\n" +
-                "import com.cloudbees.plugins.credentials.common.StandardCredentials;\n" +
-                "import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;\n" +
-                "import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;\n" +
-                "import com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl;\n" +
-                "import com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl.KeyStoreSource;\n" +
-                "import hudson.security.ACL;\n" +
-                "import java.security.KeyStore;\n" +
-                "\n" +
-                "@NonCPS\n" +
-                "def getKey(def keystoreName, def keystoreFormat, def keyPassword, def alias) {\n" +
-                "    def p12file = new FileInputStream(keystoreName)\n" +
-                "    def keystore = KeyStore.getInstance(keystoreFormat)\n" +
-                "    keystore.load(p12file, keyPassword.toCharArray())\n" +
-                "    def key = keystore.getKey(alias, keyPassword.toCharArray())\n" +
-                "    return key.getEncoded().encodeBase64().toString()\n" +
-                "}\n" +
-                "\n";
-    }
-
-    String cpsScriptCredentialTest(String runnerTag) {
-        return cpsScriptCredentialTest("myCert", "password", runnerTag);
-    }
-
-    String cpsScriptCredentialTest(String id, String password, String runnerTag) {
-        return  "def authentication='" + id + "';\n" +
-                "def password='" + password + "';\n" +
-                "StandardCredentials credential = CredentialsMatchers.firstOrNull(\n" +
-                "    CredentialsProvider.lookupCredentials(\n" +
-                "        StandardCredentials.class,\n" +
-                "        Jenkins.instance, null, null),\n" +
-                "    CredentialsMatchers.withId(authentication));\n" +
-                "StandardCredentials credentialSnap = CredentialsProvider.snapshot(credential);\n\n" +
-                "\n" +
-                "echo \"CRED ON " + runnerTag + ":\"\n" +
-                "echo credential.toString()\n" +
-                "KeyStore keyStore = credential.getKeyStore();\n" +
-                "KeyStoreSource kss = ((CertificateCredentialsImpl) credential).getKeyStoreSource();\n" +
-                "echo \"KSS: \" + kss.toString()\n" +
-                "byte[] kssb = kss.getKeyStoreBytes();\n" +
-                "echo \"KSS bytes (len): \" + kssb.length\n" +
-                "\n" +
-                "echo \"CRED-SNAP ON " + runnerTag + ":\"\n" +
-                "echo credentialSnap.toString()\n" +
-                "KeyStore keyStoreSnap = credentialSnap.getKeyStore();\n" +
-                "KeyStoreSource kssSnap = ((CertificateCredentialsImpl) credentialSnap).getKeyStoreSource();\n" +
-                "echo \"KSS-SNAP: \" + kssSnap.toString()\n" +
-                "byte[] kssbSnap = kssSnap.getKeyStoreBytes();\n" +
-                "echo \"KSS-SNAP bytes (len): \" + kssbSnap.length\n" +
-                "\n" +
-                "echo \"WITH-CREDENTIAL ON " + runnerTag + ":\"\n" + // https://groups.google.com/g/jenkinsci-users/c/evyx0O3bMWE
-                "withCredentials([certificate(\n" +
-                "        credentialsId: authentication,\n" +
-                "        keystoreVariable: 'keystoreName',\n" +
-                "        passwordVariable: 'keyPassword',\n" +
-                "        aliasVariable: 'myKeyAlias')\n" +
-                "]) {\n" +
-                "    echo \"Keystore bytes (len): \" + (new File(keystoreName)).length()\n" +
-                "    def keystoreFormat = \"PKCS12\"\n" +
-                "    def keyValue = '' //getKeyValue(keystoreName, keystoreFormat, keyPassword, myKeyAlias)\n" +
-                "    println \"-----BEGIN PRIVATE KEY-----\"\n" +
-                "    println keyValue\n" +
-                "    println \"-----END PRIVATE KEY-----\"\n" +
-                "}\n" +
-                "\n";
-    }
-
-    @Test
-    @Issue("JENKINS-70101")
-    public void keyStoreReadableOnController() throws Exception {
-        // Check that credentials are usable with pipeline script
-        // running without a node{}
-        prepareUploadedKeystore();
-
-        // Configure the build to use the credential
-        WorkflowJob proj = r.jenkins.createProject(WorkflowJob.class, "proj");
-        String script = cpsScriptCredentialTestImports() +
-                cpsScriptCredentialTest("CONTROLLER BUILT-IN");
-        proj.setDefinition(new CpsFlowDefinition(script, false));
-
-        // Execute the build
-        WorkflowRun run = proj.scheduleBuild2(0).get();
-
-        // Check expectations
-        r.assertBuildStatus(Result.SUCCESS, run);
-        // Got to the end?
-        r.assertLogContains("KSS-SNAP bytes", run);
-    }
-
-    @Test
-    @Issue("JENKINS-70101")
-    public void keyStoreReadableOnNodeLocal() throws Exception {
-        // Check that credentials are usable with pipeline script
-        // running on a node{} (provided by the controller)
-        prepareUploadedKeystore();
-
-        // Configure the build to use the credential
-        WorkflowJob proj = r.jenkins.createProject(WorkflowJob.class, "proj");
-        String script = cpsScriptCredentialTestImports() +
-                "node {\n" +
-                cpsScriptCredentialTest("CONTROLLER NODE") +
-                "}\n";
-        proj.setDefinition(new CpsFlowDefinition(script, false));
-
-        // Execute the build
-        WorkflowRun run = proj.scheduleBuild2(0).get();
-
-        // Check expectations
-        r.assertBuildStatus(Result.SUCCESS, run);
-        // Got to the end?
-        r.assertLogContains("KSS-SNAP bytes", run);
-    }
-
-    @Test
-    @Issue("JENKINS-70101")
-    public void keyStoreReadableOnNodeRemote() throws Exception {
-        // Check that credentials are usable with pipeline script
-        // running on a remote node{} with separate JVM (check
-        // that remoting/snapshot work properly)
-        assumeThat("This test needs a separate build agent", this.setupAgent(), is(true));
-
-        prepareUploadedKeystore();
-
-        // Configure the build to use the credential
-        WorkflowJob proj = r.jenkins.createProject(WorkflowJob.class, "proj");
-        String script = cpsScriptCredentialTestImports() +
-                "node(\"worker\") {\n" +
-                cpsScriptCredentialTest("REMOTE NODE") +
-                "}\n";
-        proj.setDefinition(new CpsFlowDefinition(script, false));
-
-        // Execute the build
-        WorkflowRun run = proj.scheduleBuild2(0).get();
-
-        // Check expectations
-        r.assertBuildStatus(Result.SUCCESS, run);
-        // Got to the end?
-        r.assertLogContains("KSS-SNAP bytes", run);
-    }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

As detailed in https://issues.jenkins.io/browse/JENKINS-70101 I've hit a problem using certificate-based user authentication in http-request-plugin (noticed as part of my work on https://issues.jenkins.io/browse/JENKINS-70000 in https://github.com/jenkinsci/http-request-plugin/pull/120 but also reproduced with latest 1.16 release of that plugin).

After a week of reproductions and tracing across different plugins, the root of the problem crystallized as the use of `SecretBytes` in `UploadedKeyStoreSource` and effective lack of special {{snapshot()}} support. As a consequence, serialized copies of the key store used the same `SecretBytes` as on the Jenkins Controller, but being on a different JVM in the remote agent case, they used a different instance of the static {{KEY}} field with its own {{secret}}. Although the `SecretBytes` are diligently copied (took a lot of effort to confirm that as seen in sibling branch https://github.com/jimklimov/credentials-plugin/tree/JENKINS-70101-trace), they are unreadable on the remote agent.

During investigation I found that credentials-plugin did have an implementation for the Certificate Credentials Snapshot Taker, but it was removed by https://github.com/jenkinsci/credentials-plugin/commit/40d0b5cc53c265b601ffaa4469310fad390a80fb as part of deprecation of `FileOnMasterKeyStoreSource` subclass. Also an earlier history of the plugin involved the `Secret` class which effectively stores a base64 string and only encodes/decodes it on demand -- this was superseded by `SecretBytes` but some handling for conversion from older versions remained. This code proved to be a good starting point for fixing the problem, although not without some further work:
* originally it consulted `isSnapshotSource` (forced `true` for `UploadedKeyStoreSource` subclass) and just returned the original credential if so;
* even with that check disabled, the snapshot used `SecretBytes` for the copied key store and suffered the same fate - not usable on agent.

This PR adds tests (failing at first to confirm the problem), makes use of older codebases and new verified fixes:
* `UploadedKeyStoreSource.isSnapshotSource()` depends on `Channel.current() == null` (so for remoting-related snapshots it is `false` and shortcuts to `return this` are not taken)
* `CertificateCredentialsSnapshotTaker` was revived as a separate source file and standalone class, similar to existing `UsernamePasswordCredentialsSnapshotTaker`
* `UploadedKeyStoreSource` was modified to handle again a `Secret uploadedKeyStore` field (and provide data from it if `SecretBytes uploadedKeyStoreBytes` are currently `null`). As part of that, `transient` and `final` modifiers on these fields had to go.
* `CertificateCredentialsSnapshotTaker` was modified to create the new `UploadedKeyStoreSource` instance with `Secret` version rather than `SecretBytes` (as `CredentialsSnapshotTaker` docs stipulate, "all the details are captured within the credential")

Thanks to @mawinter69 and @slide for bright ideas and pointers, and general sympathy as I woed on the chat :)

Separately note that this PR adds tests using a separate JVM for the build agent to reproduce the problem. This code may be worth exporting into some `JenkinsAgentRule` if someone is up for it.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

NOTE: I'll post commits in several phases, so CI has its chance to fail with the tests and show the original problem in logs.