### PR TITLE
[JENKINS-52386] Add preview for markup of a CredentialParameterDefinition

### DIFF
--- a/src/main/resources/com/cloudbees/plugins/credentials/CredentialsParameterDefinition/config.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/CredentialsParameterDefinition/config.jelly
@@ -39,7 +39,7 @@
   <f:entry field="defaultValue" title="${%Default Value}">
     <c:select/>
   </f:entry>
-  <f:entry field="description" title="${%Description}" help="/help/parameter/description.html">
-    <f:textarea/>
+  <f:entry title="${%Description}" help="/help/parameter/description.html">
+    <f:textarea name="parameter.description" value="${instance.description}" codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="/markupFormatter/previewDescription" />
   </f:entry>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/plugins/credentials/CredentialsParameterDefinition/config.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/CredentialsParameterDefinition/config.jelly
@@ -40,6 +40,6 @@
     <c:select/>
   </f:entry>
   <f:entry title="${%Description}" help="/help/parameter/description.html">
-    <f:textarea name="parameter.description" value="${instance.description}" codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="/markupFormatter/previewDescription" />
+    <f:textarea name="${%Name}.description" value="${instance.description}" codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="/markupFormatter/previewDescription" />
   </f:entry>
 </j:jelly>

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsParameterDefinitionTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsParameterDefinitionTest.java
@@ -157,6 +157,21 @@ public class CredentialsParameterDefinitionTest {
         collector.checkThat("parameters page should not leave param name unescaped", text, not(containsString("<param name>")));
         collector.checkThat("parameters page should mark up param description", text, containsString("<b>[</b>param description<b>]</b>"));
         collector.checkThat("parameters page should not leave param description unescaped", text, not(containsString("<param description>")));
+
+        page = wc.getPage(p, "configure");
+        form = page.getFormByName("config");
+        HtmlTextArea value = form.getTextAreaByName("parameter.description");
+        value.setText("<markup description>");
+        r.submit(form);
+        r.waitUntilNoActivity();
+        page = wc.getPage(p, "build?delay=0sec");
+        collector.checkThat(page.getWebResponse().getStatusCode(), is(HttpURLConnection.HTTP_BAD_METHOD)); // 405 to dissuade scripts from thinking this triggered the build
+        text = page.getWebResponse().getContentAsString();
+        collector.checkThat("build page should escape param name", text, containsString("&lt;param name&gt;"));
+        collector.checkThat("build page should not leave param name unescaped", text, not(containsString("<param name>")));
+        collector.checkThat("build page should mark up param description", text, containsString("<b>[</b>markup description<b>]</b>"));
+        collector.checkThat("build page should not leave param description unescaped", text, not(containsString("<markup description>")));        
+
     }
 
     static class MyMarkupFormatter extends MarkupFormatter {

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsParameterDefinitionTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsParameterDefinitionTest.java
@@ -156,22 +156,7 @@ public class CredentialsParameterDefinitionTest {
         collector.checkThat("parameters page should escape param name", text, containsString("&lt;param name&gt;"));
         collector.checkThat("parameters page should not leave param name unescaped", text, not(containsString("<param name>")));
         collector.checkThat("parameters page should mark up param description", text, containsString("<b>[</b>param description<b>]</b>"));
-        collector.checkThat("parameters page should not leave param description unescaped", text, not(containsString("<param description>")));
-
-        page = wc.getPage(p, "configure");
-        form = page.getFormByName("config");
-        HtmlTextArea value = form.getTextAreaByName(param.name+".description");
-        value.setText("<markup description>");
-        r.submit(form);
-        r.waitUntilNoActivity();
-        page = wc.getPage(p, "build?delay=0sec");
-        collector.checkThat(page.getWebResponse().getStatusCode(), is(HttpURLConnection.HTTP_BAD_METHOD)); // 405 to dissuade scripts from thinking this triggered the build
-        text = page.getWebResponse().getContentAsString();
-        collector.checkThat("build page should escape param name", text, containsString("&lt;param name&gt;"));
-        collector.checkThat("build page should not leave param name unescaped", text, not(containsString("<param name>")));
-        collector.checkThat("build page should mark up param description", text, containsString("<b>[</b>markup description<b>]</b>"));
-        collector.checkThat("build page should not leave param description unescaped", text, not(containsString("<markup description>")));        
-
+        collector.checkThat("parameters page should not leave param description unescaped", text, not(containsString("<param description>")));        
     }
 
     static class MyMarkupFormatter extends MarkupFormatter {

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsParameterDefinitionTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsParameterDefinitionTest.java
@@ -160,7 +160,7 @@ public class CredentialsParameterDefinitionTest {
 
         page = wc.getPage(p, "configure");
         form = page.getFormByName("config");
-        HtmlTextArea value = form.getTextAreaByName("parameter.description");
+        HtmlTextArea value = form.getTextAreaByName(param.name+".description");
         value.setText("<markup description>");
         r.submit(form);
         r.waitUntilNoActivity();

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsParameterDefinitionTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsParameterDefinitionTest.java
@@ -156,7 +156,7 @@ public class CredentialsParameterDefinitionTest {
         collector.checkThat("parameters page should escape param name", text, containsString("&lt;param name&gt;"));
         collector.checkThat("parameters page should not leave param name unescaped", text, not(containsString("<param name>")));
         collector.checkThat("parameters page should mark up param description", text, containsString("<b>[</b>param description<b>]</b>"));
-        collector.checkThat("parameters page should not leave param description unescaped", text, not(containsString("<param description>")));        
+        collector.checkThat("parameters page should not leave param description unescaped", text, not(containsString("<param description>")));
     }
 
     static class MyMarkupFormatter extends MarkupFormatter {


### PR DESCRIPTION
Add missing markup formater for CredentialParameterDefinition to fix [[JENKINS-52386] - credentials() parameter does not support HTML in description](https://issues.jenkins.io/browse/JENKINS-52386)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue