### PR TITLE
[JENKINS-69379] Removed 'jenkins-button jenkins-button--tertiary' from select.jelly

### DIFF
--- a/src/main/resources/lib/credentials/select.jelly
+++ b/src/main/resources/lib/credentials/select.jelly
@@ -115,7 +115,7 @@
       <j:set var="storeItems" value="${selectHelper.getStoreItems(context, includeUser)}"/>
       <j:choose>
         <j:when test="${selectHelper.hasCreatePermission(context, includeUser) and storeItems != null and !storeItems.isEmpty()}">
-          <button class="credentials-add-menu hetero-list-add jenkins-button jenkins-button--tertiary jenkins-!-margin-top-2" menualign="${attrs.menuAlign}"
+          <button class="credentials-add-menu hetero-list-add jenkins-!-margin-top-2" menualign="${attrs.menuAlign}"
                   suffix="${attrs.name}">
             <l:icon src="symbol-add"/>
             ${%Add}
@@ -148,7 +148,7 @@
           </div>
         </j:when>
         <j:otherwise>
-          <button class="credentials-add jenkins-button jenkins-button--tertiary jenkins-!-margin-top-2">
+          <button class="credentials-add jenkins-!-margin-top-2">
             <l:icon src="symbol-add"/>
             ${%Add}
           </button>

--- a/src/main/resources/lib/credentials/select/select.css
+++ b/src/main/resources/lib/credentials/select/select.css
@@ -1,5 +1,4 @@
 select.credentials-select {  width:auto; vertical-align: top; }
-button.credentials-add-menu { padding:0 20px 0 10px; }
 div.credentials-select-content-inactive { display:none; }
 div#credentialsDialog {overflow-y: scroll;}
 body.masked {overflow-y: hidden;}


### PR DESCRIPTION
https://issues.jenkins.io/browse/JENKINS-69379

I have set this to be a draft pull request as I wanted to discuss if this is the correct approach for this fix.

![image](https://user-images.githubusercontent.com/55280278/224784001-b3e5d7f0-e0fb-4b49-8a78-982c5ad92a78.png)

When investigating the black line on the add button issue, I noticed that the other 'Add' buttons on the page didn't include 'jenkins-button' on them. 

Example of a non-problematic add button on the same page:
![image](https://user-images.githubusercontent.com/55280278/224782801-7334a5b6-fbb0-4355-bbd6-403461af65e8.png)

I removed the 'jenkins-button' bits from the jelly file and tested, and now all of the buttons are looking consistent. Manual testing done with problem button:
![image](https://user-images.githubusercontent.com/55280278/224782894-a9fbb1f1-55b5-4d7b-acf2-b6613134883c.png)
![image](https://user-images.githubusercontent.com/55280278/224782971-1d674f3f-4452-4b66-93c5-0b39021577bc.png)

Do you think this is the right approach? Is there something I am missing about removing the 'jenkins-button' bits from the button?

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
