### PR TITLE
Do not use `FormApply#applyResponse` to execute arbitrary javascript

### DIFF
--- a/src/main/resources/lib/credentials/select/select.js
+++ b/src/main/resources/lib/credentials/select/select.js
@@ -120,68 +120,32 @@ window.credentials.refreshAll = function () {
         h();
     });
 };
-window.credentials.addSubmit = function (e) {
-    var id;
-    var containerId = "container" + (iota++);
+window.credentials.addSubmit = function (_) {
+    const form = document.getElementById('credentials-dialog-form');
+    buildFormTree(form);
+    ajaxFormSubmit(form);
 
-    var responseDialog = new YAHOO.widget.Panel("wait" + (iota++), {
-        fixedcenter: true,
-        close: true,
-        draggable: true,
-        zindex: 4,
-        modal: true,
-        visible: false
-    });
-
-    responseDialog.setHeader("Error");
-    responseDialog.setBody("<div id='" + containerId + "'></div>");
-    responseDialog.render(document.body);
-    var target; // iframe
-
-    function attachIframeOnload(target, f) {
-        if (target.attachEvent) {
-            target.attachEvent("onload", f);
-        } else {
-            target.onload = f;
-        }
+    function ajaxFormSubmit(form) {
+        fetch(form.action, {
+            method: form.method,
+            headers: crumb.wrap({}),
+            body: new FormData(form)
+        })
+            .then(res => res.json())
+            .then(data => {
+                window.notificationBar.show(data.message, window.notificationBar[data.notificationType]);
+                window.credentials.refreshAll();
+            })
+            .catch((e) => {
+                // notificationBar.show(...) with logging ID could be handy here?
+                console.error("Could not add credentials:", e);
+            })
+            .finally(() => {
+                window.credentials.dialog.hide();
+            });
     }
-
-    var f = document.getElementById('credentials-dialog-form');
-    // create a throw-away IFRAME to avoid back button from loading the POST result back
-    id = "iframe" + (iota++);
-    target = document.createElement("iframe");
-    target.setAttribute("id", id);
-    target.setAttribute("name", id);
-    target.setAttribute("style", "height:100%; width:100%");
-    document.getElementById(containerId).appendChild(target);
-
-    attachIframeOnload(target, function () {
-        if (target.contentWindow && target.contentWindow.applyCompletionHandler) {
-            // apply-aware server is expected to set this handler
-            target.contentWindow.applyCompletionHandler(window);
-        } else {
-            // otherwise this is possibly an error from the server, so we need to render the whole content.
-            var r = YAHOO.util.Dom.getClientRegion();
-            responseDialog.cfg.setProperty("width", r.width * 3 / 4 + "px");
-            responseDialog.cfg.setProperty("height", r.height * 3 / 4 + "px");
-            responseDialog.center();
-            responseDialog.show();
-        }
-        window.setTimeout(function () {// otherwise Firefox will fail to leave the "connecting" state
-            document.getElementById(id).remove();
-        }, 0)
-    });
-
-    f.target = target.id;
-    try {
-        buildFormTree(f);
-        f.submit();
-    } finally {
-        f.target = null;
-    }
-    window.credentials.dialog.hide();
-    return false;
 };
+
 Behaviour.specify("BUTTON.credentials-add-menu", 'credentials-select', -99, function(e) {
     var btn = e;
     var menu = btn.nextElementSibling;

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsSelectHelperTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsSelectHelperTest.java
@@ -1,0 +1,73 @@
+package com.cloudbees.plugins.credentials;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
+import hudson.model.UnprotectedRootAction;
+import java.util.List;
+import org.hamcrest.Matchers;
+import org.htmlunit.html.HtmlButton;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlInput;
+import org.htmlunit.html.HtmlListItem;
+import org.htmlunit.html.HtmlPage;
+import org.htmlunit.html.HtmlSpan;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+
+public class CredentialsSelectHelperTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void doAddCredentialsFromPopupWorksAsExpected() throws Exception {
+        try (JenkinsRule.WebClient wc = j.createWebClient()) {
+            HtmlPage htmlPage = wc.goTo("credentials-selection");
+            HtmlButton addCredentialsButton = htmlPage.querySelector(".credentials-add-menu");
+            addCredentialsButton.click();
+            HtmlListItem li = htmlPage.querySelector(".credentials-add-menu-items li");
+            li.click();
+            wc.waitForBackgroundJavaScript(2000);
+            HtmlForm form = htmlPage.querySelector("#credentialsDialog form");
+
+            HtmlInput username = form.querySelector("input[name='_.username']");
+            username.setValue("bob");
+            HtmlInput password = form.querySelector("input[name='_.password']");
+            password.setValue("secret");
+            HtmlInput id = form.querySelector("input[name='_.id']");
+            id.setValue("test");
+
+            HtmlSpan formSubmitButton = form.querySelector("#credentials-add-submit");
+            formSubmitButton.fireEvent("click");
+            wc.waitForBackgroundJavaScript(1000);
+
+            // check if credentials were added
+            List<UsernamePasswordCredentials> creds = CredentialsProvider.lookupCredentials(UsernamePasswordCredentials.class);
+            assertThat(creds, Matchers.hasSize(1));
+            UsernamePasswordCredentials cred = creds.get(0);
+            assertThat(cred.getUsername(), is("bob"));
+            assertThat(cred.getPassword().getPlainText(), is("secret"));
+        }
+    }
+
+    @TestExtension
+    public static class CredentialsSelectionAction implements UnprotectedRootAction {
+        @Override
+        public String getIconFileName() {
+            return null;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return null;
+        }
+
+        @Override
+        public String getUrlName() {
+            return "credentials-selection";
+        }
+    }
+}

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsSelectHelperTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsSelectHelperTest.java
@@ -30,7 +30,7 @@ public class CredentialsSelectHelperTest {
             addCredentialsButton.click();
             HtmlListItem li = htmlPage.querySelector(".credentials-add-menu-items li");
             li.click();
-            wc.waitForBackgroundJavaScript(2000);
+            wc.waitForBackgroundJavaScript(4000);
             HtmlForm form = htmlPage.querySelector("#credentialsDialog form");
 
             HtmlInput username = form.querySelector("input[name='_.username']");
@@ -42,7 +42,7 @@ public class CredentialsSelectHelperTest {
 
             HtmlSpan formSubmitButton = form.querySelector("#credentials-add-submit");
             formSubmitButton.fireEvent("click");
-            wc.waitForBackgroundJavaScript(1000);
+            wc.waitForBackgroundJavaScript(5000);
 
             // check if credentials were added
             List<UsernamePasswordCredentials> creds = CredentialsProvider.lookupCredentials(UsernamePasswordCredentials.class);

--- a/src/test/resources/com/cloudbees/plugins/credentials/CredentialsSelectHelperTest/CredentialsSelectionAction/index.jelly
+++ b/src/test/resources/com/cloudbees/plugins/credentials/CredentialsSelectHelperTest/CredentialsSelectionAction/index.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:c="/lib/credentials">
+    <l:layout title="Credentials Select Helper">
+        <l:main-panel>
+            <c:select/>
+        </l:main-panel>
+    </l:layout>
+</j:jelly>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Motivated by https://github.com/jenkinsci/jenkins/pull/8351.
That PR changes `FormApply#applyResponse` method to make it CSP compatible in a way that does not allow to execute arbitrary javascript as a callback.

Looking at the usages of `FormApply#applyResponse` in the ecosystem its most common (and perhaps intended) use is to show a notification after "Apply" button (or alike) was clicked. In credentials-plugin it's used in a "add credentials in-place" form, and the calls are rather uncommon.
Two calls are `FormApply.applyResponse("window.alert(...)")`, which could easily be replaced by the new CSP compatible version `FormApply.showNotification` from the core PR linked above.
Third call is worse - `FormApply.applyResponse("window.credentials.refreshAll();")`.
My initial attempt was to keep using `FormApply.applyResponse` mechanism, but moving `window.credentials.refreshAll()` to .js and making that execute at the right time turned out to be far from trivial.

After analysing the code for a bit more there seems to be no reason to keep using `FormApply.applyResponse`, hence this PR gets rid of it. It changes the way that form is submitted, and gets rid of javascript code needed for the `FormApply.applyResponse` mechanism to work. Instead server now responds with data for the notification, and javascript code uses that data to call `notificationBar.show(...)`. `window.credentials.refreshAll()` was also moved to .js file, and is executed after credentials were successfully added and response was received.

### Testing done
Tested interactively by adding credentials via "add credentials in-place" form. Made sure credentials were added successfully and immediately available in the dropdown after the form popup was closed.
Tested error paths by attaching the debugger and changing values through that, since I found no way to make credentials domain non-modifiable via UI.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
