### PR TITLE
Switch from XML Pull Parser v3 to Streaming API for XML (StAX) on newer cores

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsStoreAction.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsStoreAction.java
@@ -33,7 +33,6 @@ import com.thoughtworks.xstream.converters.MarshallingContext;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
-import com.thoughtworks.xstream.io.xml.XppDriver;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -541,7 +540,7 @@ public abstract class CredentialsStoreAction
             }
 
             Domain domain = (Domain)
-                    Items.XSTREAM.unmarshal(new XppDriver().createReader(new StringReader(out.toString())));
+                    Items.XSTREAM.unmarshal(XStream2.getDefaultDriver().createReader(new StringReader(out.toString())));
             if (getStore().addDomain(domain)) {
                 return HttpResponses.ok();
             } else {
@@ -804,7 +803,7 @@ public abstract class CredentialsStoreAction
                 }
 
                 Credentials credentials = (Credentials)
-                        Items.XSTREAM.unmarshal(new XppDriver().createReader(new StringReader(out.toString())));
+                        Items.XSTREAM.unmarshal(XStream2.getDefaultDriver().createReader(new StringReader(out.toString())));
                 if (getStore().addCredentials(domain, credentials)) {
                     return HttpResponses.ok();
                 } else {
@@ -998,7 +997,7 @@ public abstract class CredentialsStoreAction
             }
 
             Domain replacement = (Domain)
-                    Items.XSTREAM.unmarshal(new XppDriver().createReader(new StringReader(out.toString())));
+                    Items.XSTREAM.unmarshal(XStream2.getDefaultDriver().createReader(new StringReader(out.toString())));
             getStore().updateDomain(domain, replacement);
         }
 
@@ -1505,7 +1504,7 @@ public abstract class CredentialsStoreAction
             }
 
             Credentials credentials = (Credentials)
-                    Items.XSTREAM.unmarshal(new XppDriver().createReader(new StringReader(out.toString())));
+                    Items.XSTREAM.unmarshal(XStream2.getDefaultDriver().createReader(new StringReader(out.toString())));
             getStore().updateCredentials(domain.getDomain(), this.credentials, credentials);
         }
 
@@ -1561,4 +1560,5 @@ public abstract class CredentialsStoreAction
             }
         }
     }
+
 }

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/BaseCredentialsCLICommand.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/BaseCredentialsCLICommand.java
@@ -28,7 +28,6 @@ import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.common.IdCredentials;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
-import com.thoughtworks.xstream.io.xml.XppDriver;
 import hudson.cli.CLICommand;
 import java.io.IOException;
 import java.io.InputStream;
@@ -42,6 +41,7 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
+import hudson.util.XStream2;
 import jenkins.util.xml.XMLUtils;
 import org.apache.commons.lang.StringUtils;
 import org.xml.sax.SAXException;
@@ -103,7 +103,7 @@ public abstract class BaseCredentialsCLICommand extends CLICommand {
         } catch (TransformerException | SAXException e) {
             throw new IOException("Failed to parse", e);
         }
-        return new XppDriver().createReader(new StringReader(out.toString()));
+        return XStream2.getDefaultDriver().createReader(new StringReader(out.toString()));
 
     }
 }


### PR DESCRIPTION
In https://github.com/jenkinsci/jenkins/pull/7778 we switched core from KXML2 to StAX. This plugin seems to still be using an XPP3-based parser, though, which is inconsistent with core and probably suffers from the same emoji parsing bug (though in the context of a credentials file it probably doesn't matter). In any case, it is simpler and more consistent to use the same `StandardStaxDriver` used by core. To implement that we just use `XStream2#getDefaultDriver` to delegate driver selection to core.

### Testing done

In addition to running `mvn clean verify` I also ran `mvn clean verify` against a work-in-progress version of Jenkins core with XPP3 completely removed, which had previously been failing before this PR but started passing after this PR.

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
