### PR TITLE
Use `Descriptor.bindJSON` to support complex describable fields in custom credentials

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsSelectHelper.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsSelectHelper.java
@@ -611,7 +611,7 @@ public class CredentialsSelectHelper extends Descriptor<CredentialsSelectHelper>
                         .generateResponse(req, rsp, null);
             }
             store.checkPermission(CredentialsStoreAction.CREATE);
-            Credentials credentials = req.bindJSON(Credentials.class, data.getJSONObject("credentials"));
+            Credentials credentials = Descriptor.bindJSON(req, Credentials.class, data.getJSONObject("credentials"));
             store.addCredentials(wrapper.getDomain(), credentials);
             FormApply.applyResponse("window.credentials.refreshAll();").generateResponse(req, rsp, null);
         }

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsStoreAction.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsStoreAction.java
@@ -811,7 +811,7 @@ public abstract class CredentialsStoreAction
                 }
             } else {
                 JSONObject data = req.getSubmittedForm();
-                Credentials credentials = req.bindJSON(Credentials.class, data.getJSONObject("credentials"));
+                Credentials credentials = Descriptor.bindJSON(req, Credentials.class, data.getJSONObject("credentials"));
                 getStore().addCredentials(domain, credentials);
                 return HttpResponses.redirectTo("../../domain/" + getUrlName());
             }
@@ -1394,7 +1394,7 @@ public abstract class CredentialsStoreAction
         public HttpResponse doUpdateSubmit(StaplerRequest req) throws ServletException, IOException {
             getStore().checkPermission(UPDATE);
             JSONObject data = req.getSubmittedForm();
-            Credentials credentials = req.bindJSON(Credentials.class, data);
+            Credentials credentials = Descriptor.bindJSON(req, Credentials.class, data);
             if (!getStore().updateCredentials(this.domain.domain, this.credentials, credentials)) {
                 return HttpResponses.redirectTo("concurrentModification");
             }


### PR DESCRIPTION
I am prototyping a custom credentials type that has nested `Describable` fields with `Descriptor.newInstance` overrides, and this PR is necessary for data binding to work correctly for those credentials.

`Descriptor.bindJSON` is a drop-in replacement for `StaplerRequest.bindJSON` from https://github.com/jenkinsci/jenkins/pull/5417 and the only difference should be that the former correctly calls `Descriptor.newInstance` while the latter does not.

Marking this as `developer` rather than `bug` because it never worked previously, so there should not be any existing credential types where the difference would matter in a way that affects users as a `bug`.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
