### PR TITLE
[JEP-227][JENKINS-39324] Replace Acegi Security with Spring Security APIs

### DIFF
--- a/docs/consumer.adoc
+++ b/docs/consumer.adoc
@@ -170,7 +170,7 @@ public FormValidation doCheckCredentialsId(
   if (value.startsWith("${") && value.endsWith("}")) { // <5>
     return FormValidation.warning("Cannot validate expression based credentials");
   }
-  if (CredentialsProvider.listCredentials( // <6>
+  if (CredentialsProvider.listCredentialsInItem( // <6>
     ...,
     CredentialsMatchers.withId(value) // <6>
   ).isEmpty()) {
@@ -187,29 +187,26 @@ Better yet would be to try and ping the remote service anonymously and report su
 _You may want to cache the check result for a short time-span if the remote service has rate limits on anonymous access._
 <5> If you have not enabled credentials parameter expressions on the select control then you do not need this test.
 <6> This example checks that the credentials exist, but does not use them to connect.
-Alternatively `CredentialsMatchers.firstOrNull(CredentialsProvider.lookupCredentials(...), withId(value))` can be used to retrieve the credentials, a `null` return value would indicate that the error that they cannot be found, while the non-`null` return value could be used to validate the credentials against the remote service.
+Alternatively `CredentialsMatchers.firstOrNull(CredentialsProvider.lookupCredentialsInItem(...), withId(value))` can be used to retrieve the credentials, a `null` return value would indicate that the error that they cannot be found, while the non-`null` return value could be used to validate the credentials against the remote service.
 _You may want to cache the check result for a short time-span if the remote service has rate limits._
 
 === Listing available credentials matching some specific set of criteria
 
-We use the `CredentialsProvider.listCredentials()` overloads to list credentials.
-An external credentials provider may be recording usage of the credential and as such the `listCredentials` methods are supposed to not access the secret information and hence should not trigger such usage records.
+We use the `CredentialsProvider.listCredentialsInItem()` or `CredentialsProvider.listCredentialsInItemGroup()` methods to list credentials.
+An external credentials provider may be recording usage of the credential and as such the `listCredentialsInItem`/`listCredentialsInItemGroup` methods are supposed to not access the secret information and hence should not trigger such usage records.
 
 [TIP]
 ====
-If you are listing available credentials in order to populate a drop-down list, then `StandardListBoxModel.includeMatchingAs()` may be a more convenient way to call `CredentialsProvider.listCredentials()`
+If you are listing available credentials in order to populate a drop-down list, then `StandardListBoxModel.includeMatchingAs()` may be a more convenient way to call `CredentialsProvider.listCredentialsInItem()`/`CredentialsProvider.listCredentialsInItemGroup()`
 ====
-
-There are currently two overloads, one taking `Item` as the context and the other taking `ItemGroup` as the context, the other parameters are otherwise identical.
-
-NOTE: A current RFE https://issues.jenkins-ci.org/browse/JENKINS-39324[JENKINS-39324] is looking to replace overloaded methods with a single method taking the more generic `ModelObject`.
 
 The parameters are:
 
 `type`::
 The type of credentials to list.
 
-`item` or `itemGroup`::
+`item` (when using `CredentialsProvider.listCredentialsInItem`)::
+`itemGroup` (when using `CredentialsProvider.listCredentialsInItemGroup`)::
 The context within which to list available credentials.
 
 `authentication`::
@@ -227,12 +224,12 @@ Here are some examples of usage:
 +
 [source,java]
 ----
-CredentialsProvider.listCredentials(
+CredentialsProvider.listCredentialsInItem(
     StandardUsernamePasswordCredentials.class, // <1>
     job, // <2>
     job instanceof Queue.Task // <3>
-      ? Tasks.getAuthenticationOf((Queue.Task)job)) // <4>
-      : ACL.SYSTEM, // <5>
+      ? Tasks.getAuthenticationOf2((Queue.Task)job)) // <4>
+      : ACL.SYSTEM2, // <5>
     URIRequirementBuilder.fromUri(scmUrl), // <6>
     null // <7>
 );
@@ -244,7 +241,7 @@ We need `UsernamePasswordCredentials` to ensure that they are username and passw
 <3> For almost all implementations of `Job`, this will be `true`.
 (Note: https://plugins.jenkins.io/external-monitor-job[external jobs] do *not* implement `Queue.Task`)
 <4> This is important, we must use the authentication that the job is likely to run as.
-<5> If not a `Queue.Task` then use `ACL.SYSTEM`
+<5> If not a `Queue.Task` then use `ACL.SYSTEM2`
 <6> We use the requirements builder most idiomatically appropriate to our use case.
 In most cases, unless `URIRequirementBuilder` can be used to construct at least some domain requirements.
 <7> We do not have any additional requirements to place, so we can specify `null` for the matcher.
@@ -253,10 +250,10 @@ In most cases, unless `URIRequirementBuilder` can be used to construct at least 
 +
 [source,java]
 ----
-CredentialsProvider.listCredentials(
+CredentialsProvider.listCredentialsInItem(
     StandardUsernamePasswordCredentials.class,
     job,
-    Jenkins.getAuthentication(), // <1>
+    Jenkins.getAuthentication2(), // <1>
     URIRequirementBuilder.fromUri(scmUrl),
     null
 )
@@ -267,12 +264,12 @@ CredentialsProvider.listCredentials(
 +
 [source,java]
 ----
-CredentialsProvider.listCredentials(
+CredentialsProvider.listCredentialsInItem(
     StandardCredentials.class, // <1>
     job,
     job instanceof Queue.Task
-      ? Tasks.getAuthenticationOf((Queue.Task)job))
-      : ACL.SYSTEM,
+      ? Tasks.getAuthenticationOf2((Queue.Task)job))
+      : ACL.SYSTEM2,
     URIRequirementBuilder.fromUri(issueTrackerUrl),
     AuthenticationTokens.matcher(IssueTrackerAuthentication.class) // <2>
 )
@@ -288,10 +285,10 @@ Alternatively, more complex conversion contexts can be handled with `Authenticat
 +
 [source,java]
 ----
-CredentialsProvider.listCredentials(
+CredentialsProvider.listCredentialsInItem(
     StandardCredentials.class, // <1>
     job,
-    Jenkins.getAuthentication(), // <2>
+    Jenkins.getAuthentication2(), // <2>
     URIRequirementBuilder.fromUri(loadBalancerUrl),
     CredentialsMatchers.allOf(
       AuthenticationTokens.matcher(LoadBalancerAuthentication.class),
@@ -313,10 +310,10 @@ This drop down list would typically be displayed from one of the _Manage Jenkins
 +
 [source,java]
 ----
-CredentialsProvider.listCredentials(
+CredentialsProvider.listCredentialsInItemGroup(
     StandardUsernameCredentials.class, // <1>
     Jenkins.get(), // <2>
-    ACL.SYSTEM, // <2>
+    ACL.SYSTEM2, // <2>
     URIRequirementBuilder.fromUri(scmUrl),
     AuthenticationTokens.matcher(MySCMAuthentication.class) // <1>
 )
@@ -324,7 +321,7 @@ CredentialsProvider.listCredentials(
 <1> For this SCM, management of post commit hooks requires authentication that has specified a username, so even though there are other authentication mechanisms supported by `AuthenticationTokens.matcher(...)` we limit at the type level as that reduces the response that needs to be filtered.
 The alternative would have been a matcher that combined `CredentialsMatchers.instanceOf(StandardUsernameCredentials.class)` but this reduces the ability of an external credentials provider to filter the query on the remote side.
 <2> We are doing this operation outside of the context of a single job, rather this is being performed on behalf of the entire Jenkins instance.
-Thus we should be performing this as `ACL.SYSTEM` and in the context of `Jenkins.get()`.
+Thus we should be performing this as `ACL.SYSTEM2` and in the context of `Jenkins.get()`.
 This has the additional benefit that the admin can restrict the high permission hook management credentials to `CredentialsScope.SYSTEM` which will prevent access by jobs.
 
 === Persist a reference to a specific credential instance
@@ -382,24 +379,24 @@ If we have a job, "foobar", and we configure a credentials parameter on that job
 
 If you are working outside the context of a `Run` then you will not have to deal with the complexities of credentials expressions.
 
-In most cases the retrieval will just be a call to one of the `CredentialsProvider.lookupCredentials(...)` wrapped within `CredentialsMatchers.firstOrNull(..., CredentialsMatchers.withId(...))`, for example:
+In most cases the retrieval will just be a call to one of the `CredentialsProvider.lookupCredentialsInItem(...)`/`CredentialsProvider.lookupCredentialsInItemGroup(...)` wrapped within `CredentialsMatchers.firstOrNull(..., CredentialsMatchers.withId(...))`, for example:
 
 [source,java]
 ----
 StandardCredentials c = CredentialsMatchers.firstOrNull(
-  CredentialsProvider.lookupCredentials(
+  CredentialsProvider.lookupCredentialsInItem(
     StandardCredentials.class, // <1>
     job, // <1>
     job instanceof Queue.Task // <1>
       ? Tasks.getAuthenticationOf((Queue.Task)job))
-      : ACL.SYSTEM,
+      : ACL.SYSTEM2,
     URIRequirementBuilder.fromUri(...) // <1>
   ),
   CredentialsMatchers.withId(credentialsId) // <2>
 );
 ----
-<1> These should be the same as your call to `CredentialsProvider.listCredentials(...)`/`StandardListBoxModel.includeMatchingAs(...)` in order to ensure that we get the same credential instance back.
-<2> If you had additional `CredentialsMatcher` expressions in your call to `CredentialsProvider.listCredentials(...)`/`StandardListBoxModel.includeMatchingAs(...)` then you should merge them here with a `CredentialsMatchers.allOf(...)`
+<1> These should be the same as your call to `CredentialsProvider.listCredentialsInItem(...)`/`CredentialsProvider.listCredentialsInItemGroup(...)`/`StandardListBoxModel.includeMatchingAs(...)` in order to ensure that we get the same credential instance back.
+<2> If you had additional `CredentialsMatcher` expressions in your call to `CredentialsProvider.listCredentialsInItem(...)`/`CredentialsProvider.listCredentialsInItemGroup(...)`/`StandardListBoxModel.includeMatchingAs(...)` then you should merge them here with a `CredentialsMatchers.allOf(...)`
 
 Once you have retrieved a non-null credentials instance, all non-secret properties can be assumed as eager-fetch immutable.
 
@@ -416,12 +413,12 @@ The recommended way to use a credential is through the https://plugins.jenkins.i
 [source,java]
 ----
 StandardCredentials c = CredentialsMatchers.firstOrNull( // <1>
-    CredentialsProvider.listCredentials(
+    CredentialsProvider.listCredentialsInItem(
       StandardCredentials.class,
       job,
       job instanceof Queue.Task
-        ? Tasks.getAuthenticationOf((Queue.Task)job))
-        : ACL.SYSTEM,
+        ? Tasks.getAuthenticationOf2((Queue.Task)job))
+        : ACL.SYSTEM2,
       URIRequirementBuilder.fromUri(issueTrackerUrl)
     ),
     CredentialsMatchers.allOf(
@@ -461,12 +458,12 @@ IssueTrackerAuthentication auth = AuthenticationTokens.convert(
   CredentialsProvider.track(
     job,
     CredentialsMatchers.firstOrNull(
-      CredentialsProvider.listCredentials(
+      CredentialsProvider.listCredentialsInItem(
         StandardCredentials.class,
         job,
         job instanceof Queue.Task
-          ? Tasks.getAuthenticationOf((Queue.Task)job))
-          : ACL.SYSTEM,
+          ? Tasks.getAuthenticationOf2((Queue.Task)job))
+          : ACL.SYSTEM2,
         URIRequirementBuilder.fromUri(issueTrackerUrl)
       ),
       CredentialsMatchers.allOf(

--- a/docs/implementation.adoc
+++ b/docs/implementation.adoc
@@ -742,9 +742,9 @@ If you have implemented that check before creating the proxy then you could be m
 <2> Any consumer plugin that is transferring a credential to another JVM is supposed to call `CredentialsProvider.snapshot(credential)` and send the return value.
 The `CredentialsSnapshotTaker` is supposed to fetch the secret as part of the snapshotting, so a proper consumer will never be at risk of this `IOException`.
 
-* The `CredentialsProvider.getCredentials(...)` methods should instantiate the proxies, so these methods will operate from the cache while initiate background refresh. Where the cache is a miss or where the cache is stale, a short term block is acceptable.
+* The `CredentialsProvider.getCredentialsInItem(...)` / `CredentialsProvider.getCredentialsInItemGroup(...)` methods should instantiate the proxies, so these methods will operate from the cache while initiate background refresh. Where the cache is a miss or where the cache is stale, a short term block is acceptable.
 
-* The `CredentialsProvider.getCredentialIds(...)` methods are used to list credentials for drop-down list population, so these methods should use a live request with a fall-back to the cache where the live request takes too long.
+* The `CredentialsProvider.getCredentialIdsInItem(...)` / `CredentialsProvider.getCredentialIdsInItemGroup(...)` methods are used to list credentials for drop-down list population, so these methods should use a live request with a fall-back to the cache where the live request takes too long.
 
 [NOTE]
 ====
@@ -758,6 +758,6 @@ The main work in an implementation will be the mapping to `CredentialStore` inst
 +
 [NOTE]
 ====
-Technically, the "read-only, implicitly exposed" style credentials provider implementation does not need to interact with the `CredentialsStore` portion of the API as it can expose credentials directly using just the `CredentialsProvider.getCredentials(...)` and `CredentialsProvider.getCredentialIds(...)`, however, implementing the `CredentialsStore` contract is required in order for the credentials to be visible to users via the Credentials side action on the different Jenkins context objects.
+Technically, the "read-only, implicitly exposed" style credentials provider implementation does not need to interact with the `CredentialsStore` portion of the API as it can expose credentials directly using just the `CredentialsProvider.getCredentialsInItem(...)`/`CredentialsProvider.getCredentialsInItemGroup(...)` and `CredentialsProvider.getCredentialIdsInItem(...)`/`CredentialsProvider.getCredentialIdsInItemGroup(...)`, however, implementing the `CredentialsStore` contract is required in order for the credentials to be visible to users via the Credentials side action on the different Jenkins context objects.
 ====
 * A "read-write, implicitly exposed" style implementation will need to semi-dynamically create `CredentialsStore` instances for each context in order to integrate with the Jenkins credentials management UI.

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsParameterDefinition.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsParameterDefinition.java
@@ -17,13 +17,13 @@ import java.util.List;
 import java.util.Set;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-import org.acegisecurity.Authentication;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
+import org.springframework.security.core.Authentication;
 
 /**
  * A {@link ParameterDefinition} for a parameter that supplies a {@link Credentials}.
@@ -173,7 +173,7 @@ public class CredentialsParameterDefinition extends SimpleParameterDefinition {
             final StandardListBoxModel result = new StandardListBoxModel();
             result.includeEmptyValue();
             if (acl.hasPermission(CredentialsProvider.USE_ITEM)) {
-                result.includeAs(CredentialsProvider.getDefaultAuthenticationOf(context), context, typeClass, domainRequirements);
+                result.includeAs(CredentialsProvider.getDefaultAuthenticationOf2(context), context, typeClass, domainRequirements);
             }
             return result;
         }
@@ -185,9 +185,9 @@ public class CredentialsParameterDefinition extends SimpleParameterDefinition {
                                                      @QueryParameter boolean includeUser) {
             Jenkins jenkins = Jenkins.get();
             final ACL acl = context == null ? jenkins.getACL() : context.getACL();
-            final Authentication authentication = Jenkins.getAuthentication();
-            final Authentication itemAuthentication = CredentialsProvider.getDefaultAuthenticationOf(context);
-            final boolean isSystem = ACL.SYSTEM.equals(authentication);
+            final Authentication authentication = Jenkins.getAuthentication2();
+            final Authentication itemAuthentication = CredentialsProvider.getDefaultAuthenticationOf2(context);
+            final boolean isSystem = ACL.SYSTEM2.equals(authentication);
             final Class<? extends StandardCredentials> typeClass = decodeType(credentialType);
             final List<DomainRequirement> domainRequirements = Collections.emptyList();
             final StandardListBoxModel result = new StandardListBoxModel();

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsParameterValue.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsParameterValue.java
@@ -101,12 +101,12 @@ public class CredentialsParameterValue extends ParameterValue {
         final boolean isSystem = ACL.SYSTEM2.equals(authentication);
         if (!isSystem && run.getParent().hasPermission(CredentialsProvider.USE_OWN)) {
             candidates.addAll(CredentialsProvider
-                    .lookupCredentials2(type, run.getParent(), authentication, domainRequirements));
+                    .lookupCredentialsInItem(type, run.getParent(), authentication, domainRequirements));
         }
         if (run.getParent().hasPermission(CredentialsProvider.USE_ITEM) || isSystem
                 || isDefaultValue) {
             candidates.addAll(
-                    CredentialsProvider.lookupCredentials2(type, run.getParent(), ACL.SYSTEM2, domainRequirements));
+                    CredentialsProvider.lookupCredentialsInItem(type, run.getParent(), ACL.SYSTEM2, domainRequirements));
         }
         return CredentialsMatchers.firstOrNull(candidates, CredentialsMatchers.withId(value));
     }
@@ -120,13 +120,13 @@ public class CredentialsParameterValue extends ParameterValue {
             throw new IllegalStateException("Should only be called from value.jelly");
         }
         StandardCredentials c = CredentialsMatchers.firstOrNull(
-                CredentialsProvider.lookupCredentials2(StandardCredentials.class, run.getParent(), ACL.SYSTEM2,
+                CredentialsProvider.lookupCredentialsInItem(StandardCredentials.class, run.getParent(), ACL.SYSTEM2,
                         Collections.emptyList()), CredentialsMatchers.withId(value));
         if (c != null) {
             return CredentialsNameProvider.name(c);
         }
         c = CredentialsMatchers.firstOrNull(
-                CredentialsProvider.lookupCredentials2(StandardCredentials.class, run.getParent(),
+                CredentialsProvider.lookupCredentialsInItem(StandardCredentials.class, run.getParent(),
                         Jenkins.getAuthentication2(),
                         Collections.emptyList()), CredentialsMatchers.withId(value));
         if (c != null) {
@@ -144,13 +144,13 @@ public class CredentialsParameterValue extends ParameterValue {
             throw new IllegalStateException("Should only be called from value.jelly");
         }
         StandardCredentials c = CredentialsMatchers.firstOrNull(
-                CredentialsProvider.lookupCredentials2(StandardCredentials.class, run.getParent(), ACL.SYSTEM2,
+                CredentialsProvider.lookupCredentialsInItem(StandardCredentials.class, run.getParent(), ACL.SYSTEM2,
                         Collections.emptyList()), CredentialsMatchers.withId(value));
         if (c != null) {
             return c.getDescriptor().getIconClassName();
         }
         c = CredentialsMatchers.firstOrNull(
-                CredentialsProvider.lookupCredentials2(StandardCredentials.class, run.getParent(),
+                CredentialsProvider.lookupCredentialsInItem(StandardCredentials.class, run.getParent(),
                         Jenkins.getAuthentication2(),
                         Collections.emptyList()), CredentialsMatchers.withId(value));
         if (c != null) {

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsParameterValue.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsParameterValue.java
@@ -101,12 +101,12 @@ public class CredentialsParameterValue extends ParameterValue {
         final boolean isSystem = ACL.SYSTEM2.equals(authentication);
         if (!isSystem && run.getParent().hasPermission(CredentialsProvider.USE_OWN)) {
             candidates.addAll(CredentialsProvider
-                    .lookupCredentials(type, run.getParent(), authentication, domainRequirements));
+                    .lookupCredentials2(type, run.getParent(), authentication, domainRequirements));
         }
         if (run.getParent().hasPermission(CredentialsProvider.USE_ITEM) || isSystem
                 || isDefaultValue) {
             candidates.addAll(
-                    CredentialsProvider.lookupCredentials(type, run.getParent(), ACL.SYSTEM2, domainRequirements));
+                    CredentialsProvider.lookupCredentials2(type, run.getParent(), ACL.SYSTEM2, domainRequirements));
         }
         return CredentialsMatchers.firstOrNull(candidates, CredentialsMatchers.withId(value));
     }
@@ -120,13 +120,13 @@ public class CredentialsParameterValue extends ParameterValue {
             throw new IllegalStateException("Should only be called from value.jelly");
         }
         StandardCredentials c = CredentialsMatchers.firstOrNull(
-                CredentialsProvider.lookupCredentials(StandardCredentials.class, run.getParent(), ACL.SYSTEM2,
+                CredentialsProvider.lookupCredentials2(StandardCredentials.class, run.getParent(), ACL.SYSTEM2,
                         Collections.emptyList()), CredentialsMatchers.withId(value));
         if (c != null) {
             return CredentialsNameProvider.name(c);
         }
         c = CredentialsMatchers.firstOrNull(
-                CredentialsProvider.lookupCredentials(StandardCredentials.class, run.getParent(),
+                CredentialsProvider.lookupCredentials2(StandardCredentials.class, run.getParent(),
                         Jenkins.getAuthentication2(),
                         Collections.emptyList()), CredentialsMatchers.withId(value));
         if (c != null) {
@@ -144,13 +144,13 @@ public class CredentialsParameterValue extends ParameterValue {
             throw new IllegalStateException("Should only be called from value.jelly");
         }
         StandardCredentials c = CredentialsMatchers.firstOrNull(
-                CredentialsProvider.lookupCredentials(StandardCredentials.class, run.getParent(), ACL.SYSTEM2,
+                CredentialsProvider.lookupCredentials2(StandardCredentials.class, run.getParent(), ACL.SYSTEM2,
                         Collections.emptyList()), CredentialsMatchers.withId(value));
         if (c != null) {
             return c.getDescriptor().getIconClassName();
         }
         c = CredentialsMatchers.firstOrNull(
-                CredentialsProvider.lookupCredentials(StandardCredentials.class, run.getParent(),
+                CredentialsProvider.lookupCredentials2(StandardCredentials.class, run.getParent(),
                         Jenkins.getAuthentication2(),
                         Collections.emptyList()), CredentialsMatchers.withId(value));
         if (c != null) {

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsParameterValue.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsParameterValue.java
@@ -21,10 +21,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import jenkins.model.Jenkins;
-import org.acegisecurity.Authentication;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.Stapler;
+import org.springframework.security.core.Authentication;
 
 /**
  * A {@link ParameterValue} produced from a {@link CredentialsParameterDefinition}.
@@ -89,16 +89,16 @@ public class CredentialsParameterValue extends ParameterValue {
 
     public <C extends IdCredentials> C lookupCredentials(@NonNull Class<C> type, @NonNull Run run,
                                                          List<DomainRequirement> domainRequirements) {
-        Authentication authentication = Jenkins.getAuthentication();
+        Authentication authentication = Jenkins.getAuthentication2();
         final Executor executor = run.getExecutor();
         if (executor != null) {
             final WorkUnit workUnit = executor.getCurrentWorkUnit();
             if (workUnit != null) {
-                authentication = workUnit.context.item.authenticate();
+                authentication = workUnit.context.item.authenticate2();
             }
         }
         List<C> candidates = new ArrayList<>();
-        final boolean isSystem = ACL.SYSTEM.equals(authentication);
+        final boolean isSystem = ACL.SYSTEM2.equals(authentication);
         if (!isSystem && run.getParent().hasPermission(CredentialsProvider.USE_OWN)) {
             candidates.addAll(CredentialsProvider
                     .lookupCredentials(type, run.getParent(), authentication, domainRequirements));
@@ -106,7 +106,7 @@ public class CredentialsParameterValue extends ParameterValue {
         if (run.getParent().hasPermission(CredentialsProvider.USE_ITEM) || isSystem
                 || isDefaultValue) {
             candidates.addAll(
-                    CredentialsProvider.lookupCredentials(type, run.getParent(), ACL.SYSTEM, domainRequirements));
+                    CredentialsProvider.lookupCredentials(type, run.getParent(), ACL.SYSTEM2, domainRequirements));
         }
         return CredentialsMatchers.firstOrNull(candidates, CredentialsMatchers.withId(value));
     }
@@ -120,14 +120,14 @@ public class CredentialsParameterValue extends ParameterValue {
             throw new IllegalStateException("Should only be called from value.jelly");
         }
         StandardCredentials c = CredentialsMatchers.firstOrNull(
-                CredentialsProvider.lookupCredentials(StandardCredentials.class, run.getParent(), ACL.SYSTEM,
+                CredentialsProvider.lookupCredentials(StandardCredentials.class, run.getParent(), ACL.SYSTEM2,
                         Collections.emptyList()), CredentialsMatchers.withId(value));
         if (c != null) {
             return CredentialsNameProvider.name(c);
         }
         c = CredentialsMatchers.firstOrNull(
                 CredentialsProvider.lookupCredentials(StandardCredentials.class, run.getParent(),
-                        Jenkins.getAuthentication(),
+                        Jenkins.getAuthentication2(),
                         Collections.emptyList()), CredentialsMatchers.withId(value));
         if (c != null) {
             return CredentialsNameProvider.name(c);
@@ -144,14 +144,14 @@ public class CredentialsParameterValue extends ParameterValue {
             throw new IllegalStateException("Should only be called from value.jelly");
         }
         StandardCredentials c = CredentialsMatchers.firstOrNull(
-                CredentialsProvider.lookupCredentials(StandardCredentials.class, run.getParent(), ACL.SYSTEM,
+                CredentialsProvider.lookupCredentials(StandardCredentials.class, run.getParent(), ACL.SYSTEM2,
                         Collections.emptyList()), CredentialsMatchers.withId(value));
         if (c != null) {
             return c.getDescriptor().getIconClassName();
         }
         c = CredentialsMatchers.firstOrNull(
                 CredentialsProvider.lookupCredentials(StandardCredentials.class, run.getParent(),
-                        Jenkins.getAuthentication(),
+                        Jenkins.getAuthentication2(),
                         Collections.emptyList()), CredentialsMatchers.withId(value));
         if (c != null) {
             return c.getDescriptor().getIconClassName();
@@ -167,7 +167,7 @@ public class CredentialsParameterValue extends ParameterValue {
         if (run == null) {
             throw new IllegalStateException("Should only be called from value.jelly");
         }
-        try (ACLContext ctx = ACL.as(ACL.SYSTEM)) {
+        try (ACLContext ignored = ACL.as2(ACL.SYSTEM2)) {
             for (CredentialsStore store : CredentialsProvider.lookupStores(run.getParent())) {
                 String url = url(store);
                 if (url != null) {

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
@@ -290,7 +290,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * @deprecated use {@link #lookupCredentials2(Class, ItemGroup, Authentication, List)} instead.
+     * @deprecated use {@link #lookupCredentials2(Class, ItemGroup, Authentication)} instead.
      */
     @Deprecated
     @NonNull
@@ -302,7 +302,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * @deprecated use {@link #lookupCredentials2(Class, Item, Authentication, List)} instead.
+     * @deprecated use {@link #lookupCredentials2(Class, Item, Authentication)} instead.
      */
     @Deprecated
     @NonNull
@@ -314,7 +314,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * @deprecated Use {@link #lookupCredentials2(Class, ItemGroup, Authentication, List)} or {@link #lookupCredentials2(Class, ItemGroup, Authentication)}.
+     * @deprecated Use {@link #lookupCredentials2(Class, ItemGroup, Authentication)} or {@link #lookupCredentials2(Class, ItemGroup, Authentication, List)}.
      */
     @Deprecated
     @NonNull
@@ -482,7 +482,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * @deprecated use {@link #lookupCredentials2(Class, ItemGroup, Authentication, List)} or {@link #lookupCredentials2(Class, ItemGroup, Authentication)}.
+     * @deprecated use {@link #lookupCredentials2(Class, ItemGroup, Authentication)} or {@link #lookupCredentials2(Class, ItemGroup, Authentication, List)}.
      */
     @Deprecated
     @NonNull
@@ -1144,14 +1144,6 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * Returns the credentials provided by this provider which are available to the specified {@link Authentication}
-     * for items in the specified {@link ItemGroup}
-     *
-     * @param type           the type of credentials to return.
-     * @param itemGroup      the item group (if {@code null} assume {@link Jenkins#get()}.
-     * @param authentication the authentication (if {@code null} assume {@link ACL#SYSTEM}.
-     * @param <C>            the credentials type.
-     * @return the list of credentials.
      * @deprecated use {@link #getCredentials2(Class, Item, Authentication)} instead.
      */
     @NonNull
@@ -1171,6 +1163,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @param authentication the authentication (if {@code null} assume {@link ACL#SYSTEM2}.
      * @param <C>            the credentials type.
      * @return the list of credentials.
+     * @since TODO
      */
     @NonNull
     @SuppressWarnings("deprecation")
@@ -1184,20 +1177,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * Returns the credentials provided by this provider which are available to the specified {@link Authentication}
-     * for items in the specified {@link ItemGroup} and are appropriate for the specified {@link com.cloudbees
-     * .plugins.credentials.domains.DomainRequirement}s.
-     *
-     * @param type               the type of credentials to return.
-     * @param itemGroup          the item group (if {@code null} assume {@link Jenkins#get()}.
-     * @param authentication     the authentication (if {@code null} assume {@link ACL#SYSTEM}.
-     * @param domainRequirements the credential domains to match (if the {@link CredentialsProvider} does not support
-     *                           {@link DomainRequirement}s then it should
-     *                           assume the match is true).
-     * @param <C>                the credentials type.
-     * @return the list of credentials.
      * @deprecated use {@link #getCredentials2(Class, Item, Authentication, List)} instead.
-     * @since 1.5
      */
     @Deprecated
     @NonNull
@@ -1222,7 +1202,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      *                           assume the match is true).
      * @param <C>                the credentials type.
      * @return the list of credentials.
-     * @since 1.5
+     * @since TODO
      */
     @NonNull
     @SuppressWarnings("deprecation")

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
@@ -122,8 +122,8 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
          */
         @NonNull
         @Override
-        public <C extends Credentials> List<C> getCredentials2ItemGroup(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
-                                                                        @Nullable Authentication authentication) {
+        public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
+                                                               @Nullable Authentication authentication) {
             return Collections.emptyList();
         }
     };
@@ -243,8 +243,8 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * @deprecated use {@link #lookupCredentials(Class, Item, Authentication, List)}
-     * or {@link #lookupCredentials(Class, ItemGroup, Authentication, List)}
+     * @deprecated use {@link #lookupCredentials2(Class, Item, Authentication, List)}
+     * or {@link #lookupCredentials2(Class, ItemGroup, Authentication, List)}
      */
     @Deprecated
     @NonNull
@@ -254,8 +254,8 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * @deprecated use {@link #lookupCredentials(Class, Item, Authentication, List)},
-     * {@link #lookupCredentials(Class, ItemGroup, Authentication, List)}
+     * @deprecated use {@link #lookupCredentials2(Class, Item, Authentication, List)},
+     * {@link #lookupCredentials2(Class, ItemGroup, Authentication, List)}
      */
     @Deprecated
     @NonNull
@@ -266,7 +266,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * @deprecated use {@link #lookupCredentials(Class, Item, Authentication, List)} instead.
+     * @deprecated use {@link #lookupCredentials2(Class, Item, Authentication, List)} instead.
      */
     @Deprecated
     @NonNull
@@ -279,7 +279,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * @deprecated use {@link #lookupCredentials(Class, ItemGroup, Authentication, List)} instead.
+     * @deprecated use {@link #lookupCredentials2(Class, ItemGroup, Authentication, List)} instead.
      */
     @Deprecated
     @NonNull
@@ -290,7 +290,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * @deprecated use {@link #lookupCredentials(Class, ItemGroup, Authentication, List)} instead.
+     * @deprecated use {@link #lookupCredentials2(Class, ItemGroup, Authentication, List)} instead.
      */
     @Deprecated
     @NonNull
@@ -298,11 +298,11 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     public static <C extends Credentials> List<C> lookupCredentials(@NonNull Class<C> type,
                                                                     @Nullable ItemGroup itemGroup,
                                                                     @Nullable org.acegisecurity.Authentication authentication) {
-        return lookupCredentials(type, itemGroup, authentication == null ? null : authentication.toSpring(), Collections.emptyList());
+        return lookupCredentials2(type, itemGroup, authentication == null ? null : authentication.toSpring(), Collections.emptyList());
     }
 
     /**
-     * @deprecated use {@link #lookupCredentials(Class, Item, Authentication, List)} instead.
+     * @deprecated use {@link #lookupCredentials2(Class, Item, Authentication, List)} instead.
      */
     @Deprecated
     @NonNull
@@ -310,11 +310,11 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     public static <C extends Credentials> List<C> lookupCredentials(@NonNull Class<C> type,
                                                                     @Nullable Item item,
                                                                     @Nullable org.acegisecurity.Authentication authentication) {
-        return lookupCredentials(type, item, authentication == null ? null : authentication.toSpring(), Collections.emptyList());
+        return lookupCredentials2(type, item, authentication == null ? null : authentication.toSpring(), Collections.emptyList());
     }
 
     /**
-     * @deprecated Use {@link #lookupCredentials(Class, ItemGroup, Authentication, List)} or {@link #lookupCredentials(Class, ItemGroup, Authentication)}.
+     * @deprecated Use {@link #lookupCredentials2(Class, ItemGroup, Authentication, List)} or {@link #lookupCredentials2(Class, ItemGroup, Authentication)}.
      */
     @Deprecated
     @NonNull
@@ -323,7 +323,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                                     @Nullable ItemGroup itemGroup,
                                                                     @Nullable org.acegisecurity.Authentication authentication,
                                                                     @Nullable DomainRequirement... domainRequirements) {
-        return lookupCredentials(type, itemGroup, authentication == null ? null : authentication.toSpring(), Arrays.asList(domainRequirements));
+        return lookupCredentials2(type, itemGroup, authentication == null ? null : authentication.toSpring(), Arrays.asList(domainRequirements));
     }
 
     /**
@@ -339,14 +339,14 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      */
     @NonNull
     @SuppressWarnings({"unchecked", "unused"}) // API entry point for consumers
-    public static <C extends Credentials> List<C> lookupCredentials(@NonNull Class<C> type,
-                                                                    @Nullable ItemGroup itemGroup,
-                                                                    @Nullable Authentication authentication) {
-        return lookupCredentials(type, itemGroup, authentication, List.of());
+    public static <C extends Credentials> List<C> lookupCredentials2(@NonNull Class<C> type,
+                                                                     @Nullable ItemGroup itemGroup,
+                                                                     @Nullable Authentication authentication) {
+        return lookupCredentials2(type, itemGroup, authentication, List.of());
     }
 
     /**
-     * @deprecated Use {@link #lookupCredentials(Class, ItemGroup, Authentication, List)} instead.
+     * @deprecated Use {@link #lookupCredentials2(Class, ItemGroup, Authentication, List)} instead.
      */
     @NonNull
     @SuppressWarnings({"unchecked", "unused"}) // API entry point for consumers
@@ -355,7 +355,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                                     @Nullable ItemGroup itemGroup,
                                                                     @Nullable org.acegisecurity.Authentication authentication,
                                                                     @Nullable List<DomainRequirement> domainRequirements) {
-        return lookupCredentials(type, itemGroup, authentication == null ? null : authentication.toSpring(), domainRequirements);
+        return lookupCredentials2(type, itemGroup, authentication == null ? null : authentication.toSpring(), domainRequirements);
     }
 
     /**
@@ -372,10 +372,10 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      */
     @NonNull
     @SuppressWarnings({"unchecked", "unused"}) // API entry point for consumers
-    public static <C extends Credentials> List<C> lookupCredentials(@NonNull Class<C> type,
-                                                                    @Nullable ItemGroup itemGroup,
-                                                                    @Nullable Authentication authentication,
-                                                                    @Nullable List<DomainRequirement> domainRequirements) {
+    public static <C extends Credentials> List<C> lookupCredentials2(@NonNull Class<C> type,
+                                                                     @Nullable ItemGroup itemGroup,
+                                                                     @Nullable Authentication authentication,
+                                                                     @Nullable List<DomainRequirement> domainRequirements) {
         Objects.requireNonNull(type);
         Jenkins jenkins = Jenkins.get();
         itemGroup = itemGroup == null ? jenkins : itemGroup;
@@ -387,7 +387,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
             LOGGER.log(Level.FINE, "Resolving legacy credentials of type {0} with resolver {1}",
                     new Object[]{type, resolver});
             final List<Credentials> originals =
-                    lookupCredentials(resolver.getFromClass(), itemGroup, authentication, domainRequirements);
+                    lookupCredentials2(resolver.getFromClass(), itemGroup, authentication, domainRequirements);
             LOGGER.log(Level.FINE, "Original credentials for resolving: {0}", originals);
             return resolver.resolve(originals);
         }
@@ -396,7 +396,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
         for (CredentialsProvider provider : all()) {
             if (provider.isEnabled(itemGroup) && provider.isApplicable(type)) {
                 try {
-                    for (C c : provider.getCredentials2ItemGroup(type, itemGroup, authentication, domainRequirements)) {
+                    for (C c : provider.getCredentials2(type, itemGroup, authentication, domainRequirements)) {
                         if (!(c instanceof IdCredentials) || ids.add(((IdCredentials) c).getId())) {
                             // if IdCredentials, only add if we haven't added already
                             // if not IdCredentials, always add
@@ -413,7 +413,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * @deprecated Use {@link #listCredentials(Class, ItemGroup, Authentication, List, CredentialsMatcher)} instead.
+     * @deprecated Use {@link #listCredentials2(Class, ItemGroup, Authentication, List, CredentialsMatcher)} instead.
      */
     @Deprecated
     public static <C extends IdCredentials> ListBoxModel listCredentials(@NonNull Class<C> type,
@@ -422,7 +422,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                                          @Nullable List<DomainRequirement>
                                                                                  domainRequirements,
                                                                          @Nullable CredentialsMatcher matcher) {
-        return listCredentials(type, itemGroup, authentication == null ? null : authentication.toSpring(), domainRequirements, matcher);
+        return listCredentials2(type, itemGroup, authentication == null ? null : authentication.toSpring(), domainRequirements, matcher);
     }
 
     /**
@@ -439,12 +439,12 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * provided by {@link CredentialsNameProvider}.
      * @since TODO
      */
-    public static <C extends IdCredentials> ListBoxModel listCredentials(@NonNull Class<C> type,
-                                                                         @Nullable ItemGroup itemGroup,
-                                                                         @Nullable Authentication authentication,
-                                                                         @Nullable List<DomainRequirement>
+    public static <C extends IdCredentials> ListBoxModel listCredentials2(@NonNull Class<C> type,
+                                                                          @Nullable ItemGroup itemGroup,
+                                                                          @Nullable Authentication authentication,
+                                                                          @Nullable List<DomainRequirement>
                                                                                  domainRequirements,
-                                                                         @Nullable CredentialsMatcher matcher) {
+                                                                          @Nullable CredentialsMatcher matcher) {
         Objects.requireNonNull(type);
         Jenkins jenkins = Jenkins.get();
         itemGroup = itemGroup == null ? jenkins : itemGroup;
@@ -456,7 +456,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
         if (resolver != null && IdCredentials.class.isAssignableFrom(resolver.getFromClass())) {
             LOGGER.log(Level.FINE, "Listing legacy credentials of type {0} identified by resolver {1}",
                     new Object[]{type, resolver});
-            return listCredentials((Class) resolver.getFromClass(), itemGroup, authentication, domainRequirements,
+            return listCredentials2((Class) resolver.getFromClass(), itemGroup, authentication, domainRequirements,
                     matcher);
         }
         ListBoxModel result = new ListBoxModel();
@@ -464,7 +464,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
         for (CredentialsProvider provider : all()) {
             if (provider.isEnabled(itemGroup) && provider.isApplicable(type)) {
                 try {
-                    for (ListBoxModel.Option option : provider.getCredentialIds2ItemGroup(
+                    for (ListBoxModel.Option option : provider.getCredentialIds2(
                             type, itemGroup, authentication, domainRequirements, matcher)
                             ) {
                         if (ids.add(option.value)) {
@@ -482,7 +482,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * @deprecated use {@link #lookupCredentials(Class, ItemGroup, Authentication, List)} or {@link #lookupCredentials(Class, ItemGroup, Authentication)}.
+     * @deprecated use {@link #lookupCredentials2(Class, ItemGroup, Authentication, List)} or {@link #lookupCredentials2(Class, ItemGroup, Authentication)}.
      */
     @Deprecated
     @NonNull
@@ -491,7 +491,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                                     @Nullable Item item,
                                                                     @Nullable org.acegisecurity.Authentication authentication,
                                                                     DomainRequirement... domainRequirements) {
-        return lookupCredentials(type, item, authentication == null ? null : authentication.toSpring(), Arrays.asList(domainRequirements));
+        return lookupCredentials2(type, item, authentication == null ? null : authentication.toSpring(), Arrays.asList(domainRequirements));
     }
 
     /**
@@ -507,14 +507,14 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      */
     @NonNull
     @SuppressWarnings("unused") // API entry point for consumers
-    public static <C extends Credentials> List<C> lookupCredentials(@NonNull Class<C> type,
-                                                                    @Nullable Item item,
-                                                                    @Nullable Authentication authentication) {
-        return lookupCredentials(type, item, authentication, List.of());
+    public static <C extends Credentials> List<C> lookupCredentials2(@NonNull Class<C> type,
+                                                                     @Nullable Item item,
+                                                                     @Nullable Authentication authentication) {
+        return lookupCredentials2(type, item, authentication, List.of());
     }
 
     /**
-     * @deprecated use {@link #lookupCredentials(Class, Item, Authentication, List)}
+     * @deprecated use {@link #lookupCredentials2(Class, Item, Authentication, List)}
      */
     @NonNull
     @SuppressWarnings("unused") // API entry point for consumers
@@ -524,7 +524,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                                     @Nullable org.acegisecurity.Authentication authentication,
                                                                     @Nullable List<DomainRequirement>
                                                                             domainRequirements) {
-        return lookupCredentials(type, item, authentication == null ? null : authentication.toSpring(), domainRequirements);
+        return lookupCredentials2(type, item, authentication == null ? null : authentication.toSpring(), domainRequirements);
     }
 
     /**
@@ -541,17 +541,17 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      */
     @NonNull
     @SuppressWarnings("unused") // API entry point for consumers
-    public static <C extends Credentials> List<C> lookupCredentials(@NonNull Class<C> type,
-                                                                    @Nullable Item item,
-                                                                    @Nullable Authentication authentication,
-                                                                    @Nullable List<DomainRequirement>
+    public static <C extends Credentials> List<C> lookupCredentials2(@NonNull Class<C> type,
+                                                                     @Nullable Item item,
+                                                                     @Nullable Authentication authentication,
+                                                                     @Nullable List<DomainRequirement>
                                                                             domainRequirements) {
         Objects.requireNonNull(type);
         if (item == null) {
-            return lookupCredentials(type, Jenkins.get(), authentication, domainRequirements);
+            return lookupCredentials2(type, Jenkins.get(), authentication, domainRequirements);
         }
         if (item instanceof ItemGroup) {
-            return lookupCredentials(type, (ItemGroup)item, authentication, domainRequirements);
+            return lookupCredentials2(type, (ItemGroup)item, authentication, domainRequirements);
         }
         authentication = authentication == null ? ACL.SYSTEM2 : authentication;
         domainRequirements = domainRequirements
@@ -561,7 +561,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
             LOGGER.log(Level.FINE, "Resolving legacy credentials of type {0} with resolver {1}",
                     new Object[]{type, resolver});
             final List<Credentials> originals =
-                    lookupCredentials(resolver.getFromClass(), item, authentication, domainRequirements);
+                    lookupCredentials2(resolver.getFromClass(), item, authentication, domainRequirements);
             LOGGER.log(Level.FINE, "Original credentials for resolving: {0}", originals);
             return resolver.resolve(originals);
         }
@@ -570,7 +570,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
         for (CredentialsProvider provider : all()) {
             if (provider.isEnabled(item) && provider.isApplicable(type)) {
                 try {
-                    for (C c: provider.getCredentials2Item(type, item, authentication, domainRequirements)) {
+                    for (C c: provider.getCredentials2(type, item, authentication, domainRequirements)) {
                         if (!(c instanceof IdCredentials) || ids.add(((IdCredentials) c).getId())) {
                             // if IdCredentials, only add if we haven't added already
                             // if not IdCredentials, always add
@@ -587,7 +587,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * @deprecated Use {@link #listCredentials(Class, Item, Authentication, List, CredentialsMatcher)} instead.
+     * @deprecated Use {@link #listCredentials2(Class, Item, Authentication, List, CredentialsMatcher)} instead.
      */
     @NonNull
     @Deprecated
@@ -597,7 +597,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                                          @Nullable List<DomainRequirement>
                                                                                  domainRequirements,
                                                                          @Nullable CredentialsMatcher matcher) {
-        return listCredentials(type, item, authentication == null ? null : authentication.toSpring(), domainRequirements, matcher);
+        return listCredentials2(type, item, authentication == null ? null : authentication.toSpring(), domainRequirements, matcher);
     }
 
     /**
@@ -615,18 +615,18 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @since TODO
      */
     @NonNull
-    public static <C extends IdCredentials> ListBoxModel listCredentials(@NonNull Class<C> type,
-                                                                         @Nullable Item item,
-                                                                         @Nullable Authentication authentication,
-                                                                         @Nullable List<DomainRequirement>
+    public static <C extends IdCredentials> ListBoxModel listCredentials2(@NonNull Class<C> type,
+                                                                          @Nullable Item item,
+                                                                          @Nullable Authentication authentication,
+                                                                          @Nullable List<DomainRequirement>
                                                                                  domainRequirements,
-                                                                         @Nullable CredentialsMatcher matcher) {
+                                                                          @Nullable CredentialsMatcher matcher) {
         Objects.requireNonNull(type);
         if (item == null) {
-            return listCredentials(type, Jenkins.get(), authentication, domainRequirements, matcher);
+            return listCredentials2(type, Jenkins.get(), authentication, domainRequirements, matcher);
         }
         if (item instanceof ItemGroup) {
-            return listCredentials(type, (ItemGroup) item, authentication, domainRequirements, matcher);
+            return listCredentials2(type, (ItemGroup) item, authentication, domainRequirements, matcher);
         }
         authentication = authentication == null ? ACL.SYSTEM2 : authentication;
         domainRequirements = domainRequirements
@@ -635,7 +635,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
         if (resolver != null && IdCredentials.class.isAssignableFrom(resolver.getFromClass())) {
             LOGGER.log(Level.FINE, "Listing legacy credentials of type {0} identified by resolver {1}",
                     new Object[]{type, resolver});
-            return listCredentials((Class) resolver.getFromClass(), item, authentication,
+            return listCredentials2((Class) resolver.getFromClass(), item, authentication,
                     domainRequirements, matcher);
         }
         ListBoxModel result = new ListBoxModel();
@@ -643,7 +643,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
         for (CredentialsProvider provider : all()) {
             if (provider.isEnabled(item) && provider.isApplicable(type)) {
                 try {
-                    for (ListBoxModel.Option option : provider.getCredentialIds2Item(
+                    for (ListBoxModel.Option option : provider.getCredentialIds2(
                             type, item, authentication, domainRequirements, matcher)
                             ) {
                         if (ids.add(option.value)) {
@@ -929,12 +929,12 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
             Authentication runAuth = CredentialsProvider.getDefaultAuthenticationOf2(run.getParent());
             // we want the credentials available to the user the build is running as
             List<C> candidates = new ArrayList<>(
-                    CredentialsProvider.lookupCredentials(type, run.getParent(), runAuth, domainRequirements)
+                    CredentialsProvider.lookupCredentials2(type, run.getParent(), runAuth, domainRequirements)
             );
             // if that user can use the item's credentials, add those in too
             if (runAuth != ACL.SYSTEM2 && run.hasPermission2(runAuth, CredentialsProvider.USE_ITEM)) {
                 candidates.addAll(
-                        CredentialsProvider.lookupCredentials(type, run.getParent(), ACL.SYSTEM2, domainRequirements)
+                        CredentialsProvider.lookupCredentials2(type, run.getParent(), ACL.SYSTEM2, domainRequirements)
                 );
             }
             // TODO should this be calling track?
@@ -948,14 +948,14 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
             // the user triggered this job directly and they are allowed to supply their own credentials, so
             // add those into the list. We do not want to follow the chain for the user's authentication
             // though, as there is no way to limit how far the passed-through parameters can be used
-            candidates.addAll(CredentialsProvider.lookupCredentials(type, run.getParent(), a, domainRequirements));
+            candidates.addAll(CredentialsProvider.lookupCredentials2(type, run.getParent(), a, domainRequirements));
         }
         if (inputUserId != null) {
             final User inputUser = User.getById(inputUserId, false);
             if (inputUser != null) {
                 final Authentication inputAuth = inputUser.impersonate2();
                 if (run.hasPermission2(inputAuth, CredentialsProvider.USE_OWN)) {
-                    candidates.addAll(CredentialsProvider.lookupCredentials(type, run.getParent(), inputAuth, domainRequirements));
+                    candidates.addAll(CredentialsProvider.lookupCredentials2(type, run.getParent(), inputAuth, domainRequirements));
                 }
             }
         }
@@ -967,12 +967,12 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
             Authentication runAuth = CredentialsProvider.getDefaultAuthenticationOf2(run.getParent());
             // we want the credentials available to the user the build is running as
             candidates.addAll(
-                    CredentialsProvider.lookupCredentials(type, run.getParent(), runAuth, domainRequirements)
+                    CredentialsProvider.lookupCredentials2(type, run.getParent(), runAuth, domainRequirements)
             );
             // if that user can use the item's credentials, add those in too
             if (runAuth != ACL.SYSTEM2 && run.hasPermission2(runAuth, CredentialsProvider.USE_ITEM)) {
                 candidates.addAll(
-                        CredentialsProvider.lookupCredentials(type, run.getParent(), ACL.SYSTEM2, domainRequirements)
+                        CredentialsProvider.lookupCredentials2(type, run.getParent(), ACL.SYSTEM2, domainRequirements)
                 );
             }
         }
@@ -1152,14 +1152,14 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @param authentication the authentication (if {@code null} assume {@link ACL#SYSTEM}.
      * @param <C>            the credentials type.
      * @return the list of credentials.
-     * @deprecated use {@link #getCredentials2Item(Class, Item, Authentication)} instead.
+     * @deprecated use {@link #getCredentials2(Class, Item, Authentication)} instead.
      */
     @NonNull
     @Deprecated
     public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type,
                                                                    @Nullable ItemGroup itemGroup,
                                                                    @Nullable org.acegisecurity.Authentication authentication) {
-        return getCredentials2ItemGroup(type, itemGroup, authentication == null ? null : authentication.toSpring());
+        return getCredentials2(type, itemGroup, authentication == null ? null : authentication.toSpring());
     }
 
     /**
@@ -1174,9 +1174,9 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      */
     @NonNull
     @SuppressWarnings("deprecation")
-    public <C extends Credentials> List<C> getCredentials2ItemGroup(@NonNull Class<C> type,
-                                                                    @Nullable ItemGroup itemGroup,
-                                                                    @Nullable Authentication authentication) {
+    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type,
+                                                           @Nullable ItemGroup itemGroup,
+                                                           @Nullable Authentication authentication) {
         if (Util.isOverridden(CredentialsProvider.class, getClass(), "getCredentials", Class.class, ItemGroup.class, org.acegisecurity.Authentication.class)) {
             return getCredentials(type, itemGroup, authentication == null ? null : org.acegisecurity.Authentication.fromSpring(authentication));
         }
@@ -1196,7 +1196,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      *                           assume the match is true).
      * @param <C>                the credentials type.
      * @return the list of credentials.
-     * @deprecated use {@link #getCredentials2Item(Class, Item, Authentication, List)} instead.
+     * @deprecated use {@link #getCredentials2(Class, Item, Authentication, List)} instead.
      * @since 1.5
      */
     @Deprecated
@@ -1205,7 +1205,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                           @Nullable ItemGroup itemGroup,
                                                           @Nullable org.acegisecurity.Authentication authentication,
                                                           @NonNull List<DomainRequirement> domainRequirements) {
-        return getCredentials2ItemGroup(type, itemGroup, authentication == null ? null : authentication.toSpring(), domainRequirements);
+        return getCredentials2(type, itemGroup, authentication == null ? null : authentication.toSpring(), domainRequirements);
     }
 
 
@@ -1226,18 +1226,18 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      */
     @NonNull
     @SuppressWarnings("deprecation")
-    public <C extends Credentials> List<C> getCredentials2ItemGroup(@NonNull Class<C> type,
-                                                                    @Nullable ItemGroup itemGroup,
-                                                                    @Nullable Authentication authentication,
-                                                                    @NonNull List<DomainRequirement> domainRequirements) {
+    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type,
+                                                           @Nullable ItemGroup itemGroup,
+                                                           @Nullable Authentication authentication,
+                                                           @NonNull List<DomainRequirement> domainRequirements) {
         if (Util.isOverridden(CredentialsProvider.class, getClass(), "getCredentials", Class.class, ItemGroup.class, org.acegisecurity.Authentication.class, List.class)) {
             return getCredentials(type, itemGroup, authentication == null ? null : org.acegisecurity.Authentication.fromSpring(authentication), domainRequirements);
         }
-        return getCredentials2ItemGroup(type, itemGroup, authentication);
+        return getCredentials2(type, itemGroup, authentication);
     }
 
     /**
-     * @deprecated Use {@link #getCredentialIds2ItemGroup(Class, ItemGroup, Authentication, List, CredentialsMatcher)} instead.
+     * @deprecated Use {@link #getCredentialIds2(Class, ItemGroup, Authentication, List, CredentialsMatcher)} instead.
      */
     @NonNull
     @Deprecated
@@ -1247,7 +1247,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                                    @NonNull
                                                                    List<DomainRequirement> domainRequirements,
                                                                    @NonNull CredentialsMatcher matcher) {
-        return getCredentialIds2ItemGroup(type, itemGroup, authentication == null ? null : authentication.toSpring(), domainRequirements, matcher);
+        return getCredentialIds2(type, itemGroup, authentication == null ? null : authentication.toSpring(), domainRequirements, matcher);
     }
 
     /**
@@ -1256,7 +1256,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * specified {@link DomainRequirement}s.
      * <strong>NOTE:</strong> implementations are recommended to override this method if the actual secret information
      * is being stored external from Jenkins and the non-secret information can be accessed with lesser traceability
-     * requirements. The default implementation just uses {@link #getCredentials2Item(Class, Item, Authentication, List)}
+     * requirements. The default implementation just uses {@link #getCredentials2(Class, Item, Authentication, List)}
      * to build the {@link ListBoxModel}. Handling the {@link CredentialsMatcher} may require standing up a proxy
      * instance to apply the matcher against if {@link CredentialsMatchers#describe(CredentialsMatcher)} returns
      * {@code null}
@@ -1272,13 +1272,13 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @since TODO
      */
     @NonNull
-    public <C extends IdCredentials> ListBoxModel getCredentialIds2ItemGroup(@NonNull Class<C> type,
-                                                                   @Nullable ItemGroup itemGroup,
-                                                                   @Nullable Authentication authentication,
-                                                                   @NonNull
+    public <C extends IdCredentials> ListBoxModel getCredentialIds2(@NonNull Class<C> type,
+                                                                    @Nullable ItemGroup itemGroup,
+                                                                    @Nullable Authentication authentication,
+                                                                    @NonNull
                                                                            List<DomainRequirement> domainRequirements,
-                                                                   @NonNull CredentialsMatcher matcher) {
-        return getCredentials2ItemGroup(type, itemGroup, authentication, domainRequirements)
+                                                                    @NonNull CredentialsMatcher matcher) {
+        return getCredentials2(type, itemGroup, authentication, domainRequirements)
                 .stream()
                 .filter(matcher::matches)
                 .sorted(new CredentialsNameComparator())
@@ -1287,7 +1287,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * @deprecated Use {@link #getCredentials2Item(Class, Item, Authentication)} instead.
+     * @deprecated Use {@link #getCredentials2(Class, Item, Authentication)} instead.
      */
     @Deprecated
     @NonNull
@@ -1295,7 +1295,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                           @NonNull Item item,
                                                           @Nullable org.acegisecurity.Authentication authentication) {
         Objects.requireNonNull(item);
-        return getCredentials2ItemGroup(type, item.getParent(), authentication == null ? null : authentication.toSpring());
+        return getCredentials2(type, item.getParent(), authentication == null ? null : authentication.toSpring());
     }
 
     /**
@@ -1310,15 +1310,15 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @since TODO
      */
     @NonNull
-    public <C extends Credentials> List<C> getCredentials2Item(@NonNull Class<C> type,
-                                                               @NonNull Item item,
-                                                               @Nullable Authentication authentication) {
+    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type,
+                                                           @NonNull Item item,
+                                                           @Nullable Authentication authentication) {
         Objects.requireNonNull(item);
-        return getCredentials2ItemGroup(type, item.getParent(), authentication);
+        return getCredentials2(type, item.getParent(), authentication);
     }
 
     /**
-     * @deprecated Use {@link #getCredentials2Item(Class, Item, Authentication, List)} instead.
+     * @deprecated Use {@link #getCredentials2(Class, Item, Authentication, List)} instead.
      */
     @Deprecated
     @NonNull
@@ -1326,7 +1326,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                           @NonNull Item item,
                                                           @Nullable org.acegisecurity.Authentication authentication,
                                                           @NonNull List<DomainRequirement> domainRequirements) {
-        return getCredentials2Item(type, item, authentication == null ? null : authentication.toSpring(), domainRequirements);
+        return getCredentials2(type, item, authentication == null ? null : authentication.toSpring(), domainRequirements);
     }
 
     /**
@@ -1342,16 +1342,16 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @since TODO
      */
     @NonNull
-    public <C extends Credentials> List<C> getCredentials2Item(@NonNull Class<C> type,
-                                                               @NonNull Item item,
-                                                               @Nullable Authentication authentication,
-                                                               @NonNull List<DomainRequirement> domainRequirements) {
-        return getCredentials2ItemGroup(type, item instanceof ItemGroup ? (ItemGroup) item : item.getParent(),
+    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type,
+                                                           @NonNull Item item,
+                                                           @Nullable Authentication authentication,
+                                                           @NonNull List<DomainRequirement> domainRequirements) {
+        return getCredentials2(type, item instanceof ItemGroup ? (ItemGroup) item : item.getParent(),
                 authentication, domainRequirements);
     }
 
     /**
-     * @deprecated Use {@link #getCredentialIds2Item(Class, Item, Authentication, List, CredentialsMatcher)} instead.
+     * @deprecated Use {@link #getCredentialIds2(Class, Item, Authentication, List, CredentialsMatcher)} instead.
      */
     @NonNull
     @Deprecated
@@ -1360,7 +1360,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                                    @Nullable org.acegisecurity.Authentication authentication,
                                                                    @NonNull List<DomainRequirement> domainRequirements,
                                                                    @NonNull CredentialsMatcher matcher) {
-        return getCredentialIds2Item(type, item, authentication == null ? null : authentication.toSpring(), domainRequirements, matcher);
+        return getCredentialIds2(type, item, authentication == null ? null : authentication.toSpring(), domainRequirements, matcher);
     }
 
     /**
@@ -1369,7 +1369,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * specified {@link DomainRequirement}s.
      * <strong>NOTE:</strong> implementations are recommended to override this method if the actual secret information
      * is being stored external from Jenkins and the non-secret information can be accessed with lesser traceability
-     * requirements. The default implementation just uses {@link #getCredentials2Item(Class, Item, Authentication, List)}
+     * requirements. The default implementation just uses {@link #getCredentials2(Class, Item, Authentication, List)}
      * to build the {@link ListBoxModel}. Handling the {@link CredentialsMatcher} may require standing up a proxy
      * instance to apply the matcher against.
      *
@@ -1384,15 +1384,15 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @since TODO
      */
     @NonNull
-    public <C extends IdCredentials> ListBoxModel getCredentialIds2Item(@NonNull Class<C> type,
-                                                                   @NonNull Item item,
-                                                                   @Nullable Authentication authentication,
-                                                                   @NonNull List<DomainRequirement> domainRequirements,
-                                                                   @NonNull CredentialsMatcher matcher) {
+    public <C extends IdCredentials> ListBoxModel getCredentialIds2(@NonNull Class<C> type,
+                                                                    @NonNull Item item,
+                                                                    @Nullable Authentication authentication,
+                                                                    @NonNull List<DomainRequirement> domainRequirements,
+                                                                    @NonNull CredentialsMatcher matcher) {
         if (item instanceof ItemGroup) {
-            return getCredentialIds2ItemGroup(type, (ItemGroup) item, authentication, domainRequirements, matcher);
+            return getCredentialIds2(type, (ItemGroup) item, authentication, domainRequirements, matcher);
         }
-        return getCredentials2Item(type, item, authentication, domainRequirements)
+        return getCredentials2(type, item, authentication, domainRequirements)
                 .stream()
                 .filter(matcher::matches)
                 .sorted(new CredentialsNameComparator())

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
@@ -313,7 +313,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                                     @Nullable ItemGroup itemGroup,
                                                                     @Nullable org.acegisecurity.Authentication authentication,
                                                                     @Nullable DomainRequirement... domainRequirements) {
-        return lookupCredentials2(type, itemGroup, authentication == null ? null : authentication.toSpring(), Arrays.asList(domainRequirements));
+        return lookupCredentials2(type, itemGroup, authentication == null ? null : authentication.toSpring(), Arrays.asList(domainRequirements == null ? new DomainRequirement[0] : domainRequirements));
     }
 
     /**
@@ -634,7 +634,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
             if (provider.isEnabled(item) && provider.isApplicable(type)) {
                 try {
                     for (ListBoxModel.Option option : provider.getCredentialIds2(
-                            type, item, authentication, domainRequirements, matcher)
+                            type, item, authentication, domainRequirements, matcher == null ? CredentialsMatchers.always() : matcher)
                             ) {
                         if (ids.add(option.value)) {
                             result.add(option);
@@ -743,7 +743,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                             try {
                                 a = ((User) current).impersonate2();
                             } catch (UsernameNotFoundException e) {
-                                a = null;
+                                a = Jenkins.ANONYMOUS2;
                             }
                         }
                         if (current == User.current() && jenkins.getACL().hasPermission2(a, USE_ITEM)) {

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
@@ -233,8 +233,8 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * @deprecated use {@link #lookupCredentials2(Class, Item, Authentication, List)}
-     * or {@link #lookupCredentials2(Class, ItemGroup, Authentication, List)}
+     * @deprecated use {@link #lookupCredentialsInItem(Class, Item, Authentication, List)}
+     * or {@link #lookupCredentialsInItemGroup(Class, ItemGroup, Authentication, List)}
      */
     @Deprecated
     @NonNull
@@ -244,8 +244,8 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * @deprecated use {@link #lookupCredentials2(Class, Item, Authentication, List)},
-     * {@link #lookupCredentials2(Class, ItemGroup, Authentication, List)}
+     * @deprecated use {@link #lookupCredentialsInItem(Class, Item, Authentication, List)},
+     * {@link #lookupCredentialsInItemGroup(Class, ItemGroup, Authentication, List)}
      */
     @Deprecated
     @NonNull
@@ -256,7 +256,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * @deprecated use {@link #lookupCredentials2(Class, Item, Authentication, List)} instead.
+     * @deprecated use {@link #lookupCredentialsInItem(Class, Item, Authentication, List)} instead.
      */
     @Deprecated
     @NonNull
@@ -269,7 +269,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * @deprecated use {@link #lookupCredentials2(Class, ItemGroup, Authentication, List)} instead.
+     * @deprecated use {@link #lookupCredentialsInItemGroup(Class, ItemGroup, Authentication, List)} instead.
      */
     @Deprecated
     @NonNull
@@ -280,7 +280,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * @deprecated use {@link #lookupCredentials2(Class, ItemGroup, Authentication)} instead.
+     * @deprecated use {@link #lookupCredentialsInItemGroup(Class, ItemGroup, Authentication)} instead.
      */
     @Deprecated
     @NonNull
@@ -288,11 +288,11 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     public static <C extends Credentials> List<C> lookupCredentials(@NonNull Class<C> type,
                                                                     @Nullable ItemGroup itemGroup,
                                                                     @Nullable org.acegisecurity.Authentication authentication) {
-        return lookupCredentials2(type, itemGroup, authentication == null ? null : authentication.toSpring(), Collections.emptyList());
+        return lookupCredentialsInItemGroup(type, itemGroup, authentication == null ? null : authentication.toSpring(), Collections.emptyList());
     }
 
     /**
-     * @deprecated use {@link #lookupCredentials2(Class, Item, Authentication)} instead.
+     * @deprecated use {@link #lookupCredentialsInItem(Class, Item, Authentication)} instead.
      */
     @Deprecated
     @NonNull
@@ -300,11 +300,11 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     public static <C extends Credentials> List<C> lookupCredentials(@NonNull Class<C> type,
                                                                     @Nullable Item item,
                                                                     @Nullable org.acegisecurity.Authentication authentication) {
-        return lookupCredentials2(type, item, authentication == null ? null : authentication.toSpring(), Collections.emptyList());
+        return lookupCredentialsInItem(type, item, authentication == null ? null : authentication.toSpring(), Collections.emptyList());
     }
 
     /**
-     * @deprecated Use {@link #lookupCredentials2(Class, ItemGroup, Authentication)} or {@link #lookupCredentials2(Class, ItemGroup, Authentication, List)}.
+     * @deprecated Use {@link #lookupCredentialsInItemGroup(Class, ItemGroup, Authentication)} or {@link #lookupCredentialsInItemGroup(Class, ItemGroup, Authentication, List)}.
      */
     @Deprecated
     @NonNull
@@ -313,7 +313,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                                     @Nullable ItemGroup itemGroup,
                                                                     @Nullable org.acegisecurity.Authentication authentication,
                                                                     @Nullable DomainRequirement... domainRequirements) {
-        return lookupCredentials2(type, itemGroup, authentication == null ? null : authentication.toSpring(), Arrays.asList(domainRequirements == null ? new DomainRequirement[0] : domainRequirements));
+        return lookupCredentialsInItemGroup(type, itemGroup, authentication == null ? null : authentication.toSpring(), Arrays.asList(domainRequirements == null ? new DomainRequirement[0] : domainRequirements));
     }
 
     /**
@@ -329,14 +329,14 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      */
     @NonNull
     @SuppressWarnings({"unchecked", "unused"}) // API entry point for consumers
-    public static <C extends Credentials> List<C> lookupCredentials2(@NonNull Class<C> type,
-                                                                     @Nullable ItemGroup itemGroup,
-                                                                     @Nullable Authentication authentication) {
-        return lookupCredentials2(type, itemGroup, authentication, List.of());
+    public static <C extends Credentials> List<C> lookupCredentialsInItemGroup(@NonNull Class<C> type,
+                                                                               @Nullable ItemGroup itemGroup,
+                                                                               @Nullable Authentication authentication) {
+        return lookupCredentialsInItemGroup(type, itemGroup, authentication, List.of());
     }
 
     /**
-     * @deprecated Use {@link #lookupCredentials2(Class, ItemGroup, Authentication, List)} instead.
+     * @deprecated Use {@link #lookupCredentialsInItemGroup(Class, ItemGroup, Authentication, List)} instead.
      */
     @NonNull
     @SuppressWarnings({"unchecked", "unused"}) // API entry point for consumers
@@ -345,7 +345,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                                     @Nullable ItemGroup itemGroup,
                                                                     @Nullable org.acegisecurity.Authentication authentication,
                                                                     @Nullable List<DomainRequirement> domainRequirements) {
-        return lookupCredentials2(type, itemGroup, authentication == null ? null : authentication.toSpring(), domainRequirements);
+        return lookupCredentialsInItemGroup(type, itemGroup, authentication == null ? null : authentication.toSpring(), domainRequirements);
     }
 
     /**
@@ -362,10 +362,10 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      */
     @NonNull
     @SuppressWarnings({"unchecked", "unused"}) // API entry point for consumers
-    public static <C extends Credentials> List<C> lookupCredentials2(@NonNull Class<C> type,
-                                                                     @Nullable ItemGroup itemGroup,
-                                                                     @Nullable Authentication authentication,
-                                                                     @Nullable List<DomainRequirement> domainRequirements) {
+    public static <C extends Credentials> List<C> lookupCredentialsInItemGroup(@NonNull Class<C> type,
+                                                                               @Nullable ItemGroup itemGroup,
+                                                                               @Nullable Authentication authentication,
+                                                                               @Nullable List<DomainRequirement> domainRequirements) {
         Objects.requireNonNull(type);
         Jenkins jenkins = Jenkins.get();
         itemGroup = itemGroup == null ? jenkins : itemGroup;
@@ -377,7 +377,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
             LOGGER.log(Level.FINE, "Resolving legacy credentials of type {0} with resolver {1}",
                     new Object[]{type, resolver});
             final List<Credentials> originals =
-                    lookupCredentials2(resolver.getFromClass(), itemGroup, authentication, domainRequirements);
+                    lookupCredentialsInItemGroup(resolver.getFromClass(), itemGroup, authentication, domainRequirements);
             LOGGER.log(Level.FINE, "Original credentials for resolving: {0}", originals);
             return resolver.resolve(originals);
         }
@@ -386,7 +386,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
         for (CredentialsProvider provider : all()) {
             if (provider.isEnabled(itemGroup) && provider.isApplicable(type)) {
                 try {
-                    for (C c : provider.getCredentials2(type, itemGroup, authentication, domainRequirements)) {
+                    for (C c : provider.getCredentialsInItemGroup(type, itemGroup, authentication, domainRequirements)) {
                         if (!(c instanceof IdCredentials) || ids.add(((IdCredentials) c).getId())) {
                             // if IdCredentials, only add if we haven't added already
                             // if not IdCredentials, always add
@@ -403,7 +403,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * @deprecated Use {@link #listCredentials2(Class, ItemGroup, Authentication, List, CredentialsMatcher)} instead.
+     * @deprecated Use {@link #listCredentialsInItemGroup(Class, ItemGroup, Authentication, List, CredentialsMatcher)} instead.
      */
     @Deprecated
     public static <C extends IdCredentials> ListBoxModel listCredentials(@NonNull Class<C> type,
@@ -412,7 +412,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                                          @Nullable List<DomainRequirement>
                                                                                  domainRequirements,
                                                                          @Nullable CredentialsMatcher matcher) {
-        return listCredentials2(type, itemGroup, authentication == null ? null : authentication.toSpring(), domainRequirements, matcher);
+        return listCredentialsInItemGroup(type, itemGroup, authentication == null ? null : authentication.toSpring(), domainRequirements, matcher);
     }
 
     /**
@@ -429,12 +429,12 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * provided by {@link CredentialsNameProvider}.
      * @since TODO
      */
-    public static <C extends IdCredentials> ListBoxModel listCredentials2(@NonNull Class<C> type,
-                                                                          @Nullable ItemGroup itemGroup,
-                                                                          @Nullable Authentication authentication,
-                                                                          @Nullable List<DomainRequirement>
+    public static <C extends IdCredentials> ListBoxModel listCredentialsInItemGroup(@NonNull Class<C> type,
+                                                                                    @Nullable ItemGroup itemGroup,
+                                                                                    @Nullable Authentication authentication,
+                                                                                    @Nullable List<DomainRequirement>
                                                                                  domainRequirements,
-                                                                          @Nullable CredentialsMatcher matcher) {
+                                                                                    @Nullable CredentialsMatcher matcher) {
         Objects.requireNonNull(type);
         Jenkins jenkins = Jenkins.get();
         itemGroup = itemGroup == null ? jenkins : itemGroup;
@@ -446,7 +446,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
         if (resolver != null && IdCredentials.class.isAssignableFrom(resolver.getFromClass())) {
             LOGGER.log(Level.FINE, "Listing legacy credentials of type {0} identified by resolver {1}",
                     new Object[]{type, resolver});
-            return listCredentials2((Class) resolver.getFromClass(), itemGroup, authentication, domainRequirements,
+            return listCredentialsInItemGroup((Class) resolver.getFromClass(), itemGroup, authentication, domainRequirements,
                     matcher);
         }
         ListBoxModel result = new ListBoxModel();
@@ -454,7 +454,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
         for (CredentialsProvider provider : all()) {
             if (provider.isEnabled(itemGroup) && provider.isApplicable(type)) {
                 try {
-                    for (ListBoxModel.Option option : provider.getCredentialIds2(
+                    for (ListBoxModel.Option option : provider.getCredentialIdsInItemGroup(
                             type, itemGroup, authentication, domainRequirements, matcher)
                             ) {
                         if (ids.add(option.value)) {
@@ -472,7 +472,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * @deprecated use {@link #lookupCredentials2(Class, ItemGroup, Authentication)} or {@link #lookupCredentials2(Class, ItemGroup, Authentication, List)}.
+     * @deprecated use {@link #lookupCredentialsInItemGroup(Class, ItemGroup, Authentication)} or {@link #lookupCredentialsInItemGroup(Class, ItemGroup, Authentication, List)}.
      */
     @Deprecated
     @NonNull
@@ -481,7 +481,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                                     @Nullable Item item,
                                                                     @Nullable org.acegisecurity.Authentication authentication,
                                                                     DomainRequirement... domainRequirements) {
-        return lookupCredentials2(type, item, authentication == null ? null : authentication.toSpring(), Arrays.asList(domainRequirements));
+        return lookupCredentialsInItem(type, item, authentication == null ? null : authentication.toSpring(), Arrays.asList(domainRequirements));
     }
 
     /**
@@ -497,14 +497,14 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      */
     @NonNull
     @SuppressWarnings("unused") // API entry point for consumers
-    public static <C extends Credentials> List<C> lookupCredentials2(@NonNull Class<C> type,
-                                                                     @Nullable Item item,
-                                                                     @Nullable Authentication authentication) {
-        return lookupCredentials2(type, item, authentication, List.of());
+    public static <C extends Credentials> List<C> lookupCredentialsInItem(@NonNull Class<C> type,
+                                                                          @Nullable Item item,
+                                                                          @Nullable Authentication authentication) {
+        return lookupCredentialsInItem(type, item, authentication, List.of());
     }
 
     /**
-     * @deprecated use {@link #lookupCredentials2(Class, Item, Authentication, List)}
+     * @deprecated use {@link #lookupCredentialsInItem(Class, Item, Authentication, List)}
      */
     @NonNull
     @SuppressWarnings("unused") // API entry point for consumers
@@ -514,7 +514,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                                     @Nullable org.acegisecurity.Authentication authentication,
                                                                     @Nullable List<DomainRequirement>
                                                                             domainRequirements) {
-        return lookupCredentials2(type, item, authentication == null ? null : authentication.toSpring(), domainRequirements);
+        return lookupCredentialsInItem(type, item, authentication == null ? null : authentication.toSpring(), domainRequirements);
     }
 
     /**
@@ -531,17 +531,17 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      */
     @NonNull
     @SuppressWarnings("unused") // API entry point for consumers
-    public static <C extends Credentials> List<C> lookupCredentials2(@NonNull Class<C> type,
-                                                                     @Nullable Item item,
-                                                                     @Nullable Authentication authentication,
-                                                                     @Nullable List<DomainRequirement>
+    public static <C extends Credentials> List<C> lookupCredentialsInItem(@NonNull Class<C> type,
+                                                                          @Nullable Item item,
+                                                                          @Nullable Authentication authentication,
+                                                                          @Nullable List<DomainRequirement>
                                                                             domainRequirements) {
         Objects.requireNonNull(type);
         if (item == null) {
-            return lookupCredentials2(type, Jenkins.get(), authentication, domainRequirements);
+            return lookupCredentialsInItemGroup(type, Jenkins.get(), authentication, domainRequirements);
         }
         if (item instanceof ItemGroup) {
-            return lookupCredentials2(type, (ItemGroup)item, authentication, domainRequirements);
+            return lookupCredentialsInItemGroup(type, (ItemGroup)item, authentication, domainRequirements);
         }
         authentication = authentication == null ? ACL.SYSTEM2 : authentication;
         domainRequirements = domainRequirements
@@ -551,7 +551,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
             LOGGER.log(Level.FINE, "Resolving legacy credentials of type {0} with resolver {1}",
                     new Object[]{type, resolver});
             final List<Credentials> originals =
-                    lookupCredentials2(resolver.getFromClass(), item, authentication, domainRequirements);
+                    lookupCredentialsInItem(resolver.getFromClass(), item, authentication, domainRequirements);
             LOGGER.log(Level.FINE, "Original credentials for resolving: {0}", originals);
             return resolver.resolve(originals);
         }
@@ -560,7 +560,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
         for (CredentialsProvider provider : all()) {
             if (provider.isEnabled(item) && provider.isApplicable(type)) {
                 try {
-                    for (C c: provider.getCredentials2(type, item, authentication, domainRequirements)) {
+                    for (C c: provider.getCredentialsInItem(type, item, authentication, domainRequirements)) {
                         if (!(c instanceof IdCredentials) || ids.add(((IdCredentials) c).getId())) {
                             // if IdCredentials, only add if we haven't added already
                             // if not IdCredentials, always add
@@ -577,7 +577,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * @deprecated Use {@link #listCredentials2(Class, Item, Authentication, List, CredentialsMatcher)} instead.
+     * @deprecated Use {@link #listCredentialsInItem(Class, Item, Authentication, List, CredentialsMatcher)} instead.
      */
     @NonNull
     @Deprecated
@@ -587,7 +587,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                                          @Nullable List<DomainRequirement>
                                                                                  domainRequirements,
                                                                          @Nullable CredentialsMatcher matcher) {
-        return listCredentials2(type, item, authentication == null ? null : authentication.toSpring(), domainRequirements, matcher);
+        return listCredentialsInItem(type, item, authentication == null ? null : authentication.toSpring(), domainRequirements, matcher);
     }
 
     /**
@@ -605,18 +605,18 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @since TODO
      */
     @NonNull
-    public static <C extends IdCredentials> ListBoxModel listCredentials2(@NonNull Class<C> type,
-                                                                          @Nullable Item item,
-                                                                          @Nullable Authentication authentication,
-                                                                          @Nullable List<DomainRequirement>
+    public static <C extends IdCredentials> ListBoxModel listCredentialsInItem(@NonNull Class<C> type,
+                                                                               @Nullable Item item,
+                                                                               @Nullable Authentication authentication,
+                                                                               @Nullable List<DomainRequirement>
                                                                                  domainRequirements,
-                                                                          @Nullable CredentialsMatcher matcher) {
+                                                                               @Nullable CredentialsMatcher matcher) {
         Objects.requireNonNull(type);
         if (item == null) {
-            return listCredentials2(type, Jenkins.get(), authentication, domainRequirements, matcher);
+            return listCredentialsInItemGroup(type, Jenkins.get(), authentication, domainRequirements, matcher);
         }
         if (item instanceof ItemGroup) {
-            return listCredentials2(type, (ItemGroup) item, authentication, domainRequirements, matcher);
+            return listCredentialsInItemGroup(type, (ItemGroup) item, authentication, domainRequirements, matcher);
         }
         authentication = authentication == null ? ACL.SYSTEM2 : authentication;
         domainRequirements = domainRequirements
@@ -625,7 +625,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
         if (resolver != null && IdCredentials.class.isAssignableFrom(resolver.getFromClass())) {
             LOGGER.log(Level.FINE, "Listing legacy credentials of type {0} identified by resolver {1}",
                     new Object[]{type, resolver});
-            return listCredentials2((Class) resolver.getFromClass(), item, authentication,
+            return listCredentialsInItem((Class) resolver.getFromClass(), item, authentication,
                     domainRequirements, matcher);
         }
         ListBoxModel result = new ListBoxModel();
@@ -633,7 +633,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
         for (CredentialsProvider provider : all()) {
             if (provider.isEnabled(item) && provider.isApplicable(type)) {
                 try {
-                    for (ListBoxModel.Option option : provider.getCredentialIds2(
+                    for (ListBoxModel.Option option : provider.getCredentialIdsInItem(
                             type, item, authentication, domainRequirements, matcher == null ? CredentialsMatchers.always() : matcher)
                             ) {
                         if (ids.add(option.value)) {
@@ -928,12 +928,12 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
             Authentication runAuth = CredentialsProvider.getDefaultAuthenticationOf2(run.getParent());
             // we want the credentials available to the user the build is running as
             List<C> candidates = new ArrayList<>(
-                    CredentialsProvider.lookupCredentials2(type, run.getParent(), runAuth, domainRequirements)
+                    CredentialsProvider.lookupCredentialsInItem(type, run.getParent(), runAuth, domainRequirements)
             );
             // if that user can use the item's credentials, add those in too
             if (runAuth != ACL.SYSTEM2 && run.hasPermission2(runAuth, CredentialsProvider.USE_ITEM)) {
                 candidates.addAll(
-                        CredentialsProvider.lookupCredentials2(type, run.getParent(), ACL.SYSTEM2, domainRequirements)
+                        CredentialsProvider.lookupCredentialsInItem(type, run.getParent(), ACL.SYSTEM2, domainRequirements)
                 );
             }
             // TODO should this be calling track?
@@ -947,14 +947,14 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
             // the user triggered this job directly and they are allowed to supply their own credentials, so
             // add those into the list. We do not want to follow the chain for the user's authentication
             // though, as there is no way to limit how far the passed-through parameters can be used
-            candidates.addAll(CredentialsProvider.lookupCredentials2(type, run.getParent(), a, domainRequirements));
+            candidates.addAll(CredentialsProvider.lookupCredentialsInItem(type, run.getParent(), a, domainRequirements));
         }
         if (inputUserId != null) {
             final User inputUser = User.getById(inputUserId, false);
             if (inputUser != null) {
                 final Authentication inputAuth = inputUser.impersonate2();
                 if (run.hasPermission2(inputAuth, CredentialsProvider.USE_OWN)) {
-                    candidates.addAll(CredentialsProvider.lookupCredentials2(type, run.getParent(), inputAuth, domainRequirements));
+                    candidates.addAll(CredentialsProvider.lookupCredentialsInItem(type, run.getParent(), inputAuth, domainRequirements));
                 }
             }
         }
@@ -966,12 +966,12 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
             Authentication runAuth = CredentialsProvider.getDefaultAuthenticationOf2(run.getParent());
             // we want the credentials available to the user the build is running as
             candidates.addAll(
-                    CredentialsProvider.lookupCredentials2(type, run.getParent(), runAuth, domainRequirements)
+                    CredentialsProvider.lookupCredentialsInItem(type, run.getParent(), runAuth, domainRequirements)
             );
             // if that user can use the item's credentials, add those in too
             if (runAuth != ACL.SYSTEM2 && run.hasPermission2(runAuth, CredentialsProvider.USE_ITEM)) {
                 candidates.addAll(
-                        CredentialsProvider.lookupCredentials2(type, run.getParent(), ACL.SYSTEM2, domainRequirements)
+                        CredentialsProvider.lookupCredentialsInItem(type, run.getParent(), ACL.SYSTEM2, domainRequirements)
                 );
             }
         }
@@ -1143,18 +1143,18 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * @deprecated use {@link #getCredentials2(Class, Item, Authentication, List)} instead.
+     * @deprecated use {@link #getCredentialsInItem(Class, Item, Authentication, List)} instead.
      */
     @NonNull
     @Deprecated
     public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type,
                                                                    @Nullable ItemGroup itemGroup,
                                                                    @Nullable org.acegisecurity.Authentication authentication) {
-        return getCredentials2(type, itemGroup, authentication == null ? null : authentication.toSpring(), List.of());
+        return getCredentialsInItemGroup(type, itemGroup, authentication == null ? null : authentication.toSpring(), List.of());
     }
 
     /**
-     * @deprecated use {@link #getCredentials2(Class, Item, Authentication, List)} instead.
+     * @deprecated use {@link #getCredentialsInItem(Class, Item, Authentication, List)} instead.
      */
     @Deprecated
     @NonNull
@@ -1162,7 +1162,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                           @Nullable ItemGroup itemGroup,
                                                           @Nullable org.acegisecurity.Authentication authentication,
                                                           @NonNull List<DomainRequirement> domainRequirements) {
-        return getCredentials2(type, itemGroup, authentication == null ? null : authentication.toSpring(), domainRequirements);
+        return getCredentialsInItemGroup(type, itemGroup, authentication == null ? null : authentication.toSpring(), domainRequirements);
     }
 
 
@@ -1183,18 +1183,18 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      */
     @NonNull
     @SuppressWarnings("deprecation")
-    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type,
-                                                           @Nullable ItemGroup itemGroup,
-                                                           @Nullable Authentication authentication,
-                                                           @NonNull List<DomainRequirement> domainRequirements) {
+    public <C extends Credentials> List<C> getCredentialsInItemGroup(@NonNull Class<C> type,
+                                                                     @Nullable ItemGroup itemGroup,
+                                                                     @Nullable Authentication authentication,
+                                                                     @NonNull List<DomainRequirement> domainRequirements) {
         if (Util.isOverridden(CredentialsProvider.class, getClass(), "getCredentials", Class.class, ItemGroup.class, org.acegisecurity.Authentication.class, List.class)) {
             return getCredentials(type, itemGroup, authentication == null ? null : org.acegisecurity.Authentication.fromSpring(authentication), domainRequirements);
         }
-        throw new AbstractMethodError("Implement getCredentials2(Class, ItemGroup, Authentication, List)");
+        throw new AbstractMethodError("Implement getCredentialsInItemGroup");
     }
 
     /**
-     * @deprecated Use {@link #getCredentialIds2(Class, ItemGroup, Authentication, List, CredentialsMatcher)} instead.
+     * @deprecated Use {@link #getCredentialIdsInItemGroup(Class, ItemGroup, Authentication, List, CredentialsMatcher)} instead.
      */
     @NonNull
     @Deprecated
@@ -1204,7 +1204,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                                    @NonNull
                                                                    List<DomainRequirement> domainRequirements,
                                                                    @NonNull CredentialsMatcher matcher) {
-        return getCredentialIds2(type, itemGroup, authentication == null ? null : authentication.toSpring(), domainRequirements, matcher);
+        return getCredentialIdsInItemGroup(type, itemGroup, authentication == null ? null : authentication.toSpring(), domainRequirements, matcher);
     }
 
     /**
@@ -1213,7 +1213,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * specified {@link DomainRequirement}s.
      * <strong>NOTE:</strong> implementations are recommended to override this method if the actual secret information
      * is being stored external from Jenkins and the non-secret information can be accessed with lesser traceability
-     * requirements. The default implementation just uses {@link #getCredentials2(Class, Item, Authentication, List)}
+     * requirements. The default implementation just uses {@link #getCredentialsInItem(Class, Item, Authentication, List)}
      * to build the {@link ListBoxModel}. Handling the {@link CredentialsMatcher} may require standing up a proxy
      * instance to apply the matcher against if {@link CredentialsMatchers#describe(CredentialsMatcher)} returns
      * {@code null}
@@ -1229,13 +1229,13 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @since TODO
      */
     @NonNull
-    public <C extends IdCredentials> ListBoxModel getCredentialIds2(@NonNull Class<C> type,
-                                                                    @Nullable ItemGroup itemGroup,
-                                                                    @Nullable Authentication authentication,
-                                                                    @NonNull
+    public <C extends IdCredentials> ListBoxModel getCredentialIdsInItemGroup(@NonNull Class<C> type,
+                                                                              @Nullable ItemGroup itemGroup,
+                                                                              @Nullable Authentication authentication,
+                                                                              @NonNull
                                                                            List<DomainRequirement> domainRequirements,
-                                                                    @NonNull CredentialsMatcher matcher) {
-        return getCredentials2(type, itemGroup, authentication, domainRequirements)
+                                                                              @NonNull CredentialsMatcher matcher) {
+        return getCredentialsInItemGroup(type, itemGroup, authentication, domainRequirements)
                 .stream()
                 .filter(matcher::matches)
                 .sorted(new CredentialsNameComparator())
@@ -1244,7 +1244,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * @deprecated Use {@link #getCredentials2(Class, Item, Authentication, List)} instead.
+     * @deprecated Use {@link #getCredentialsInItem(Class, Item, Authentication, List)} instead.
      */
     @Deprecated
     @NonNull
@@ -1252,11 +1252,11 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                           @NonNull Item item,
                                                           @Nullable org.acegisecurity.Authentication authentication) {
         Objects.requireNonNull(item);
-        return getCredentials2(type, item.getParent(), authentication == null ? null : authentication.toSpring(), List.of());
+        return getCredentialsInItemGroup(type, item.getParent(), authentication == null ? null : authentication.toSpring(), List.of());
     }
 
     /**
-     * @deprecated Use {@link #getCredentials2(Class, Item, Authentication, List)} instead.
+     * @deprecated Use {@link #getCredentialsInItem(Class, Item, Authentication, List)} instead.
      */
     @Deprecated
     @NonNull
@@ -1264,7 +1264,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                           @NonNull Item item,
                                                           @Nullable org.acegisecurity.Authentication authentication,
                                                           @NonNull List<DomainRequirement> domainRequirements) {
-        return getCredentials2(type, item, authentication == null ? null : authentication.toSpring(), domainRequirements);
+        return getCredentialsInItem(type, item, authentication == null ? null : authentication.toSpring(), domainRequirements);
     }
 
     /**
@@ -1280,16 +1280,16 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @since TODO
      */
     @NonNull
-    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type,
-                                                           @NonNull Item item,
-                                                           @Nullable Authentication authentication,
-                                                           @NonNull List<DomainRequirement> domainRequirements) {
-        return getCredentials2(type, item instanceof ItemGroup ? (ItemGroup) item : item.getParent(),
+    public <C extends Credentials> List<C> getCredentialsInItem(@NonNull Class<C> type,
+                                                                @NonNull Item item,
+                                                                @Nullable Authentication authentication,
+                                                                @NonNull List<DomainRequirement> domainRequirements) {
+        return getCredentialsInItemGroup(type, item instanceof ItemGroup ? (ItemGroup) item : item.getParent(),
                 authentication, domainRequirements);
     }
 
     /**
-     * @deprecated Use {@link #getCredentialIds2(Class, Item, Authentication, List, CredentialsMatcher)} instead.
+     * @deprecated Use {@link #getCredentialIdsInItem(Class, Item, Authentication, List, CredentialsMatcher)} instead.
      */
     @NonNull
     @Deprecated
@@ -1298,7 +1298,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                                    @Nullable org.acegisecurity.Authentication authentication,
                                                                    @NonNull List<DomainRequirement> domainRequirements,
                                                                    @NonNull CredentialsMatcher matcher) {
-        return getCredentialIds2(type, item, authentication == null ? null : authentication.toSpring(), domainRequirements, matcher);
+        return getCredentialIdsInItem(type, item, authentication == null ? null : authentication.toSpring(), domainRequirements, matcher);
     }
 
     /**
@@ -1307,7 +1307,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * specified {@link DomainRequirement}s.
      * <strong>NOTE:</strong> implementations are recommended to override this method if the actual secret information
      * is being stored external from Jenkins and the non-secret information can be accessed with lesser traceability
-     * requirements. The default implementation just uses {@link #getCredentials2(Class, Item, Authentication, List)}
+     * requirements. The default implementation just uses {@link #getCredentialsInItem(Class, Item, Authentication, List)}
      * to build the {@link ListBoxModel}. Handling the {@link CredentialsMatcher} may require standing up a proxy
      * instance to apply the matcher against.
      *
@@ -1322,15 +1322,15 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @since TODO
      */
     @NonNull
-    public <C extends IdCredentials> ListBoxModel getCredentialIds2(@NonNull Class<C> type,
-                                                                    @NonNull Item item,
-                                                                    @Nullable Authentication authentication,
-                                                                    @NonNull List<DomainRequirement> domainRequirements,
-                                                                    @NonNull CredentialsMatcher matcher) {
+    public <C extends IdCredentials> ListBoxModel getCredentialIdsInItem(@NonNull Class<C> type,
+                                                                         @NonNull Item item,
+                                                                         @Nullable Authentication authentication,
+                                                                         @NonNull List<DomainRequirement> domainRequirements,
+                                                                         @NonNull CredentialsMatcher matcher) {
         if (item instanceof ItemGroup) {
-            return getCredentialIds2(type, (ItemGroup) item, authentication, domainRequirements, matcher);
+            return getCredentialIdsInItemGroup(type, (ItemGroup) item, authentication, domainRequirements, matcher);
         }
-        return getCredentials2(type, item, authentication, domainRequirements)
+        return getCredentialsInItem(type, item, authentication, domainRequirements)
                 .stream()
                 .filter(matcher::matches)
                 .sorted(new CredentialsNameComparator())

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
@@ -116,17 +116,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      *
      * @since 2.1.1
      */
-    public static final CredentialsProvider NONE = new CredentialsProvider() {
-        /**
-         * {@inheritDoc}
-         */
-        @NonNull
-        @Override
-        public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
-                                                               @Nullable Authentication authentication) {
-            return Collections.emptyList();
-        }
-    };
+    public static final CredentialsProvider NONE = new CredentialsProvider() {};
 
     /**
      * The permission group for credentials.
@@ -1151,29 +1141,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type,
                                                                    @Nullable ItemGroup itemGroup,
                                                                    @Nullable org.acegisecurity.Authentication authentication) {
-        return getCredentials2(type, itemGroup, authentication == null ? null : authentication.toSpring());
-    }
-
-    /**
-     * Returns the credentials provided by this provider which are available to the specified {@link Authentication}
-     * for items in the specified {@link ItemGroup}
-     *
-     * @param type           the type of credentials to return.
-     * @param itemGroup      the item group (if {@code null} assume {@link Jenkins#get()}.
-     * @param authentication the authentication (if {@code null} assume {@link ACL#SYSTEM2}.
-     * @param <C>            the credentials type.
-     * @return the list of credentials.
-     * @since TODO
-     */
-    @NonNull
-    @SuppressWarnings("deprecation")
-    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type,
-                                                           @Nullable ItemGroup itemGroup,
-                                                           @Nullable Authentication authentication) {
-        if (Util.isOverridden(CredentialsProvider.class, getClass(), "getCredentials", Class.class, ItemGroup.class, org.acegisecurity.Authentication.class)) {
-            return getCredentials(type, itemGroup, authentication == null ? null : org.acegisecurity.Authentication.fromSpring(authentication));
-        }
-        throw new AbstractMethodError("Implement getCredentials(Class, ItemGroup, Authentication)");
+        return getCredentials2(type, itemGroup, authentication == null ? null : authentication.toSpring(), List.of());
     }
 
     /**
@@ -1213,7 +1181,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
         if (Util.isOverridden(CredentialsProvider.class, getClass(), "getCredentials", Class.class, ItemGroup.class, org.acegisecurity.Authentication.class, List.class)) {
             return getCredentials(type, itemGroup, authentication == null ? null : org.acegisecurity.Authentication.fromSpring(authentication), domainRequirements);
         }
-        return getCredentials2(type, itemGroup, authentication);
+        throw new AbstractMethodError("Implement getCredentials2(Class, ItemGroup, Authentication, List)");
     }
 
     /**
@@ -1275,7 +1243,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                           @NonNull Item item,
                                                           @Nullable org.acegisecurity.Authentication authentication) {
         Objects.requireNonNull(item);
-        return getCredentials2(type, item.getParent(), authentication == null ? null : authentication.toSpring());
+        return getCredentials2(type, item.getParent(), authentication == null ? null : authentication.toSpring(), List.of());
     }
 
     /**

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
@@ -122,7 +122,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
          */
         @NonNull
         @Override
-        public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
+        public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
                                                               @Nullable Authentication authentication) {
             return Collections.emptyList();
         }
@@ -470,7 +470,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
         for (CredentialsProvider provider : all()) {
             if (provider.isEnabled(itemGroup) && provider.isApplicable(type)) {
                 try {
-                    for (C c : provider.getCredentials(type, itemGroup, authentication, domainRequirements)) {
+                    for (C c : provider.getCredentials2(type, itemGroup, authentication, domainRequirements)) {
                         if (!(c instanceof IdCredentials) || ids.add(((IdCredentials) c).getId())) {
                             // if IdCredentials, only add if we haven't added already
                             // if not IdCredentials, always add
@@ -550,7 +550,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
         for (CredentialsProvider provider : all()) {
             if (provider.isEnabled(itemGroup) && provider.isApplicable(type)) {
                 try {
-                    for (ListBoxModel.Option option : provider.getCredentialIds(
+                    for (ListBoxModel.Option option : provider.getCredentialIds2(
                             type, itemGroup, authentication, domainRequirements, matcher)
                             ) {
                         if (ids.add(option.value)) {
@@ -678,7 +678,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
         for (CredentialsProvider provider : all()) {
             if (provider.isEnabled(item) && provider.isApplicable(type)) {
                 try {
-                    for (C c: provider.getCredentials(type, item, authentication, domainRequirements)) {
+                    for (C c: provider.getCredentials2(type, item, authentication, domainRequirements)) {
                         if (!(c instanceof IdCredentials) || ids.add(((IdCredentials) c).getId())) {
                             // if IdCredentials, only add if we haven't added already
                             // if not IdCredentials, always add
@@ -763,7 +763,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
         for (CredentialsProvider provider : all()) {
             if (provider.isEnabled(item) && provider.isApplicable(type)) {
                 try {
-                    for (ListBoxModel.Option option : provider.getCredentialIds(
+                    for (ListBoxModel.Option option : provider.getCredentialIds2(
                             type, item, authentication, domainRequirements, matcher)
                             ) {
                         if (ids.add(option.value)) {
@@ -1284,14 +1284,14 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @param authentication the authentication (if {@code null} assume {@link ACL#SYSTEM}.
      * @param <C>            the credentials type.
      * @return the list of credentials.
-     * @deprecated use {@link #getCredentials(Class, Item, Authentication)} instead.
+     * @deprecated use {@link #getCredentials2(Class, Item, Authentication)} instead.
      */
     @NonNull
     @Deprecated
     public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type,
                                                                    @Nullable ItemGroup itemGroup,
                                                                    @Nullable org.acegisecurity.Authentication authentication) {
-        return getCredentials(type, itemGroup, authentication == null ? null : authentication.toSpring());
+        return getCredentials2(type, itemGroup, authentication == null ? null : authentication.toSpring());
     }
 
     /**
@@ -1306,7 +1306,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      */
     @NonNull
     @SuppressWarnings("deprecation")
-    public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type,
+    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type,
                                                                    @Nullable ItemGroup itemGroup,
                                                                    @Nullable Authentication authentication) {
         if (Util.isOverridden(CredentialsProvider.class, getClass(), "getCredentials", Class.class, ItemGroup.class, org.acegisecurity.Authentication.class)) {
@@ -1328,7 +1328,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      *                           assume the match is true).
      * @param <C>                the credentials type.
      * @return the list of credentials.
-     * @deprecated use {@link #getCredentials(Class, Item, Authentication, List)} instead.
+     * @deprecated use {@link #getCredentials2(Class, Item, Authentication, List)} instead.
      * @since 1.5
      */
     @Deprecated
@@ -1337,7 +1337,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                           @Nullable ItemGroup itemGroup,
                                                           @Nullable org.acegisecurity.Authentication authentication,
                                                           @NonNull List<DomainRequirement> domainRequirements) {
-        return getCredentials(type, itemGroup, authentication, domainRequirements);
+        return getCredentials2(type, itemGroup, authentication == null ? null : authentication.toSpring(), domainRequirements);
     }
 
 
@@ -1358,14 +1358,14 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      */
     @NonNull
     @SuppressWarnings("deprecation")
-    public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type,
+    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type,
                                                           @Nullable ItemGroup itemGroup,
                                                           @Nullable Authentication authentication,
                                                           @NonNull List<DomainRequirement> domainRequirements) {
         if (Util.isOverridden(CredentialsProvider.class, getClass(), "getCredentials", Class.class, ItemGroup.class, org.acegisecurity.Authentication.class, List.class)) {
             return getCredentials(type, itemGroup, authentication == null ? null : org.acegisecurity.Authentication.fromSpring(authentication), domainRequirements);
         }
-        return getCredentials(type, itemGroup, authentication);
+        return getCredentials2(type, itemGroup, authentication);
     }
 
     /**
@@ -1374,7 +1374,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * specified {@link DomainRequirement}s.
      * <strong>NOTE:</strong> implementations are recommended to override this method if the actual secret information
      * is being stored external from Jenkins and the non-secret information can be accessed with lesser traceability
-     * requirements. The default implementation just uses {@link #getCredentials(Class, Item, Authentication, List)}
+     * requirements. The default implementation just uses {@link #getCredentials2(Class, Item, Authentication, List)}
      * to build the {@link ListBoxModel}. Handling the {@link CredentialsMatcher} may require standing up a proxy
      * instance to apply the matcher against if {@link CredentialsMatchers#describe(CredentialsMatcher)} returns
      * {@code null}
@@ -1387,7 +1387,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @param matcher            the additional filtering to apply to the credentials
      * @return the {@link ListBoxModel} of {@link IdCredentials#getId()} with names provided by
      * {@link CredentialsNameProvider}.
-     * @deprecated Use {@link #getCredentialIds(Class, ItemGroup, Authentication, List, CredentialsMatcher)} instead.
+     * @deprecated Use {@link #getCredentialIds2(Class, ItemGroup, Authentication, List, CredentialsMatcher)} instead.
      * @since 2.1.0
      */
     @NonNull
@@ -1398,7 +1398,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                                    @NonNull
                                                                    List<DomainRequirement> domainRequirements,
                                                                    @NonNull CredentialsMatcher matcher) {
-        return getCredentialIds(type, itemGroup, authentication == null ? null : authentication.toSpring(), domainRequirements, matcher);
+        return getCredentialIds2(type, itemGroup, authentication == null ? null : authentication.toSpring(), domainRequirements, matcher);
     }
 
     /**
@@ -1407,7 +1407,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * specified {@link DomainRequirement}s.
      * <strong>NOTE:</strong> implementations are recommended to override this method if the actual secret information
      * is being stored external from Jenkins and the non-secret information can be accessed with lesser traceability
-     * requirements. The default implementation just uses {@link #getCredentials(Class, Item, Authentication, List)}
+     * requirements. The default implementation just uses {@link #getCredentials2(Class, Item, Authentication, List)}
      * to build the {@link ListBoxModel}. Handling the {@link CredentialsMatcher} may require standing up a proxy
      * instance to apply the matcher against if {@link CredentialsMatchers#describe(CredentialsMatcher)} returns
      * {@code null}
@@ -1423,13 +1423,13 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @since 2.1.0
      */
     @NonNull
-    public <C extends IdCredentials> ListBoxModel getCredentialIds(@NonNull Class<C> type,
+    public <C extends IdCredentials> ListBoxModel getCredentialIds2(@NonNull Class<C> type,
                                                                    @Nullable ItemGroup itemGroup,
                                                                    @Nullable Authentication authentication,
                                                                    @NonNull
                                                                            List<DomainRequirement> domainRequirements,
                                                                    @NonNull CredentialsMatcher matcher) {
-        return getCredentials(type, itemGroup, authentication, domainRequirements)
+        return getCredentials2(type, itemGroup, authentication, domainRequirements)
                 .stream()
                 .filter(matcher::matches)
                 .sorted(new CredentialsNameComparator())
@@ -1446,7 +1446,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @param authentication the authentication (if {@code null} assume {@link ACL#SYSTEM}.
      * @param <C>            the credentials type.
      * @return the list of credentials.
-     * @deprecated Use {@link #getCredentials(Class, Item, Authentication)} instead.
+     * @deprecated Use {@link #getCredentials2(Class, Item, Authentication)} instead.
      */
     @Deprecated
     @NonNull
@@ -1454,7 +1454,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                           @NonNull Item item,
                                                           @Nullable org.acegisecurity.Authentication authentication) {
         Objects.requireNonNull(item);
-        return getCredentials(type, item.getParent(), authentication);
+        return getCredentials2(type, item.getParent(), authentication == null ? null : authentication.toSpring());
     }
 
     /**
@@ -1468,11 +1468,11 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @return the list of credentials.
      */
     @NonNull
-    public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type,
+    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type,
                                                           @NonNull Item item,
                                                           @Nullable Authentication authentication) {
         Objects.requireNonNull(item);
-        return getCredentials(type, item.getParent(), authentication);
+        return getCredentials2(type, item.getParent(), authentication);
     }
 
     /**
@@ -1485,7 +1485,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @param domainRequirements the credential domain to match.
      * @param <C>                the credentials type.
      * @return the list of credentials.
-     * @deprecated Use {@link #getCredentials(Class, Item, Authentication, List)} instead.
+     * @deprecated Use {@link #getCredentials2(Class, Item, Authentication, List)} instead.
      * @since 1.5
      */
     @Deprecated
@@ -1494,7 +1494,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                           @NonNull Item item,
                                                           @Nullable org.acegisecurity.Authentication authentication,
                                                           @NonNull List<DomainRequirement> domainRequirements) {
-        return getCredentials(type, item, authentication == null ? null : authentication.toSpring(), domainRequirements);
+        return getCredentials2(type, item, authentication == null ? null : authentication.toSpring(), domainRequirements);
     }
 
     /**
@@ -1510,11 +1510,11 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @since 1.5
      */
     @NonNull
-    public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type,
+    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type,
                                                           @NonNull Item item,
                                                           @Nullable Authentication authentication,
                                                           @NonNull List<DomainRequirement> domainRequirements) {
-        return getCredentials(type, item instanceof ItemGroup ? (ItemGroup) item : item.getParent(),
+        return getCredentials2(type, item instanceof ItemGroup ? (ItemGroup) item : item.getParent(),
                 authentication, domainRequirements);
     }
 
@@ -1524,7 +1524,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * specified {@link DomainRequirement}s.
      * <strong>NOTE:</strong> implementations are recommended to override this method if the actual secret information
      * is being stored external from Jenkins and the non-secret information can be accessed with lesser traceability
-     * requirements. The default implementation just uses {@link #getCredentials(Class, Item, Authentication, List)}
+     * requirements. The default implementation just uses {@link #getCredentials2(Class, Item, Authentication, List)}
      * to build the {@link ListBoxModel}. Handling the {@link CredentialsMatcher} may require standing up a proxy
      * instance to apply the matcher against.
      *
@@ -1536,7 +1536,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @param <C>                the credentials type.
      * @return the {@link ListBoxModel} of {@link IdCredentials#getId()} with names provided by
      * {@link CredentialsNameProvider}.
-     * @deprecated Use {@link #getCredentialIds(Class, Item, Authentication, List, CredentialsMatcher)} instead.
+     * @deprecated Use {@link #getCredentialIds2(Class, Item, Authentication, List, CredentialsMatcher)} instead.
      * @since 2.1.0
      */
     @NonNull
@@ -1546,7 +1546,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                                    @Nullable org.acegisecurity.Authentication authentication,
                                                                    @NonNull List<DomainRequirement> domainRequirements,
                                                                    @NonNull CredentialsMatcher matcher) {
-        return getCredentialIds(type, item, authentication == null ? null : authentication.toSpring(), domainRequirements, matcher);
+        return getCredentialIds2(type, item, authentication == null ? null : authentication.toSpring(), domainRequirements, matcher);
     }
 
     /**
@@ -1555,7 +1555,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * specified {@link DomainRequirement}s.
      * <strong>NOTE:</strong> implementations are recommended to override this method if the actual secret information
      * is being stored external from Jenkins and the non-secret information can be accessed with lesser traceability
-     * requirements. The default implementation just uses {@link #getCredentials(Class, Item, Authentication, List)}
+     * requirements. The default implementation just uses {@link #getCredentials2(Class, Item, Authentication, List)}
      * to build the {@link ListBoxModel}. Handling the {@link CredentialsMatcher} may require standing up a proxy
      * instance to apply the matcher against.
      *
@@ -1570,15 +1570,15 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @since 2.1.0
      */
     @NonNull
-    public <C extends IdCredentials> ListBoxModel getCredentialIds(@NonNull Class<C> type,
+    public <C extends IdCredentials> ListBoxModel getCredentialIds2(@NonNull Class<C> type,
                                                                    @NonNull Item item,
                                                                    @Nullable Authentication authentication,
                                                                    @NonNull List<DomainRequirement> domainRequirements,
                                                                    @NonNull CredentialsMatcher matcher) {
         if (item instanceof ItemGroup) {
-            return getCredentialIds(type, (ItemGroup) item, authentication, domainRequirements, matcher);
+            return getCredentialIds2(type, (ItemGroup) item, authentication, domainRequirements, matcher);
         }
-        return getCredentials(type, item, authentication, domainRequirements)
+        return getCredentials2(type, item, authentication, domainRequirements)
                 .stream()
                 .filter(matcher::matches)
                 .sorted(new CredentialsNameComparator())

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
@@ -867,6 +867,15 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
+     * @deprecated Use {@link #findCredentialById(String, Class, Run, List)} instead.
+     */
+    public static <C extends IdCredentials> C findCredentialById(@NonNull String id, @NonNull Class<C> type,
+                                                                 @NonNull Run<?, ?> run,
+                                                                 DomainRequirement... domainRequirements) {
+        return findCredentialById(id, type, run, Arrays.asList(domainRequirements));
+    }
+
+    /**
      * A common requirement for plugins is to resolve a specific credential by id in the context of a specific run.
      * Given that the credential itself could be resulting from a build parameter expression and the complexities of
      * determining the scope of items from which the credential should be resolved in a chain of builds, this method

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
@@ -1144,7 +1144,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * @deprecated use {@link #getCredentials2(Class, Item, Authentication)} instead.
+     * @deprecated use {@link #getCredentials2(Class, Item, Authentication, List)} instead.
      */
     @NonNull
     @Deprecated

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
@@ -122,8 +122,8 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
          */
         @NonNull
         @Override
-        public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
-                                                              @Nullable Authentication authentication) {
+        public <C extends Credentials> List<C> getCredentials2ItemGroup(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
+                                                                        @Nullable Authentication authentication) {
             return Collections.emptyList();
         }
     };
@@ -243,16 +243,8 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * Returns all credentials which are available to the {@link ACL#SYSTEM} {@link Authentication}
-     * within the {@link Jenkins#get()}.
-     *
-     * @param type the type of credentials to get.
-     * @param <C>  the credentials type.
-     * @return the list of credentials.
-     * @deprecated use {@link #lookupCredentials(Class, Item, Authentication, List)},
-     * {@link #lookupCredentials(Class, Item, Authentication, DomainRequirement...)},
-     * {@link #lookupCredentials(Class, ItemGroup, Authentication, List)}
-     * or {@link #lookupCredentials(Class, ItemGroup, Authentication, DomainRequirement...)}
+     * @deprecated use {@link #lookupCredentials(Class, Item, Authentication, List)}
+     * or {@link #lookupCredentials(Class, ItemGroup, Authentication, List)}
      */
     @Deprecated
     @NonNull
@@ -262,17 +254,8 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * Returns all credentials which are available to the specified {@link Authentication}
-     * within the {@link Jenkins#get()}.
-     *
-     * @param type           the type of credentials to get.
-     * @param authentication the authentication.
-     * @param <C>            the credentials type.
-     * @return the list of credentials.
      * @deprecated use {@link #lookupCredentials(Class, Item, Authentication, List)},
-     * {@link #lookupCredentials(Class, Item, Authentication, DomainRequirement...)},
      * {@link #lookupCredentials(Class, ItemGroup, Authentication, List)}
-     * or {@link #lookupCredentials(Class, ItemGroup, Authentication, DomainRequirement...)}
      */
     @Deprecated
     @NonNull
@@ -283,15 +266,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * Returns all credentials which are available to the {@link ACL#SYSTEM} {@link Authentication}
-     * for use by the specified {@link Item}.
-     *
-     * @param type the type of credentials to get.
-     * @param item the item.
-     * @param <C>  the credentials type.
-     * @return the list of credentials.
-     * @deprecated use {@link #lookupCredentials(Class, Item, Authentication, List)}
-     * or {@link #lookupCredentials(Class, Item, Authentication, DomainRequirement...)}
+     * @deprecated use {@link #lookupCredentials(Class, Item, Authentication, List)} instead.
      */
     @Deprecated
     @NonNull
@@ -304,15 +279,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * Returns all credentials which are available to the {@link ACL#SYSTEM} {@link Authentication}
-     * for use by the {@link Item}s in the specified {@link ItemGroup}.
-     *
-     * @param type      the type of credentials to get.
-     * @param itemGroup the item group.
-     * @param <C>       the credentials type.
-     * @return the list of credentials.
-     * @deprecated use {@link #lookupCredentials(Class, ItemGroup, Authentication, List)}
-     * or {@link #lookupCredentials(Class, ItemGroup, Authentication, DomainRequirement...)}
+     * @deprecated use {@link #lookupCredentials(Class, ItemGroup, Authentication, List)} instead.
      */
     @Deprecated
     @NonNull
@@ -323,16 +290,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * Returns all credentials which are available to the specified {@link Authentication}
-     * for use by the {@link Item}s in the specified {@link ItemGroup}.
-     *
-     * @param type           the type of credentials to get.
-     * @param itemGroup      the item group.
-     * @param authentication the authentication.
-     * @param <C>            the credentials type.
-     * @return the list of credentials.
-     * @deprecated use {@link #lookupCredentials(Class, ItemGroup, Authentication, List)}
-     * or {@link #lookupCredentials(Class, ItemGroup, Authentication, DomainRequirement...)}
+     * @deprecated use {@link #lookupCredentials(Class, ItemGroup, Authentication, List)} instead.
      */
     @Deprecated
     @NonNull
@@ -344,16 +302,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * Returns all credentials which are available to the specified {@link Authentication}
-     * for use by the specified {@link Item}.
-     *
-     * @param type           the type of credentials to get.
-     * @param authentication the authentication.
-     * @param item           the item.
-     * @param <C>            the credentials type.
-     * @return the list of credentials.
-     * @deprecated use {@link #lookupCredentials(Class, Item, Authentication, List)}
-     * or {@link #lookupCredentials(Class, Item, Authentication, DomainRequirement...)}
+     * @deprecated use {@link #lookupCredentials(Class, Item, Authentication, List)} instead.
      */
     @Deprecated
     @NonNull
@@ -365,17 +314,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * Returns all credentials which are available to the specified {@link Authentication}
-     * for use by the {@link Item}s in the specified {@link ItemGroup}.
-     *
-     * @param type               the type of credentials to get.
-     * @param itemGroup          the item group.
-     * @param authentication     the authentication.
-     * @param domainRequirements the credential domains to match.
-     * @param <C>                the credentials type.
-     * @return the list of credentials.
-     * @since 1.5
-     * @deprecated Use {@link #lookupCredentials(Class, ItemGroup, Authentication, List)} instead.
+     * @deprecated Use {@link #lookupCredentials(Class, ItemGroup, Authentication, List)} or {@link #lookupCredentials(Class, ItemGroup, Authentication)}.
      */
     @Deprecated
     @NonNull
@@ -394,31 +333,20 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @param type               the type of credentials to get.
      * @param itemGroup          the item group.
      * @param authentication     the authentication.
-     * @param domainRequirements the credential domains to match.
      * @param <C>                the credentials type.
      * @return the list of credentials.
-     * @since 1.5
+     * @since TODO
      */
     @NonNull
     @SuppressWarnings({"unchecked", "unused"}) // API entry point for consumers
     public static <C extends Credentials> List<C> lookupCredentials(@NonNull Class<C> type,
                                                                     @Nullable ItemGroup itemGroup,
-                                                                    @Nullable Authentication authentication,
-                                                                    @Nullable DomainRequirement... domainRequirements) {
-        return lookupCredentials(type, itemGroup, authentication == null ? null : authentication, Arrays.asList(domainRequirements));
+                                                                    @Nullable Authentication authentication) {
+        return lookupCredentials(type, itemGroup, authentication, List.of());
     }
 
     /**
-     * Returns all credentials which are available to the specified {@link Authentication}
-     * for use by the {@link Item}s in the specified {@link ItemGroup}.
-     *
-     * @param type               the type of credentials to get.
-     * @param itemGroup          the item group.
-     * @param authentication     the authentication.
-     * @param domainRequirements the credential domains to match.
-     * @param <C>                the credentials type.
-     * @return the list of credentials.
-     * @since 1.5
+     * @deprecated Use {@link #lookupCredentials(Class, ItemGroup, Authentication, List)} instead.
      */
     @NonNull
     @SuppressWarnings({"unchecked", "unused"}) // API entry point for consumers
@@ -426,8 +354,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     public static <C extends Credentials> List<C> lookupCredentials(@NonNull Class<C> type,
                                                                     @Nullable ItemGroup itemGroup,
                                                                     @Nullable org.acegisecurity.Authentication authentication,
-                                                                    @Nullable List<DomainRequirement>
-                                                                            domainRequirements) {
+                                                                    @Nullable List<DomainRequirement> domainRequirements) {
         return lookupCredentials(type, itemGroup, authentication == null ? null : authentication.toSpring(), domainRequirements);
     }
 
@@ -441,15 +368,14 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @param domainRequirements the credential domains to match.
      * @param <C>                the credentials type.
      * @return the list of credentials.
-     * @since 1.5
+     * @since TODO
      */
     @NonNull
     @SuppressWarnings({"unchecked", "unused"}) // API entry point for consumers
     public static <C extends Credentials> List<C> lookupCredentials(@NonNull Class<C> type,
                                                                     @Nullable ItemGroup itemGroup,
                                                                     @Nullable Authentication authentication,
-                                                                    @Nullable List<DomainRequirement>
-                                                                            domainRequirements) {
+                                                                    @Nullable List<DomainRequirement> domainRequirements) {
         Objects.requireNonNull(type);
         Jenkins jenkins = Jenkins.get();
         itemGroup = itemGroup == null ? jenkins : itemGroup;
@@ -470,7 +396,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
         for (CredentialsProvider provider : all()) {
             if (provider.isEnabled(itemGroup) && provider.isApplicable(type)) {
                 try {
-                    for (C c : provider.getCredentials2(type, itemGroup, authentication, domainRequirements)) {
+                    for (C c : provider.getCredentials2ItemGroup(type, itemGroup, authentication, domainRequirements)) {
                         if (!(c instanceof IdCredentials) || ids.add(((IdCredentials) c).getId())) {
                             // if IdCredentials, only add if we haven't added already
                             // if not IdCredentials, always add
@@ -487,19 +413,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * Returns a {@link ListBoxModel} of all credentials which are available to the specified {@link Authentication}
-     * for use by the {@link Item}s in the specified {@link ItemGroup}.
-     *
-     * @param type               the type of credentials to get.
-     * @param authentication     the authentication.
-     * @param itemGroup          the item group.
-     * @param domainRequirements the credential domains to match.
-     * @param matcher            the additional filtering to apply to the credentials
-     * @param <C>                the credentials type.
-     * @return the {@link ListBoxModel} of {@link IdCredentials#getId()} with the corresponding display names as
-     * provided by {@link CredentialsNameProvider}.
      * @deprecated Use {@link #listCredentials(Class, ItemGroup, Authentication, List, CredentialsMatcher)} instead.
-     * @since 2.1.0
      */
     @Deprecated
     public static <C extends IdCredentials> ListBoxModel listCredentials(@NonNull Class<C> type,
@@ -523,7 +437,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @param <C>                the credentials type.
      * @return the {@link ListBoxModel} of {@link IdCredentials#getId()} with the corresponding display names as
      * provided by {@link CredentialsNameProvider}.
-     * @since 2.1.0
+     * @since TODO
      */
     public static <C extends IdCredentials> ListBoxModel listCredentials(@NonNull Class<C> type,
                                                                          @Nullable ItemGroup itemGroup,
@@ -550,7 +464,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
         for (CredentialsProvider provider : all()) {
             if (provider.isEnabled(itemGroup) && provider.isApplicable(type)) {
                 try {
-                    for (ListBoxModel.Option option : provider.getCredentialIds2(
+                    for (ListBoxModel.Option option : provider.getCredentialIds2ItemGroup(
                             type, itemGroup, authentication, domainRequirements, matcher)
                             ) {
                         if (ids.add(option.value)) {
@@ -568,17 +482,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * Returns all credentials which are available to the specified {@link Authentication}
-     * for use by the specified {@link Item}.
-     *
-     * @param type               the type of credentials to get.
-     * @param authentication     the authentication.
-     * @param item               the item.
-     * @param domainRequirements the credential domains to match.
-     * @param <C>                the credentials type.
-     * @return the list of credentials.
-     * @deprecated use {@link #lookupCredentials(Class, ItemGroup, Authentication, DomainRequirement...)}
-     * @since 1.5
+     * @deprecated use {@link #lookupCredentials(Class, ItemGroup, Authentication, List)} or {@link #lookupCredentials(Class, ItemGroup, Authentication)}.
      */
     @Deprecated
     @NonNull
@@ -587,7 +491,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                                     @Nullable Item item,
                                                                     @Nullable org.acegisecurity.Authentication authentication,
                                                                     DomainRequirement... domainRequirements) {
-        return lookupCredentials(type, item, authentication == null ? null : authentication.toSpring(), domainRequirements);
+        return lookupCredentials(type, item, authentication == null ? null : authentication.toSpring(), Arrays.asList(domainRequirements));
     }
 
     /**
@@ -597,32 +501,20 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @param type               the type of credentials to get.
      * @param authentication     the authentication.
      * @param item               the item.
-     * @param domainRequirements the credential domains to match.
      * @param <C>                the credentials type.
      * @return the list of credentials.
-     * @since 1.5
+     * @since TODO
      */
     @NonNull
     @SuppressWarnings("unused") // API entry point for consumers
     public static <C extends Credentials> List<C> lookupCredentials(@NonNull Class<C> type,
                                                                     @Nullable Item item,
-                                                                    @Nullable Authentication authentication,
-                                                                    DomainRequirement... domainRequirements) {
-        return lookupCredentials(type, item, authentication, Arrays.asList(domainRequirements));
+                                                                    @Nullable Authentication authentication) {
+        return lookupCredentials(type, item, authentication, List.of());
     }
 
     /**
-     * Returns all credentials which are available to the specified {@link Authentication}
-     * for use by the specified {@link Item}.
-     *
-     * @param type               the type of credentials to get.
-     * @param authentication     the authentication.
-     * @param item               the item.
-     * @param domainRequirements the credential domains to match.
-     * @param <C>                the credentials type.
-     * @return the list of credentials.
      * @deprecated use {@link #lookupCredentials(Class, Item, Authentication, List)}
-     * @since 1.5
      */
     @NonNull
     @SuppressWarnings("unused") // API entry point for consumers
@@ -645,7 +537,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @param domainRequirements the credential domains to match.
      * @param <C>                the credentials type.
      * @return the list of credentials.
-     * @since 1.5
+     * @since TODO
      */
     @NonNull
     @SuppressWarnings("unused") // API entry point for consumers
@@ -678,7 +570,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
         for (CredentialsProvider provider : all()) {
             if (provider.isEnabled(item) && provider.isApplicable(type)) {
                 try {
-                    for (C c: provider.getCredentials2(type, item, authentication, domainRequirements)) {
+                    for (C c: provider.getCredentials2Item(type, item, authentication, domainRequirements)) {
                         if (!(c instanceof IdCredentials) || ids.add(((IdCredentials) c).getId())) {
                             // if IdCredentials, only add if we haven't added already
                             // if not IdCredentials, always add
@@ -695,19 +587,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * Returns a {@link ListBoxModel} of all credentials which are available to the specified {@link Authentication}
-     * for use by the specified {@link Item}.
-     *
-     * @param type               the type of credentials to get.
-     * @param authentication     the authentication.
-     * @param item               the item.
-     * @param domainRequirements the credential domains to match.
-     * @param matcher            the additional filtering to apply to the credentials
-     * @param <C>                the credentials type.
-     * @return the {@link ListBoxModel} of {@link IdCredentials#getId()} with the corresponding display names as
-     * provided by {@link CredentialsNameProvider}.
      * @deprecated Use {@link #listCredentials(Class, Item, Authentication, List, CredentialsMatcher)} instead.
-     * @since 2.1.0
      */
     @NonNull
     @Deprecated
@@ -732,7 +612,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @param <C>                the credentials type.
      * @return the {@link ListBoxModel} of {@link IdCredentials#getId()} with the corresponding display names as
      * provided by {@link CredentialsNameProvider}.
-     * @since 2.1.0
+     * @since TODO
      */
     @NonNull
     public static <C extends IdCredentials> ListBoxModel listCredentials(@NonNull Class<C> type,
@@ -763,7 +643,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
         for (CredentialsProvider provider : all()) {
             if (provider.isEnabled(item) && provider.isApplicable(type)) {
                 try {
-                    for (ListBoxModel.Option option : provider.getCredentialIds2(
+                    for (ListBoxModel.Option option : provider.getCredentialIds2Item(
                             type, item, authentication, domainRequirements, matcher)
                             ) {
                         if (ids.add(option.value)) {
@@ -966,16 +846,6 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
 
     /**
      * Helper method to get the default authentication to use for an {@link Item}.
-     * @deprecated use {@link #getDefaultAuthenticationOf2(Item)} instead.
-     */
-    @NonNull
-    @Deprecated
-    /*package*/ static org.acegisecurity.Authentication getDefaultAuthenticationOf(Item item) {
-        return org.acegisecurity.Authentication.fromSpring(getDefaultAuthenticationOf2(item));
-    }
-
-    /**
-     * Helper method to get the default authentication to use for an {@link Item}.
      */
     @NonNull
     /*package*/ static Authentication getDefaultAuthenticationOf2(Item item) {
@@ -995,17 +865,15 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @param id                 either the id of the credential to find or a parameter expression for the id.
      * @param type               the type of credential to find.
      * @param run                the {@link Run} defining the context within which to find the credential.
-     * @param domainRequirements the domain requirements of the credential.
      * @param <C>                the credentials type.
      * @return the credential or {@code null} if either the credential cannot be found or the user triggering the run
      * is not permitted to use the credential in the context of the run.
-     * @since 1.16
+     * @since TODO
      */
     @CheckForNull
     public static <C extends IdCredentials> C findCredentialById(@NonNull String id, @NonNull Class<C> type,
-                                                                 @NonNull Run<?, ?> run,
-                                                                 DomainRequirement... domainRequirements) {
-        return findCredentialById(id, type, run, Arrays.asList(domainRequirements));
+                                                                 @NonNull Run<?, ?> run) {
+        return findCredentialById(id, type, run, List.of());
     }
 
     /**
@@ -1284,14 +1152,14 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @param authentication the authentication (if {@code null} assume {@link ACL#SYSTEM}.
      * @param <C>            the credentials type.
      * @return the list of credentials.
-     * @deprecated use {@link #getCredentials2(Class, Item, Authentication)} instead.
+     * @deprecated use {@link #getCredentials2Item(Class, Item, Authentication)} instead.
      */
     @NonNull
     @Deprecated
     public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type,
                                                                    @Nullable ItemGroup itemGroup,
                                                                    @Nullable org.acegisecurity.Authentication authentication) {
-        return getCredentials2(type, itemGroup, authentication == null ? null : authentication.toSpring());
+        return getCredentials2ItemGroup(type, itemGroup, authentication == null ? null : authentication.toSpring());
     }
 
     /**
@@ -1306,9 +1174,9 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      */
     @NonNull
     @SuppressWarnings("deprecation")
-    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type,
-                                                                   @Nullable ItemGroup itemGroup,
-                                                                   @Nullable Authentication authentication) {
+    public <C extends Credentials> List<C> getCredentials2ItemGroup(@NonNull Class<C> type,
+                                                                    @Nullable ItemGroup itemGroup,
+                                                                    @Nullable Authentication authentication) {
         if (Util.isOverridden(CredentialsProvider.class, getClass(), "getCredentials", Class.class, ItemGroup.class, org.acegisecurity.Authentication.class)) {
             return getCredentials(type, itemGroup, authentication == null ? null : org.acegisecurity.Authentication.fromSpring(authentication));
         }
@@ -1328,7 +1196,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      *                           assume the match is true).
      * @param <C>                the credentials type.
      * @return the list of credentials.
-     * @deprecated use {@link #getCredentials2(Class, Item, Authentication, List)} instead.
+     * @deprecated use {@link #getCredentials2Item(Class, Item, Authentication, List)} instead.
      * @since 1.5
      */
     @Deprecated
@@ -1337,7 +1205,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                           @Nullable ItemGroup itemGroup,
                                                           @Nullable org.acegisecurity.Authentication authentication,
                                                           @NonNull List<DomainRequirement> domainRequirements) {
-        return getCredentials2(type, itemGroup, authentication == null ? null : authentication.toSpring(), domainRequirements);
+        return getCredentials2ItemGroup(type, itemGroup, authentication == null ? null : authentication.toSpring(), domainRequirements);
     }
 
 
@@ -1358,37 +1226,18 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      */
     @NonNull
     @SuppressWarnings("deprecation")
-    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type,
-                                                          @Nullable ItemGroup itemGroup,
-                                                          @Nullable Authentication authentication,
-                                                          @NonNull List<DomainRequirement> domainRequirements) {
+    public <C extends Credentials> List<C> getCredentials2ItemGroup(@NonNull Class<C> type,
+                                                                    @Nullable ItemGroup itemGroup,
+                                                                    @Nullable Authentication authentication,
+                                                                    @NonNull List<DomainRequirement> domainRequirements) {
         if (Util.isOverridden(CredentialsProvider.class, getClass(), "getCredentials", Class.class, ItemGroup.class, org.acegisecurity.Authentication.class, List.class)) {
             return getCredentials(type, itemGroup, authentication == null ? null : org.acegisecurity.Authentication.fromSpring(authentication), domainRequirements);
         }
-        return getCredentials2(type, itemGroup, authentication);
+        return getCredentials2ItemGroup(type, itemGroup, authentication);
     }
 
     /**
-     * Returns a {@link ListBoxModel} of the credentials provided by this provider which are available to the
-     * specified {@link Authentication} for items in the specified {@link ItemGroup} and are appropriate for the
-     * specified {@link DomainRequirement}s.
-     * <strong>NOTE:</strong> implementations are recommended to override this method if the actual secret information
-     * is being stored external from Jenkins and the non-secret information can be accessed with lesser traceability
-     * requirements. The default implementation just uses {@link #getCredentials2(Class, Item, Authentication, List)}
-     * to build the {@link ListBoxModel}. Handling the {@link CredentialsMatcher} may require standing up a proxy
-     * instance to apply the matcher against if {@link CredentialsMatchers#describe(CredentialsMatcher)} returns
-     * {@code null}
-     *
-     * @param <C>                the credentials type.
-     * @param type               the type of credentials to return.
-     * @param itemGroup          the item group (if {@code null} assume {@link Jenkins#get()}.
-     * @param authentication     the authentication (if {@code null} assume {@link ACL#SYSTEM}.
-     * @param domainRequirements the credential domain to match.
-     * @param matcher            the additional filtering to apply to the credentials
-     * @return the {@link ListBoxModel} of {@link IdCredentials#getId()} with names provided by
-     * {@link CredentialsNameProvider}.
-     * @deprecated Use {@link #getCredentialIds2(Class, ItemGroup, Authentication, List, CredentialsMatcher)} instead.
-     * @since 2.1.0
+     * @deprecated Use {@link #getCredentialIds2ItemGroup(Class, ItemGroup, Authentication, List, CredentialsMatcher)} instead.
      */
     @NonNull
     @Deprecated
@@ -1398,7 +1247,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                                    @NonNull
                                                                    List<DomainRequirement> domainRequirements,
                                                                    @NonNull CredentialsMatcher matcher) {
-        return getCredentialIds2(type, itemGroup, authentication == null ? null : authentication.toSpring(), domainRequirements, matcher);
+        return getCredentialIds2ItemGroup(type, itemGroup, authentication == null ? null : authentication.toSpring(), domainRequirements, matcher);
     }
 
     /**
@@ -1407,7 +1256,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * specified {@link DomainRequirement}s.
      * <strong>NOTE:</strong> implementations are recommended to override this method if the actual secret information
      * is being stored external from Jenkins and the non-secret information can be accessed with lesser traceability
-     * requirements. The default implementation just uses {@link #getCredentials2(Class, Item, Authentication, List)}
+     * requirements. The default implementation just uses {@link #getCredentials2Item(Class, Item, Authentication, List)}
      * to build the {@link ListBoxModel}. Handling the {@link CredentialsMatcher} may require standing up a proxy
      * instance to apply the matcher against if {@link CredentialsMatchers#describe(CredentialsMatcher)} returns
      * {@code null}
@@ -1420,16 +1269,16 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @param matcher            the additional filtering to apply to the credentials
      * @return the {@link ListBoxModel} of {@link IdCredentials#getId()} with names provided by
      * {@link CredentialsNameProvider}.
-     * @since 2.1.0
+     * @since TODO
      */
     @NonNull
-    public <C extends IdCredentials> ListBoxModel getCredentialIds2(@NonNull Class<C> type,
+    public <C extends IdCredentials> ListBoxModel getCredentialIds2ItemGroup(@NonNull Class<C> type,
                                                                    @Nullable ItemGroup itemGroup,
                                                                    @Nullable Authentication authentication,
                                                                    @NonNull
                                                                            List<DomainRequirement> domainRequirements,
                                                                    @NonNull CredentialsMatcher matcher) {
-        return getCredentials2(type, itemGroup, authentication, domainRequirements)
+        return getCredentials2ItemGroup(type, itemGroup, authentication, domainRequirements)
                 .stream()
                 .filter(matcher::matches)
                 .sorted(new CredentialsNameComparator())
@@ -1438,15 +1287,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * Returns the credentials provided by this provider which are available to the specified {@link Authentication}
-     * for the specified {@link Item}
-     *
-     * @param type           the type of credentials to return.
-     * @param item           the item.
-     * @param authentication the authentication (if {@code null} assume {@link ACL#SYSTEM}.
-     * @param <C>            the credentials type.
-     * @return the list of credentials.
-     * @deprecated Use {@link #getCredentials2(Class, Item, Authentication)} instead.
+     * @deprecated Use {@link #getCredentials2Item(Class, Item, Authentication)} instead.
      */
     @Deprecated
     @NonNull
@@ -1454,7 +1295,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                           @NonNull Item item,
                                                           @Nullable org.acegisecurity.Authentication authentication) {
         Objects.requireNonNull(item);
-        return getCredentials2(type, item.getParent(), authentication == null ? null : authentication.toSpring());
+        return getCredentials2ItemGroup(type, item.getParent(), authentication == null ? null : authentication.toSpring());
     }
 
     /**
@@ -1466,27 +1307,18 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @param authentication the authentication (if {@code null} assume {@link ACL#SYSTEM2}.
      * @param <C>            the credentials type.
      * @return the list of credentials.
+     * @since TODO
      */
     @NonNull
-    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type,
-                                                          @NonNull Item item,
-                                                          @Nullable Authentication authentication) {
+    public <C extends Credentials> List<C> getCredentials2Item(@NonNull Class<C> type,
+                                                               @NonNull Item item,
+                                                               @Nullable Authentication authentication) {
         Objects.requireNonNull(item);
-        return getCredentials2(type, item.getParent(), authentication);
+        return getCredentials2ItemGroup(type, item.getParent(), authentication);
     }
 
     /**
-     * Returns the credentials provided by this provider which are available to the specified {@link Authentication}
-     * for the specified {@link Item} and are appropriate for the specified {@link DomainRequirement}s.
-     *
-     * @param type               the type of credentials to return.
-     * @param item               the item.
-     * @param authentication     the authentication (if {@code null} assume {@link ACL#SYSTEM}.
-     * @param domainRequirements the credential domain to match.
-     * @param <C>                the credentials type.
-     * @return the list of credentials.
-     * @deprecated Use {@link #getCredentials2(Class, Item, Authentication, List)} instead.
-     * @since 1.5
+     * @deprecated Use {@link #getCredentials2Item(Class, Item, Authentication, List)} instead.
      */
     @Deprecated
     @NonNull
@@ -1494,7 +1326,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                           @NonNull Item item,
                                                           @Nullable org.acegisecurity.Authentication authentication,
                                                           @NonNull List<DomainRequirement> domainRequirements) {
-        return getCredentials2(type, item, authentication == null ? null : authentication.toSpring(), domainRequirements);
+        return getCredentials2Item(type, item, authentication == null ? null : authentication.toSpring(), domainRequirements);
     }
 
     /**
@@ -1507,37 +1339,19 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @param domainRequirements the credential domain to match.
      * @param <C>                the credentials type.
      * @return the list of credentials.
-     * @since 1.5
+     * @since TODO
      */
     @NonNull
-    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type,
-                                                          @NonNull Item item,
-                                                          @Nullable Authentication authentication,
-                                                          @NonNull List<DomainRequirement> domainRequirements) {
-        return getCredentials2(type, item instanceof ItemGroup ? (ItemGroup) item : item.getParent(),
+    public <C extends Credentials> List<C> getCredentials2Item(@NonNull Class<C> type,
+                                                               @NonNull Item item,
+                                                               @Nullable Authentication authentication,
+                                                               @NonNull List<DomainRequirement> domainRequirements) {
+        return getCredentials2ItemGroup(type, item instanceof ItemGroup ? (ItemGroup) item : item.getParent(),
                 authentication, domainRequirements);
     }
 
     /**
-     * Returns a {@link ListBoxModel} of the credentials provided by this provider which are available to the
-     * specified {@link Authentication} for the specified {@link Item} and are appropriate for the
-     * specified {@link DomainRequirement}s.
-     * <strong>NOTE:</strong> implementations are recommended to override this method if the actual secret information
-     * is being stored external from Jenkins and the non-secret information can be accessed with lesser traceability
-     * requirements. The default implementation just uses {@link #getCredentials2(Class, Item, Authentication, List)}
-     * to build the {@link ListBoxModel}. Handling the {@link CredentialsMatcher} may require standing up a proxy
-     * instance to apply the matcher against.
-     *
-     * @param type               the type of credentials to return.
-     * @param item               the item.
-     * @param authentication     the authentication (if {@code null} assume {@link ACL#SYSTEM}.
-     * @param domainRequirements the credential domain to match.
-     * @param matcher            the additional filtering to apply to the credentials
-     * @param <C>                the credentials type.
-     * @return the {@link ListBoxModel} of {@link IdCredentials#getId()} with names provided by
-     * {@link CredentialsNameProvider}.
-     * @deprecated Use {@link #getCredentialIds2(Class, Item, Authentication, List, CredentialsMatcher)} instead.
-     * @since 2.1.0
+     * @deprecated Use {@link #getCredentialIds2Item(Class, Item, Authentication, List, CredentialsMatcher)} instead.
      */
     @NonNull
     @Deprecated
@@ -1546,7 +1360,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                                    @Nullable org.acegisecurity.Authentication authentication,
                                                                    @NonNull List<DomainRequirement> domainRequirements,
                                                                    @NonNull CredentialsMatcher matcher) {
-        return getCredentialIds2(type, item, authentication == null ? null : authentication.toSpring(), domainRequirements, matcher);
+        return getCredentialIds2Item(type, item, authentication == null ? null : authentication.toSpring(), domainRequirements, matcher);
     }
 
     /**
@@ -1555,7 +1369,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * specified {@link DomainRequirement}s.
      * <strong>NOTE:</strong> implementations are recommended to override this method if the actual secret information
      * is being stored external from Jenkins and the non-secret information can be accessed with lesser traceability
-     * requirements. The default implementation just uses {@link #getCredentials2(Class, Item, Authentication, List)}
+     * requirements. The default implementation just uses {@link #getCredentials2Item(Class, Item, Authentication, List)}
      * to build the {@link ListBoxModel}. Handling the {@link CredentialsMatcher} may require standing up a proxy
      * instance to apply the matcher against.
      *
@@ -1567,18 +1381,18 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @param <C>                the credentials type.
      * @return the {@link ListBoxModel} of {@link IdCredentials#getId()} with names provided by
      * {@link CredentialsNameProvider}.
-     * @since 2.1.0
+     * @since TODO
      */
     @NonNull
-    public <C extends IdCredentials> ListBoxModel getCredentialIds2(@NonNull Class<C> type,
+    public <C extends IdCredentials> ListBoxModel getCredentialIds2Item(@NonNull Class<C> type,
                                                                    @NonNull Item item,
                                                                    @Nullable Authentication authentication,
                                                                    @NonNull List<DomainRequirement> domainRequirements,
                                                                    @NonNull CredentialsMatcher matcher) {
         if (item instanceof ItemGroup) {
-            return getCredentialIds2(type, (ItemGroup) item, authentication, domainRequirements, matcher);
+            return getCredentialIds2ItemGroup(type, (ItemGroup) item, authentication, domainRequirements, matcher);
         }
-        return getCredentials2(type, item, authentication, domainRequirements)
+        return getCredentials2Item(type, item, authentication, domainRequirements)
                 .stream()
                 .filter(matcher::matches)
                 .sorted(new CredentialsNameComparator())

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
@@ -1267,7 +1267,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
-     * @deprecated Use {@link #getCredentials2(Class, Item, Authentication)} instead.
+     * @deprecated Use {@link #getCredentials2(Class, Item, Authentication, List)} instead.
      */
     @Deprecated
     @NonNull
@@ -1276,25 +1276,6 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                           @Nullable org.acegisecurity.Authentication authentication) {
         Objects.requireNonNull(item);
         return getCredentials2(type, item.getParent(), authentication == null ? null : authentication.toSpring());
-    }
-
-    /**
-     * Returns the credentials provided by this provider which are available to the specified {@link Authentication}
-     * for the specified {@link Item}
-     *
-     * @param type           the type of credentials to return.
-     * @param item           the item.
-     * @param authentication the authentication (if {@code null} assume {@link ACL#SYSTEM2}.
-     * @param <C>            the credentials type.
-     * @return the list of credentials.
-     * @since TODO
-     */
-    @NonNull
-    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type,
-                                                           @NonNull Item item,
-                                                           @Nullable Authentication authentication) {
-        Objects.requireNonNull(item);
-        return getCredentials2(type, item.getParent(), authentication);
     }
 
     /**

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsStore.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsStore.java
@@ -41,7 +41,7 @@ import hudson.model.Saveable;
 import hudson.model.User;
 import hudson.security.ACL;
 import hudson.security.AccessControlled;
-import hudson.security.AccessDeniedException2;
+import hudson.security.AccessDeniedException3;
 import hudson.security.Permission;
 import java.io.IOException;
 import java.net.URI;
@@ -51,10 +51,10 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
-import org.acegisecurity.Authentication;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
+import org.springframework.security.core.Authentication;
 
 /**
  * A store of {@link Credentials}. Each {@link CredentialsStore} is associated with one and only one
@@ -167,6 +167,20 @@ public abstract class CredentialsStore implements AccessControlled, Saveable {
     @NonNull
     public abstract ModelObject getContext();
 
+
+    /**
+     * Checks if the given principle has the given permission.
+     *
+     * @param a          the principle.
+     * @param permission the permission.
+     * @return {@code false} if the user doesn't have the permission.
+     * @deprecated Use {@link #hasPermission2(Authentication, Permission)} instead.
+     */
+    @Deprecated
+    public boolean hasPermission(@NonNull org.acegisecurity.Authentication a, @NonNull Permission permission) {
+        return hasPermission2(a.toSpring(), permission);
+    }
+
     /**
      * Checks if the given principle has the given permission.
      *
@@ -174,7 +188,13 @@ public abstract class CredentialsStore implements AccessControlled, Saveable {
      * @param permission the permission.
      * @return {@code false} if the user doesn't have the permission.
      */
-    public abstract boolean hasPermission(@NonNull Authentication a, @NonNull Permission permission);
+    public boolean hasPermission2(@NonNull Authentication a, @NonNull Permission permission) {
+        if (Util.isOverridden(CredentialsStore.class, getClass(), "hasPermission", org.acegisecurity.Authentication.class,
+                Permission.class)) {
+            return hasPermission(org.acegisecurity.Authentication.fromSpring(a), permission);
+        }
+        throw new AbstractMethodError("Implement hasPermission2");
+    }
 
     /**
      * {@inheritDoc}
@@ -185,8 +205,8 @@ public abstract class CredentialsStore implements AccessControlled, Saveable {
         // an effective ACL implementation.
         return new ACL() {
             @Override
-            public boolean hasPermission(@NonNull Authentication a, @NonNull Permission permission) {
-                return CredentialsStore.this.hasPermission(a, permission);
+            public boolean hasPermission2(@NonNull Authentication a, @NonNull Permission permission) {
+                return CredentialsStore.this.hasPermission2(a, permission);
             }
         };
     }
@@ -197,12 +217,12 @@ public abstract class CredentialsStore implements AccessControlled, Saveable {
      * Note: This is just a convenience function.
      * </p>
      *
-     * @throws org.acegisecurity.AccessDeniedException if the user doesn't have the permission.
+     * @throws AccessDeniedException3 if the user doesn't have the permission.
      */
     public final void checkPermission(@NonNull Permission p) {
-        Authentication a = Jenkins.getAuthentication();
-        if (!hasPermission(a, p)) {
-            throw new AccessDeniedException2(a, p);
+        Authentication a = Jenkins.getAuthentication2();
+        if (!hasPermission2(a, p)) {
+            throw new AccessDeniedException3(a, p);
         }
     }
 
@@ -212,7 +232,7 @@ public abstract class CredentialsStore implements AccessControlled, Saveable {
      * @return {@code false} if the user doesn't have the permission.
      */
     public final boolean hasPermission(@NonNull Permission p) {
-        return hasPermission(Jenkins.getAuthentication(), p);
+        return hasPermission2(Jenkins.getAuthentication2(), p);
     }
 
     /**

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsStore.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsStore.java
@@ -169,11 +169,6 @@ public abstract class CredentialsStore implements AccessControlled, Saveable {
 
 
     /**
-     * Checks if the given principle has the given permission.
-     *
-     * @param a          the principle.
-     * @param permission the permission.
-     * @return {@code false} if the user doesn't have the permission.
      * @deprecated Use {@link #hasPermission2(Authentication, Permission)} instead.
      */
     @Deprecated
@@ -187,6 +182,7 @@ public abstract class CredentialsStore implements AccessControlled, Saveable {
      * @param a          the principle.
      * @param permission the permission.
      * @return {@code false} if the user doesn't have the permission.
+     * @since TODO
      */
     public boolean hasPermission2(@NonNull Authentication a, @NonNull Permission permission) {
         if (Util.isOverridden(CredentialsStore.class, getClass(), "hasPermission", org.acegisecurity.Authentication.class,

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsStoreAction.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsStoreAction.java
@@ -83,7 +83,6 @@ import jenkins.model.ModelObjectWithChildren;
 import jenkins.model.ModelObjectWithContextMenu;
 import jenkins.util.xml.XMLUtils;
 import net.sf.json.JSONObject;
-import org.acegisecurity.AccessDeniedException;
 import org.apache.commons.lang.StringUtils;
 import org.jenkins.ui.icon.IconSpec;
 import org.kohsuke.accmod.Restricted;
@@ -97,6 +96,7 @@ import org.kohsuke.stapler.WebMethod;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 import org.kohsuke.stapler.interceptor.RequirePOST;
+import org.springframework.security.access.AccessDeniedException;
 import org.xml.sax.SAXException;
 
 import static com.cloudbees.plugins.credentials.ContextMenuIconUtils.getMenuItemIconUrlByClassSpec;

--- a/src/main/java/com/cloudbees/plugins/credentials/SystemCredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/SystemCredentialsProvider.java
@@ -423,9 +423,9 @@ public class SystemCredentialsProvider extends AbstractDescribableImpl<SystemCre
          */
         @NonNull
         @Override
-        public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
-                                                               @Nullable Authentication authentication,
-                                                               @NonNull List<DomainRequirement> domainRequirements) {
+        public <C extends Credentials> List<C> getCredentialsInItemGroup(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
+                                                                         @Nullable Authentication authentication,
+                                                                         @NonNull List<DomainRequirement> domainRequirements) {
             if (ACL.SYSTEM2.equals(authentication)) {
                 CredentialsMatcher matcher = Jenkins.get() == itemGroup ? always() : not(withScope(SYSTEM));
                 return DomainCredentials.getCredentials(SystemCredentialsProvider.getInstance()
@@ -439,9 +439,9 @@ public class SystemCredentialsProvider extends AbstractDescribableImpl<SystemCre
          */
         @NonNull
         @Override
-        public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @NonNull Item item,
-                                                               @Nullable Authentication authentication,
-                                                               @NonNull List<DomainRequirement> domainRequirements) {
+        public <C extends Credentials> List<C> getCredentialsInItem(@NonNull Class<C> type, @NonNull Item item,
+                                                                    @Nullable Authentication authentication,
+                                                                    @NonNull List<DomainRequirement> domainRequirements) {
             if (ACL.SYSTEM2.equals(authentication)) {
                 return DomainCredentials.getCredentials(SystemCredentialsProvider.getInstance()
                         .getDomainCredentialsMap(), type, domainRequirements, not(withScope(SYSTEM)));

--- a/src/main/java/com/cloudbees/plugins/credentials/SystemCredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/SystemCredentialsProvider.java
@@ -423,10 +423,10 @@ public class SystemCredentialsProvider extends AbstractDescribableImpl<SystemCre
          */
         @NonNull
         @Override
-        public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type,
+        public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type,
                                                               @Nullable ItemGroup itemGroup,
                                                               @Nullable Authentication authentication) {
-            return getCredentials(type, itemGroup, authentication, Collections.emptyList());
+            return getCredentials2(type, itemGroup, authentication, Collections.emptyList());
         }
 
         /**
@@ -434,7 +434,7 @@ public class SystemCredentialsProvider extends AbstractDescribableImpl<SystemCre
          */
         @NonNull
         @Override
-        public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
+        public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
                                                               @Nullable Authentication authentication,
                                                               @NonNull List<DomainRequirement> domainRequirements) {
             if (ACL.SYSTEM2.equals(authentication)) {
@@ -450,9 +450,9 @@ public class SystemCredentialsProvider extends AbstractDescribableImpl<SystemCre
          */
         @NonNull
         @Override
-        public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type, @NonNull Item item,
+        public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @NonNull Item item,
                                                               @Nullable Authentication authentication) {
-            return getCredentials(type, item, authentication, Collections.emptyList());
+            return getCredentials2(type, item, authentication, Collections.emptyList());
         }
 
         /**
@@ -460,7 +460,7 @@ public class SystemCredentialsProvider extends AbstractDescribableImpl<SystemCre
          */
         @NonNull
         @Override
-        public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type, @NonNull Item item,
+        public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @NonNull Item item,
                                                               @Nullable Authentication authentication,
                                                               @NonNull List<DomainRequirement> domainRequirements) {
             if (ACL.SYSTEM2.equals(authentication)) {

--- a/src/main/java/com/cloudbees/plugins/credentials/SystemCredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/SystemCredentialsProvider.java
@@ -59,9 +59,9 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
-import org.acegisecurity.Authentication;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
+import org.springframework.security.core.Authentication;
 
 import static com.cloudbees.plugins.credentials.CredentialsMatchers.always;
 import static com.cloudbees.plugins.credentials.CredentialsMatchers.not;
@@ -204,7 +204,7 @@ public class SystemCredentialsProvider extends AbstractDescribableImpl<SystemCre
      */
     private void checkedSave(Permission p) throws IOException {
         checkPermission(p);
-        try (ACLContext ignored = ACL.as(ACL.SYSTEM)) {
+        try (ACLContext ignored = ACL.as2(ACL.SYSTEM2)) {
             save();
         }
     }
@@ -437,7 +437,7 @@ public class SystemCredentialsProvider extends AbstractDescribableImpl<SystemCre
         public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
                                                               @Nullable Authentication authentication,
                                                               @NonNull List<DomainRequirement> domainRequirements) {
-            if (ACL.SYSTEM.equals(authentication)) {
+            if (ACL.SYSTEM2.equals(authentication)) {
                 CredentialsMatcher matcher = Jenkins.get() == itemGroup ? always() : not(withScope(SYSTEM));
                 return DomainCredentials.getCredentials(SystemCredentialsProvider.getInstance()
                         .getDomainCredentialsMap(), type, domainRequirements, matcher);
@@ -463,7 +463,7 @@ public class SystemCredentialsProvider extends AbstractDescribableImpl<SystemCre
         public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type, @NonNull Item item,
                                                               @Nullable Authentication authentication,
                                                               @NonNull List<DomainRequirement> domainRequirements) {
-            if (ACL.SYSTEM.equals(authentication)) {
+            if (ACL.SYSTEM2.equals(authentication)) {
                 return DomainCredentials.getCredentials(SystemCredentialsProvider.getInstance()
                         .getDomainCredentialsMap(), type, domainRequirements, not(withScope(SYSTEM)));
             }
@@ -507,9 +507,9 @@ public class SystemCredentialsProvider extends AbstractDescribableImpl<SystemCre
          * {@inheritDoc}
          */
         @Override
-        public boolean hasPermission(@NonNull Authentication a, @NonNull Permission permission) {
+        public boolean hasPermission2(@NonNull Authentication a, @NonNull Permission permission) {
             // we follow the permissions of Jenkins itself
-            return getACL().hasPermission(a, permission);
+            return getACL().hasPermission2(a, permission);
         }
 
         @NonNull

--- a/src/main/java/com/cloudbees/plugins/credentials/SystemCredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/SystemCredentialsProvider.java
@@ -423,17 +423,6 @@ public class SystemCredentialsProvider extends AbstractDescribableImpl<SystemCre
          */
         @NonNull
         @Override
-        public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type,
-                                                               @Nullable ItemGroup itemGroup,
-                                                               @Nullable Authentication authentication) {
-            return getCredentials2(type, itemGroup, authentication, Collections.emptyList());
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @NonNull
-        @Override
         public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
                                                                @Nullable Authentication authentication,
                                                                @NonNull List<DomainRequirement> domainRequirements) {

--- a/src/main/java/com/cloudbees/plugins/credentials/SystemCredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/SystemCredentialsProvider.java
@@ -423,10 +423,10 @@ public class SystemCredentialsProvider extends AbstractDescribableImpl<SystemCre
          */
         @NonNull
         @Override
-        public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type,
-                                                              @Nullable ItemGroup itemGroup,
-                                                              @Nullable Authentication authentication) {
-            return getCredentials2(type, itemGroup, authentication, Collections.emptyList());
+        public <C extends Credentials> List<C> getCredentials2ItemGroup(@NonNull Class<C> type,
+                                                                        @Nullable ItemGroup itemGroup,
+                                                                        @Nullable Authentication authentication) {
+            return getCredentials2ItemGroup(type, itemGroup, authentication, Collections.emptyList());
         }
 
         /**
@@ -434,9 +434,9 @@ public class SystemCredentialsProvider extends AbstractDescribableImpl<SystemCre
          */
         @NonNull
         @Override
-        public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
-                                                              @Nullable Authentication authentication,
-                                                              @NonNull List<DomainRequirement> domainRequirements) {
+        public <C extends Credentials> List<C> getCredentials2ItemGroup(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
+                                                                        @Nullable Authentication authentication,
+                                                                        @NonNull List<DomainRequirement> domainRequirements) {
             if (ACL.SYSTEM2.equals(authentication)) {
                 CredentialsMatcher matcher = Jenkins.get() == itemGroup ? always() : not(withScope(SYSTEM));
                 return DomainCredentials.getCredentials(SystemCredentialsProvider.getInstance()
@@ -450,9 +450,9 @@ public class SystemCredentialsProvider extends AbstractDescribableImpl<SystemCre
          */
         @NonNull
         @Override
-        public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @NonNull Item item,
-                                                              @Nullable Authentication authentication) {
-            return getCredentials2(type, item, authentication, Collections.emptyList());
+        public <C extends Credentials> List<C> getCredentials2Item(@NonNull Class<C> type, @NonNull Item item,
+                                                                   @Nullable Authentication authentication) {
+            return getCredentials2Item(type, item, authentication, Collections.emptyList());
         }
 
         /**
@@ -460,9 +460,9 @@ public class SystemCredentialsProvider extends AbstractDescribableImpl<SystemCre
          */
         @NonNull
         @Override
-        public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @NonNull Item item,
-                                                              @Nullable Authentication authentication,
-                                                              @NonNull List<DomainRequirement> domainRequirements) {
+        public <C extends Credentials> List<C> getCredentials2Item(@NonNull Class<C> type, @NonNull Item item,
+                                                                   @Nullable Authentication authentication,
+                                                                   @NonNull List<DomainRequirement> domainRequirements) {
             if (ACL.SYSTEM2.equals(authentication)) {
                 return DomainCredentials.getCredentials(SystemCredentialsProvider.getInstance()
                         .getDomainCredentialsMap(), type, domainRequirements, not(withScope(SYSTEM)));

--- a/src/main/java/com/cloudbees/plugins/credentials/SystemCredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/SystemCredentialsProvider.java
@@ -423,10 +423,10 @@ public class SystemCredentialsProvider extends AbstractDescribableImpl<SystemCre
          */
         @NonNull
         @Override
-        public <C extends Credentials> List<C> getCredentials2ItemGroup(@NonNull Class<C> type,
-                                                                        @Nullable ItemGroup itemGroup,
-                                                                        @Nullable Authentication authentication) {
-            return getCredentials2ItemGroup(type, itemGroup, authentication, Collections.emptyList());
+        public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type,
+                                                               @Nullable ItemGroup itemGroup,
+                                                               @Nullable Authentication authentication) {
+            return getCredentials2(type, itemGroup, authentication, Collections.emptyList());
         }
 
         /**
@@ -434,9 +434,9 @@ public class SystemCredentialsProvider extends AbstractDescribableImpl<SystemCre
          */
         @NonNull
         @Override
-        public <C extends Credentials> List<C> getCredentials2ItemGroup(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
-                                                                        @Nullable Authentication authentication,
-                                                                        @NonNull List<DomainRequirement> domainRequirements) {
+        public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
+                                                               @Nullable Authentication authentication,
+                                                               @NonNull List<DomainRequirement> domainRequirements) {
             if (ACL.SYSTEM2.equals(authentication)) {
                 CredentialsMatcher matcher = Jenkins.get() == itemGroup ? always() : not(withScope(SYSTEM));
                 return DomainCredentials.getCredentials(SystemCredentialsProvider.getInstance()
@@ -450,9 +450,9 @@ public class SystemCredentialsProvider extends AbstractDescribableImpl<SystemCre
          */
         @NonNull
         @Override
-        public <C extends Credentials> List<C> getCredentials2Item(@NonNull Class<C> type, @NonNull Item item,
-                                                                   @Nullable Authentication authentication) {
-            return getCredentials2Item(type, item, authentication, Collections.emptyList());
+        public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @NonNull Item item,
+                                                               @Nullable Authentication authentication) {
+            return getCredentials2(type, item, authentication, Collections.emptyList());
         }
 
         /**
@@ -460,9 +460,9 @@ public class SystemCredentialsProvider extends AbstractDescribableImpl<SystemCre
          */
         @NonNull
         @Override
-        public <C extends Credentials> List<C> getCredentials2Item(@NonNull Class<C> type, @NonNull Item item,
-                                                                   @Nullable Authentication authentication,
-                                                                   @NonNull List<DomainRequirement> domainRequirements) {
+        public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @NonNull Item item,
+                                                               @Nullable Authentication authentication,
+                                                               @NonNull List<DomainRequirement> domainRequirements) {
             if (ACL.SYSTEM2.equals(authentication)) {
                 return DomainCredentials.getCredentials(SystemCredentialsProvider.getInstance()
                         .getDomainCredentialsMap(), type, domainRequirements, not(withScope(SYSTEM)));

--- a/src/main/java/com/cloudbees/plugins/credentials/SystemCredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/SystemCredentialsProvider.java
@@ -451,16 +451,6 @@ public class SystemCredentialsProvider extends AbstractDescribableImpl<SystemCre
         @NonNull
         @Override
         public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @NonNull Item item,
-                                                               @Nullable Authentication authentication) {
-            return getCredentials2(type, item, authentication, Collections.emptyList());
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @NonNull
-        @Override
-        public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @NonNull Item item,
                                                                @Nullable Authentication authentication,
                                                                @NonNull List<DomainRequirement> domainRequirements) {
             if (ACL.SYSTEM2.equals(authentication)) {

--- a/src/main/java/com/cloudbees/plugins/credentials/UserCredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/UserCredentialsProvider.java
@@ -118,9 +118,9 @@ public class UserCredentialsProvider extends CredentialsProvider {
      */
     @NonNull
     @Override
-    public <C extends Credentials> List<C> getCredentials2ItemGroup(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
-                                                                    @Nullable Authentication authentication) {
-        return getCredentials2ItemGroup(type, itemGroup, authentication, Collections.emptyList());
+    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
+                                                           @Nullable Authentication authentication) {
+        return getCredentials2(type, itemGroup, authentication, Collections.emptyList());
     }
 
     /**
@@ -128,10 +128,10 @@ public class UserCredentialsProvider extends CredentialsProvider {
      */
     @NonNull
     @Override
-    public <C extends Credentials> List<C> getCredentials2ItemGroup(@NonNull Class<C> type,
-                                                                    @Nullable ItemGroup itemGroup,
-                                                                    @Nullable Authentication authentication,
-                                                                    @NonNull List<DomainRequirement> domainRequirements) {
+    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type,
+                                                           @Nullable ItemGroup itemGroup,
+                                                           @Nullable Authentication authentication,
+                                                           @NonNull List<DomainRequirement> domainRequirements) {
         // ignore itemGroup, as per-user credentials are available on any object
         if (authentication == null) {
             // assume ACL#SYSTEM

--- a/src/main/java/com/cloudbees/plugins/credentials/UserCredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/UserCredentialsProvider.java
@@ -119,9 +119,9 @@ public class UserCredentialsProvider extends CredentialsProvider {
      */
     @NonNull
     @Override
-    public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
+    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
                                                           @Nullable Authentication authentication) {
-        return getCredentials(type, itemGroup, authentication, Collections.emptyList());
+        return getCredentials2(type, itemGroup, authentication, Collections.emptyList());
     }
 
     /**
@@ -129,7 +129,7 @@ public class UserCredentialsProvider extends CredentialsProvider {
      */
     @NonNull
     @Override
-    public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type,
+    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type,
                                                           @Nullable ItemGroup itemGroup,
                                                           @Nullable Authentication authentication,
                                                           @NonNull List<DomainRequirement> domainRequirements) {

--- a/src/main/java/com/cloudbees/plugins/credentials/UserCredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/UserCredentialsProvider.java
@@ -118,10 +118,10 @@ public class UserCredentialsProvider extends CredentialsProvider {
      */
     @NonNull
     @Override
-    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type,
-                                                           @Nullable ItemGroup itemGroup,
-                                                           @Nullable Authentication authentication,
-                                                           @NonNull List<DomainRequirement> domainRequirements) {
+    public <C extends Credentials> List<C> getCredentialsInItemGroup(@NonNull Class<C> type,
+                                                                     @Nullable ItemGroup itemGroup,
+                                                                     @Nullable Authentication authentication,
+                                                                     @NonNull List<DomainRequirement> domainRequirements) {
         // ignore itemGroup, as per-user credentials are available on any object
         if (authentication == null) {
             // assume ACL#SYSTEM

--- a/src/main/java/com/cloudbees/plugins/credentials/UserCredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/UserCredentialsProvider.java
@@ -42,7 +42,6 @@ import hudson.model.UserProperty;
 import hudson.model.UserPropertyDescriptor;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
-import hudson.security.AccessDeniedException2;
 import hudson.security.AccessDeniedException3;
 import hudson.security.Permission;
 import java.io.IOException;
@@ -119,9 +118,9 @@ public class UserCredentialsProvider extends CredentialsProvider {
      */
     @NonNull
     @Override
-    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
-                                                          @Nullable Authentication authentication) {
-        return getCredentials2(type, itemGroup, authentication, Collections.emptyList());
+    public <C extends Credentials> List<C> getCredentials2ItemGroup(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
+                                                                    @Nullable Authentication authentication) {
+        return getCredentials2ItemGroup(type, itemGroup, authentication, Collections.emptyList());
     }
 
     /**
@@ -129,10 +128,10 @@ public class UserCredentialsProvider extends CredentialsProvider {
      */
     @NonNull
     @Override
-    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type,
-                                                          @Nullable ItemGroup itemGroup,
-                                                          @Nullable Authentication authentication,
-                                                          @NonNull List<DomainRequirement> domainRequirements) {
+    public <C extends Credentials> List<C> getCredentials2ItemGroup(@NonNull Class<C> type,
+                                                                    @Nullable ItemGroup itemGroup,
+                                                                    @Nullable Authentication authentication,
+                                                                    @NonNull List<DomainRequirement> domainRequirements) {
         // ignore itemGroup, as per-user credentials are available on any object
         if (authentication == null) {
             // assume ACL#SYSTEM

--- a/src/main/java/com/cloudbees/plugins/credentials/UserCredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/UserCredentialsProvider.java
@@ -43,6 +43,7 @@ import hudson.model.UserPropertyDescriptor;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
 import hudson.security.AccessDeniedException2;
+import hudson.security.AccessDeniedException3;
 import hudson.security.Permission;
 import java.io.IOException;
 import java.net.URI;
@@ -59,12 +60,12 @@ import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
 import net.jcip.annotations.GuardedBy;
 import net.sf.json.JSONObject;
-import org.acegisecurity.Authentication;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
+import org.springframework.security.core.Authentication;
 
 import static com.cloudbees.plugins.credentials.CredentialsMatchers.always;
 
@@ -135,10 +136,10 @@ public class UserCredentialsProvider extends CredentialsProvider {
         // ignore itemGroup, as per-user credentials are available on any object
         if (authentication == null) {
             // assume ACL#SYSTEM
-            authentication = ACL.SYSTEM;
+            authentication = ACL.SYSTEM2;
         }
-        if (!ACL.SYSTEM.equals(authentication)) {
-            User user = User.get(authentication);
+        if (!ACL.SYSTEM2.equals(authentication)) {
+            User user = User.get2(authentication);
             if (user != null) {
                 UserCredentialsProperty property = user.getProperty(UserCredentialsProperty.class);
                 if (property != null) {
@@ -425,7 +426,7 @@ public class UserCredentialsProvider extends CredentialsProvider {
             if (user.equals(User.current())) {
                 user.checkPermission(p);
             } else {
-                throw new AccessDeniedException2(Jenkins.getAuthentication(), p);
+                throw new AccessDeniedException3(Jenkins.getAuthentication2(), p);
             }
         }
 
@@ -671,8 +672,8 @@ public class UserCredentialsProvider extends CredentialsProvider {
          * {@inheritDoc}
          */
         @Override
-        public boolean hasPermission(@NonNull Authentication a, @NonNull Permission permission) {
-            return getACL().hasPermission(a, permission);
+        public boolean hasPermission2(@NonNull Authentication a, @NonNull Permission permission) {
+            return getACL().hasPermission2(a, permission);
         }
 
         /**
@@ -683,8 +684,8 @@ public class UserCredentialsProvider extends CredentialsProvider {
         public ACL getACL() {
             return new ACL() {
                 @Override
-                public boolean hasPermission(@NonNull Authentication a, @NonNull Permission permission) {
-                    return user.equals(User.getById(a.getName(), true)) && user.getACL().hasPermission(a, permission);
+                public boolean hasPermission2(@NonNull Authentication a, @NonNull Permission permission) {
+                    return user.equals(User.getById(a.getName(), true)) && user.getACL().hasPermission2(a, permission);
                 }
             };
         }

--- a/src/main/java/com/cloudbees/plugins/credentials/UserCredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/UserCredentialsProvider.java
@@ -118,16 +118,6 @@ public class UserCredentialsProvider extends CredentialsProvider {
      */
     @NonNull
     @Override
-    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
-                                                           @Nullable Authentication authentication) {
-        return getCredentials2(type, itemGroup, authentication, Collections.emptyList());
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @NonNull
-    @Override
     public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type,
                                                            @Nullable ItemGroup itemGroup,
                                                            @Nullable Authentication authentication,

--- a/src/main/java/com/cloudbees/plugins/credentials/ViewCredentialsAction.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/ViewCredentialsAction.java
@@ -57,7 +57,6 @@ import java.util.stream.StreamSupport;
 import jenkins.model.Jenkins;
 import jenkins.model.ModelObjectWithContextMenu;
 import jenkins.model.TransientActionFactory;
-import org.acegisecurity.Authentication;
 import org.jenkins.ui.icon.IconSpec;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -65,6 +64,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
+import org.springframework.security.core.Authentication;
 
 /**
  * An {@link Action} that lets you view the available credentials for any {@link ModelObject}.
@@ -377,10 +377,10 @@ public class ViewCredentialsAction implements Action, IconSpec, AccessControlled
                 context instanceof AccessControlled ? (AccessControlled) context : Jenkins.get();
         return new ACL() {
             @Override
-            public boolean hasPermission(@NonNull Authentication a, @NonNull Permission permission) {
-                if (accessControlled.hasPermission(a, permission)) {
+            public boolean hasPermission2(@NonNull Authentication a, @NonNull Permission permission) {
+                if (accessControlled.hasPermission2(a, permission)) {
                     for (CredentialsStore s : getLocalStores()) {
-                        if (s.hasPermission(a, permission)) {
+                        if (s.hasPermission2(a, permission)) {
                             return true;
                         }
                     }

--- a/src/main/java/com/cloudbees/plugins/credentials/common/AbstractIdCredentialsListBoxModel.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/common/AbstractIdCredentialsListBoxModel.java
@@ -313,16 +313,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
     }
 
     /**
-     * Adds the ids of the specified credential type that are available to the specified context as the specified
-     * authentication.
-     *
-     * @param authentication the authentication to search with
-     * @param context        the context to add credentials from.
-     * @param type           the base class of the credentials to add.
-     * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials(Class, Item, Authentication, List, CredentialsMatcher)
      * @deprecated Use {@link #includeAs(Authentication, Item, Class)} instead.
-     * @since 2.1.0
      */
     @Deprecated
     public AbstractIdCredentialsListBoxModel<T, C> includeAs(@NonNull org.acegisecurity.Authentication authentication,
@@ -340,7 +331,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param type           the base class of the credentials to add.
      * @return {@code this} for method chaining.
      * @see CredentialsProvider#listCredentials(Class, Item, Authentication, List, CredentialsMatcher)
-     * @since 2.1.0
+     * @since TODO
      */
     public AbstractIdCredentialsListBoxModel<T, C> includeAs(@NonNull Authentication authentication,
                                                              @Nullable Item context,
@@ -349,16 +340,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
     }
 
     /**
-     * Adds the ids of the specified credential type that are available to the specified context as the specified
-     * authentication.
-     *
-     * @param authentication the authentication to search with
-     * @param context        the context to add credentials from.
-     * @param type           the base class of the credentials to add.
-     * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials(Class, ItemGroup, Authentication, List, CredentialsMatcher)
      * @deprecated Use {@link #includeAs(Authentication, ItemGroup, Class)} instead.
-     * @since 2.1.0
      */
     @Deprecated
     public AbstractIdCredentialsListBoxModel<T, C> includeAs(@NonNull org.acegisecurity.Authentication authentication,
@@ -376,7 +358,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param type           the base class of the credentials to add.
      * @return {@code this} for method chaining.
      * @see CredentialsProvider#listCredentials(Class, ItemGroup, Authentication, List, CredentialsMatcher)
-     * @since 2.1.0
+     * @since TODO
      */
     public AbstractIdCredentialsListBoxModel<T, C> includeAs(@NonNull Authentication authentication,
                                                              @NonNull ItemGroup context,
@@ -417,17 +399,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
     }
 
     /**
-     * Adds the ids of the specified credential type that are available to the specified context as the specified
-     * authentication with the specified domain requirements.
-     *
-     * @param authentication     the authentication to search with
-     * @param context            the context to add credentials from.
-     * @param type               the base class of the credentials to add.
-     * @param domainRequirements the domain requirements.
-     * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials(Class, Item, Authentication, List, CredentialsMatcher)
      * @deprecated Use {@link #includeAs(Authentication, Item, Class, List)} instead.
-     * @since 2.1.0
      */
     @Deprecated
     public AbstractIdCredentialsListBoxModel<T, C> includeAs(@NonNull org.acegisecurity.Authentication authentication,
@@ -447,7 +419,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param domainRequirements the domain requirements.
      * @return {@code this} for method chaining.
      * @see CredentialsProvider#listCredentials(Class, Item, Authentication, List, CredentialsMatcher)
-     * @since 2.1.0
+     * @since TODO
      */
     public AbstractIdCredentialsListBoxModel<T, C> includeAs(@NonNull Authentication authentication,
                                                              @Nullable Item context,
@@ -457,17 +429,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
     }
 
     /**
-     * Adds the ids of the specified credential type that are available to the specified context as the specified
-     * authentication with the specified domain requirements.
-     *
-     * @param authentication     the authentication to search with
-     * @param context            the context to add credentials from.
-     * @param type               the base class of the credentials to add.
-     * @param domainRequirements the domain requirements.
-     * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials(Class, ItemGroup, Authentication, List, CredentialsMatcher)
      * @deprecated Use {@link #includeAs(Authentication, ItemGroup, Class, List)} instead.
-     * @since 2.1.0
      */
     @Deprecated
     public AbstractIdCredentialsListBoxModel<T, C> includeAs(@NonNull org.acegisecurity.Authentication authentication,
@@ -487,7 +449,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param domainRequirements the domain requirements.
      * @return {@code this} for method chaining.
      * @see CredentialsProvider#listCredentials(Class, ItemGroup, Authentication, List, CredentialsMatcher)
-     * @since 2.1.0
+     * @since TODO
      */
     public AbstractIdCredentialsListBoxModel<T, C> includeAs(@NonNull Authentication authentication,
                                                              @NonNull ItemGroup context,
@@ -535,18 +497,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
     }
 
     /**
-     * Adds the ids of the specified credential type that are available to the specified context as the specified
-     * authentication with the specified domain requirements and match the specified filter.
-     *
-     * @param authentication     the authentication to search with
-     * @param context            the context to add credentials from.
-     * @param type               the base class of the credentials to add.
-     * @param domainRequirements the domain requirements.
-     * @param matcher            the filter to apply to the credentials.
-     * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials(Class, Item, Authentication, List, CredentialsMatcher)
      * @deprecated Use {@link #includeMatchingAs(Authentication, Item, Class, List, CredentialsMatcher)} instead.
-     * @since 2.1.0
      */
     @Deprecated
     public AbstractIdCredentialsListBoxModel<T, C> includeMatchingAs(@NonNull org.acegisecurity.Authentication authentication,
@@ -569,31 +520,20 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param matcher            the filter to apply to the credentials.
      * @return {@code this} for method chaining.
      * @see CredentialsProvider#listCredentials(Class, Item, Authentication, List, CredentialsMatcher)
-     * @since 2.1.0
+     * @since TODO
      */
     public AbstractIdCredentialsListBoxModel<T, C> includeMatchingAs(@NonNull Authentication authentication,
                                                                      @Nullable Item context,
                                                                      @NonNull Class<? extends C> type,
                                                                      @NonNull
-                                                                     List<DomainRequirement> domainRequirements,
+                                                                             List<DomainRequirement> domainRequirements,
                                                                      @NonNull CredentialsMatcher matcher) {
         addMissing(CredentialsProvider.listCredentials(type, context, authentication, domainRequirements, matcher));
         return this;
     }
 
     /**
-     * Adds the ids of the specified credential type that are available to the specified context as the specified
-     * authentication with the specified domain requirements and match the specified filter.
-     *
-     * @param authentication     the authentication to search with
-     * @param context            the context to add credentials from.
-     * @param type               the base class of the credentials to add.
-     * @param domainRequirements the domain requirements.
-     * @param matcher            the filter to apply to the credentials.
-     * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials(Class, ItemGroup, Authentication, List, CredentialsMatcher)
      * @deprecated Use {@link #includeMatchingAs(Authentication, ItemGroup, Class, List, CredentialsMatcher)} instead.
-     * @since 2.1.0
      */
     @Deprecated
     public AbstractIdCredentialsListBoxModel<T, C> includeMatchingAs(@NonNull org.acegisecurity.Authentication authentication,
@@ -616,7 +556,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param matcher            the filter to apply to the credentials.
      * @return {@code this} for method chaining.
      * @see CredentialsProvider#listCredentials(Class, ItemGroup, Authentication, List, CredentialsMatcher)
-     * @since 2.1.0
+     * @since TODO
      */
     public AbstractIdCredentialsListBoxModel<T, C> includeMatchingAs(@NonNull Authentication authentication,
                                                                      @NonNull ItemGroup context,

--- a/src/main/java/com/cloudbees/plugins/credentials/common/AbstractIdCredentialsListBoxModel.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/common/AbstractIdCredentialsListBoxModel.java
@@ -290,7 +290,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param context the context to add credentials from.
      * @param type    the base class of the credentials to add.
      * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials(Class, Item, Authentication, List, CredentialsMatcher)
+     * @see CredentialsProvider#listCredentials2(Class, Item, Authentication, List, CredentialsMatcher)
      * @since 2.1.0
      */
     public AbstractIdCredentialsListBoxModel<T, C> include(@Nullable Item context, @NonNull Class<? extends C> type) {
@@ -304,7 +304,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param context the context to add credentials from.
      * @param type    the base class of the credentials to add.
      * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials(Class, ItemGroup, Authentication, List, CredentialsMatcher)
+     * @see CredentialsProvider#listCredentials2(Class, ItemGroup, Authentication, List, CredentialsMatcher)
      * @since 2.1.0
      */
     public AbstractIdCredentialsListBoxModel<T, C> include(@NonNull ItemGroup context,
@@ -330,7 +330,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param context        the context to add credentials from.
      * @param type           the base class of the credentials to add.
      * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials(Class, Item, Authentication, List, CredentialsMatcher)
+     * @see CredentialsProvider#listCredentials2(Class, Item, Authentication, List, CredentialsMatcher)
      * @since TODO
      */
     public AbstractIdCredentialsListBoxModel<T, C> includeAs(@NonNull Authentication authentication,
@@ -357,7 +357,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param context        the context to add credentials from.
      * @param type           the base class of the credentials to add.
      * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials(Class, ItemGroup, Authentication, List, CredentialsMatcher)
+     * @see CredentialsProvider#listCredentials2(Class, ItemGroup, Authentication, List, CredentialsMatcher)
      * @since TODO
      */
     public AbstractIdCredentialsListBoxModel<T, C> includeAs(@NonNull Authentication authentication,
@@ -374,7 +374,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param type               the base class of the credentials to add.
      * @param domainRequirements the domain requirements.
      * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials(Class, Item, Authentication, List, CredentialsMatcher)
+     * @see CredentialsProvider#listCredentials2(Class, Item, Authentication, List, CredentialsMatcher)
      * @since 2.1.0
      */
     public AbstractIdCredentialsListBoxModel<T, C> include(@Nullable Item context, @NonNull Class<? extends C> type,
@@ -390,7 +390,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param type               the base class of the credentials to add.
      * @param domainRequirements the domain requirements.
      * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials(Class, ItemGroup, Authentication, List, CredentialsMatcher)
+     * @see CredentialsProvider#listCredentials2(Class, ItemGroup, Authentication, List, CredentialsMatcher)
      * @since 2.1.0
      */
     public AbstractIdCredentialsListBoxModel<T, C> include(@NonNull ItemGroup context, @NonNull Class<? extends C> type,
@@ -418,7 +418,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param type               the base class of the credentials to add.
      * @param domainRequirements the domain requirements.
      * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials(Class, Item, Authentication, List, CredentialsMatcher)
+     * @see CredentialsProvider#listCredentials2(Class, Item, Authentication, List, CredentialsMatcher)
      * @since TODO
      */
     public AbstractIdCredentialsListBoxModel<T, C> includeAs(@NonNull Authentication authentication,
@@ -448,7 +448,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param type               the base class of the credentials to add.
      * @param domainRequirements the domain requirements.
      * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials(Class, ItemGroup, Authentication, List, CredentialsMatcher)
+     * @see CredentialsProvider#listCredentials2(Class, ItemGroup, Authentication, List, CredentialsMatcher)
      * @since TODO
      */
     public AbstractIdCredentialsListBoxModel<T, C> includeAs(@NonNull Authentication authentication,
@@ -467,7 +467,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param domainRequirements the domain requirements.
      * @param matcher            the filter to apply to the credentials.
      * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials(Class, Item, Authentication, List, CredentialsMatcher)
+     * @see CredentialsProvider#listCredentials2(Class, Item, Authentication, List, CredentialsMatcher)
      * @since 2.1.0
      */
     public AbstractIdCredentialsListBoxModel<T, C> includeMatching(@Nullable Item context,
@@ -486,7 +486,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param domainRequirements the domain requirements.
      * @param matcher            the filter to apply to the credentials.
      * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials(Class, ItemGroup, Authentication, List, CredentialsMatcher)
+     * @see CredentialsProvider#listCredentials2(Class, ItemGroup, Authentication, List, CredentialsMatcher)
      * @since 2.1.0
      */
     public AbstractIdCredentialsListBoxModel<T, C> includeMatching(@NonNull ItemGroup context,
@@ -519,7 +519,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param domainRequirements the domain requirements.
      * @param matcher            the filter to apply to the credentials.
      * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials(Class, Item, Authentication, List, CredentialsMatcher)
+     * @see CredentialsProvider#listCredentials2(Class, Item, Authentication, List, CredentialsMatcher)
      * @since TODO
      */
     public AbstractIdCredentialsListBoxModel<T, C> includeMatchingAs(@NonNull Authentication authentication,
@@ -528,7 +528,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
                                                                      @NonNull
                                                                              List<DomainRequirement> domainRequirements,
                                                                      @NonNull CredentialsMatcher matcher) {
-        addMissing(CredentialsProvider.listCredentials(type, context, authentication, domainRequirements, matcher));
+        addMissing(CredentialsProvider.listCredentials2(type, context, authentication, domainRequirements, matcher));
         return this;
     }
 
@@ -555,7 +555,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param domainRequirements the domain requirements.
      * @param matcher            the filter to apply to the credentials.
      * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials(Class, ItemGroup, Authentication, List, CredentialsMatcher)
+     * @see CredentialsProvider#listCredentials2(Class, ItemGroup, Authentication, List, CredentialsMatcher)
      * @since TODO
      */
     public AbstractIdCredentialsListBoxModel<T, C> includeMatchingAs(@NonNull Authentication authentication,
@@ -564,7 +564,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
                                                                      @NonNull
                                                                              List<DomainRequirement> domainRequirements,
                                                                      @NonNull CredentialsMatcher matcher) {
-        addMissing(CredentialsProvider.listCredentials(type, context, authentication, domainRequirements, matcher));
+        addMissing(CredentialsProvider.listCredentials2(type, context, authentication, domainRequirements, matcher));
         return this;
     }
 

--- a/src/main/java/com/cloudbees/plugins/credentials/common/AbstractIdCredentialsListBoxModel.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/common/AbstractIdCredentialsListBoxModel.java
@@ -290,7 +290,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param context the context to add credentials from.
      * @param type    the base class of the credentials to add.
      * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials2(Class, Item, Authentication, List, CredentialsMatcher)
+     * @see CredentialsProvider#listCredentialsInItem(Class, Item, Authentication, List, CredentialsMatcher)
      * @since 2.1.0
      */
     public AbstractIdCredentialsListBoxModel<T, C> include(@Nullable Item context, @NonNull Class<? extends C> type) {
@@ -304,7 +304,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param context the context to add credentials from.
      * @param type    the base class of the credentials to add.
      * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials2(Class, ItemGroup, Authentication, List, CredentialsMatcher)
+     * @see CredentialsProvider#listCredentialsInItemGroup(Class, ItemGroup, Authentication, List, CredentialsMatcher)
      * @since 2.1.0
      */
     public AbstractIdCredentialsListBoxModel<T, C> include(@NonNull ItemGroup context,
@@ -330,7 +330,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param context        the context to add credentials from.
      * @param type           the base class of the credentials to add.
      * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials2(Class, Item, Authentication, List, CredentialsMatcher)
+     * @see CredentialsProvider#listCredentialsInItem(Class, Item, Authentication, List, CredentialsMatcher)
      * @since TODO
      */
     public AbstractIdCredentialsListBoxModel<T, C> includeAs(@NonNull Authentication authentication,
@@ -357,7 +357,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param context        the context to add credentials from.
      * @param type           the base class of the credentials to add.
      * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials2(Class, ItemGroup, Authentication, List, CredentialsMatcher)
+     * @see CredentialsProvider#listCredentialsInItemGroup(Class, ItemGroup, Authentication, List, CredentialsMatcher)
      * @since TODO
      */
     public AbstractIdCredentialsListBoxModel<T, C> includeAs(@NonNull Authentication authentication,
@@ -374,7 +374,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param type               the base class of the credentials to add.
      * @param domainRequirements the domain requirements.
      * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials2(Class, Item, Authentication, List, CredentialsMatcher)
+     * @see CredentialsProvider#listCredentialsInItem(Class, Item, Authentication, List, CredentialsMatcher)
      * @since 2.1.0
      */
     public AbstractIdCredentialsListBoxModel<T, C> include(@Nullable Item context, @NonNull Class<? extends C> type,
@@ -390,7 +390,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param type               the base class of the credentials to add.
      * @param domainRequirements the domain requirements.
      * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials2(Class, ItemGroup, Authentication, List, CredentialsMatcher)
+     * @see CredentialsProvider#listCredentialsInItemGroup(Class, ItemGroup, Authentication, List, CredentialsMatcher)
      * @since 2.1.0
      */
     public AbstractIdCredentialsListBoxModel<T, C> include(@NonNull ItemGroup context, @NonNull Class<? extends C> type,
@@ -418,7 +418,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param type               the base class of the credentials to add.
      * @param domainRequirements the domain requirements.
      * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials2(Class, Item, Authentication, List, CredentialsMatcher)
+     * @see CredentialsProvider#listCredentialsInItem(Class, Item, Authentication, List, CredentialsMatcher)
      * @since TODO
      */
     public AbstractIdCredentialsListBoxModel<T, C> includeAs(@NonNull Authentication authentication,
@@ -448,7 +448,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param type               the base class of the credentials to add.
      * @param domainRequirements the domain requirements.
      * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials2(Class, ItemGroup, Authentication, List, CredentialsMatcher)
+     * @see CredentialsProvider#listCredentialsInItemGroup(Class, ItemGroup, Authentication, List, CredentialsMatcher)
      * @since TODO
      */
     public AbstractIdCredentialsListBoxModel<T, C> includeAs(@NonNull Authentication authentication,
@@ -467,7 +467,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param domainRequirements the domain requirements.
      * @param matcher            the filter to apply to the credentials.
      * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials2(Class, Item, Authentication, List, CredentialsMatcher)
+     * @see CredentialsProvider#listCredentialsInItem(Class, Item, Authentication, List, CredentialsMatcher)
      * @since 2.1.0
      */
     public AbstractIdCredentialsListBoxModel<T, C> includeMatching(@Nullable Item context,
@@ -486,7 +486,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param domainRequirements the domain requirements.
      * @param matcher            the filter to apply to the credentials.
      * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials2(Class, ItemGroup, Authentication, List, CredentialsMatcher)
+     * @see CredentialsProvider#listCredentialsInItemGroup(Class, ItemGroup, Authentication, List, CredentialsMatcher)
      * @since 2.1.0
      */
     public AbstractIdCredentialsListBoxModel<T, C> includeMatching(@NonNull ItemGroup context,
@@ -519,7 +519,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param domainRequirements the domain requirements.
      * @param matcher            the filter to apply to the credentials.
      * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials2(Class, Item, Authentication, List, CredentialsMatcher)
+     * @see CredentialsProvider#listCredentialsInItem(Class, Item, Authentication, List, CredentialsMatcher)
      * @since TODO
      */
     public AbstractIdCredentialsListBoxModel<T, C> includeMatchingAs(@NonNull Authentication authentication,
@@ -528,7 +528,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
                                                                      @NonNull
                                                                              List<DomainRequirement> domainRequirements,
                                                                      @NonNull CredentialsMatcher matcher) {
-        addMissing(CredentialsProvider.listCredentials2(type, context, authentication, domainRequirements, matcher));
+        addMissing(CredentialsProvider.listCredentialsInItem(type, context, authentication, domainRequirements, matcher));
         return this;
     }
 
@@ -555,7 +555,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param domainRequirements the domain requirements.
      * @param matcher            the filter to apply to the credentials.
      * @return {@code this} for method chaining.
-     * @see CredentialsProvider#listCredentials2(Class, ItemGroup, Authentication, List, CredentialsMatcher)
+     * @see CredentialsProvider#listCredentialsInItemGroup(Class, ItemGroup, Authentication, List, CredentialsMatcher)
      * @since TODO
      */
     public AbstractIdCredentialsListBoxModel<T, C> includeMatchingAs(@NonNull Authentication authentication,
@@ -564,7 +564,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
                                                                      @NonNull
                                                                              List<DomainRequirement> domainRequirements,
                                                                      @NonNull CredentialsMatcher matcher) {
-        addMissing(CredentialsProvider.listCredentials2(type, context, authentication, domainRequirements, matcher));
+        addMissing(CredentialsProvider.listCredentialsInItemGroup(type, context, authentication, domainRequirements, matcher));
         return this;
     }
 

--- a/src/main/java/com/cloudbees/plugins/credentials/common/AbstractIdCredentialsListBoxModel.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/common/AbstractIdCredentialsListBoxModel.java
@@ -43,8 +43,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import jenkins.model.Jenkins;
-import org.acegisecurity.Authentication;
 import org.apache.commons.lang.StringUtils;
+import org.springframework.security.core.Authentication;
 
 /**
  * {@link ListBoxModel} with support for credentials.
@@ -321,10 +321,48 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param type           the base class of the credentials to add.
      * @return {@code this} for method chaining.
      * @see CredentialsProvider#listCredentials(Class, Item, Authentication, List, CredentialsMatcher)
+     * @deprecated Use {@link #includeAs(Authentication, Item, Class)} instead.
+     * @since 2.1.0
+     */
+    @Deprecated
+    public AbstractIdCredentialsListBoxModel<T, C> includeAs(@NonNull org.acegisecurity.Authentication authentication,
+                                                             @Nullable Item context,
+                                                             @NonNull Class<? extends C> type) {
+        return includeAs(authentication, context, type, Collections.emptyList());
+    }
+
+    /**
+     * Adds the ids of the specified credential type that are available to the specified context as the specified
+     * authentication.
+     *
+     * @param authentication the authentication to search with
+     * @param context        the context to add credentials from.
+     * @param type           the base class of the credentials to add.
+     * @return {@code this} for method chaining.
+     * @see CredentialsProvider#listCredentials(Class, Item, Authentication, List, CredentialsMatcher)
      * @since 2.1.0
      */
     public AbstractIdCredentialsListBoxModel<T, C> includeAs(@NonNull Authentication authentication,
                                                              @Nullable Item context,
+                                                             @NonNull Class<? extends C> type) {
+        return includeAs(authentication, context, type, Collections.emptyList());
+    }
+
+    /**
+     * Adds the ids of the specified credential type that are available to the specified context as the specified
+     * authentication.
+     *
+     * @param authentication the authentication to search with
+     * @param context        the context to add credentials from.
+     * @param type           the base class of the credentials to add.
+     * @return {@code this} for method chaining.
+     * @see CredentialsProvider#listCredentials(Class, ItemGroup, Authentication, List, CredentialsMatcher)
+     * @deprecated Use {@link #includeAs(Authentication, ItemGroup, Class)} instead.
+     * @since 2.1.0
+     */
+    @Deprecated
+    public AbstractIdCredentialsListBoxModel<T, C> includeAs(@NonNull org.acegisecurity.Authentication authentication,
+                                                             @NonNull ItemGroup context,
                                                              @NonNull Class<? extends C> type) {
         return includeAs(authentication, context, type, Collections.emptyList());
     }
@@ -388,6 +426,27 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
      * @param domainRequirements the domain requirements.
      * @return {@code this} for method chaining.
      * @see CredentialsProvider#listCredentials(Class, Item, Authentication, List, CredentialsMatcher)
+     * @deprecated Use {@link #includeAs(Authentication, Item, Class, List)} instead.
+     * @since 2.1.0
+     */
+    @Deprecated
+    public AbstractIdCredentialsListBoxModel<T, C> includeAs(@NonNull org.acegisecurity.Authentication authentication,
+                                                             @Nullable Item context,
+                                                             @NonNull Class<? extends C> type,
+                                                             @NonNull List<DomainRequirement> domainRequirements) {
+        return includeMatchingAs(authentication, context, type, domainRequirements, CredentialsMatchers.always());
+    }
+
+    /**
+     * Adds the ids of the specified credential type that are available to the specified context as the specified
+     * authentication with the specified domain requirements.
+     *
+     * @param authentication     the authentication to search with
+     * @param context            the context to add credentials from.
+     * @param type               the base class of the credentials to add.
+     * @param domainRequirements the domain requirements.
+     * @return {@code this} for method chaining.
+     * @see CredentialsProvider#listCredentials(Class, Item, Authentication, List, CredentialsMatcher)
      * @since 2.1.0
      */
     public AbstractIdCredentialsListBoxModel<T, C> includeAs(@NonNull Authentication authentication,
@@ -395,6 +454,27 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
                                                              @NonNull Class<? extends C> type,
                                                              @NonNull List<DomainRequirement> domainRequirements) {
         return includeMatchingAs(authentication, context, type, domainRequirements, CredentialsMatchers.always());
+    }
+
+    /**
+     * Adds the ids of the specified credential type that are available to the specified context as the specified
+     * authentication with the specified domain requirements.
+     *
+     * @param authentication     the authentication to search with
+     * @param context            the context to add credentials from.
+     * @param type               the base class of the credentials to add.
+     * @param domainRequirements the domain requirements.
+     * @return {@code this} for method chaining.
+     * @see CredentialsProvider#listCredentials(Class, ItemGroup, Authentication, List, CredentialsMatcher)
+     * @deprecated Use {@link #includeAs(Authentication, ItemGroup, Class, List)} instead.
+     * @since 2.1.0
+     */
+    @Deprecated
+    public AbstractIdCredentialsListBoxModel<T, C> includeAs(@NonNull org.acegisecurity.Authentication authentication,
+                                                             @NonNull ItemGroup context,
+                                                             @NonNull Class<? extends C> type,
+                                                             @NonNull List<DomainRequirement> domainRequirements) {
+        return includeMatchingAs(authentication.toSpring(), context, type, domainRequirements, CredentialsMatchers.always());
     }
 
     /**
@@ -432,7 +512,7 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
                                                                    @NonNull Class<? extends C> type,
                                                                    @NonNull List<DomainRequirement> domainRequirements,
                                                                    @NonNull CredentialsMatcher matcher) {
-        return includeMatchingAs(Jenkins.getAuthentication(), context, type, domainRequirements, matcher);
+        return includeMatchingAs(Jenkins.getAuthentication2(), context, type, domainRequirements, matcher);
     }
 
     /**
@@ -451,7 +531,31 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
                                                                    @NonNull Class<? extends C> type,
                                                                    @NonNull List<DomainRequirement> domainRequirements,
                                                                    @NonNull CredentialsMatcher matcher) {
-        return includeMatchingAs(Jenkins.getAuthentication(), context, type, domainRequirements, matcher);
+        return includeMatchingAs(Jenkins.getAuthentication2(), context, type, domainRequirements, matcher);
+    }
+
+    /**
+     * Adds the ids of the specified credential type that are available to the specified context as the specified
+     * authentication with the specified domain requirements and match the specified filter.
+     *
+     * @param authentication     the authentication to search with
+     * @param context            the context to add credentials from.
+     * @param type               the base class of the credentials to add.
+     * @param domainRequirements the domain requirements.
+     * @param matcher            the filter to apply to the credentials.
+     * @return {@code this} for method chaining.
+     * @see CredentialsProvider#listCredentials(Class, Item, Authentication, List, CredentialsMatcher)
+     * @deprecated Use {@link #includeMatchingAs(Authentication, Item, Class, List, CredentialsMatcher)} instead.
+     * @since 2.1.0
+     */
+    @Deprecated
+    public AbstractIdCredentialsListBoxModel<T, C> includeMatchingAs(@NonNull org.acegisecurity.Authentication authentication,
+                                                                     @Nullable Item context,
+                                                                     @NonNull Class<? extends C> type,
+                                                                     @NonNull
+                                                                             List<DomainRequirement> domainRequirements,
+                                                                     @NonNull CredentialsMatcher matcher) {
+        return includeMatchingAs(authentication.toSpring(), context, type, domainRequirements, matcher);
     }
 
     /**
@@ -471,10 +575,34 @@ public abstract class AbstractIdCredentialsListBoxModel<T extends AbstractIdCred
                                                                      @Nullable Item context,
                                                                      @NonNull Class<? extends C> type,
                                                                      @NonNull
-                                                                             List<DomainRequirement> domainRequirements,
+                                                                     List<DomainRequirement> domainRequirements,
                                                                      @NonNull CredentialsMatcher matcher) {
         addMissing(CredentialsProvider.listCredentials(type, context, authentication, domainRequirements, matcher));
         return this;
+    }
+
+    /**
+     * Adds the ids of the specified credential type that are available to the specified context as the specified
+     * authentication with the specified domain requirements and match the specified filter.
+     *
+     * @param authentication     the authentication to search with
+     * @param context            the context to add credentials from.
+     * @param type               the base class of the credentials to add.
+     * @param domainRequirements the domain requirements.
+     * @param matcher            the filter to apply to the credentials.
+     * @return {@code this} for method chaining.
+     * @see CredentialsProvider#listCredentials(Class, ItemGroup, Authentication, List, CredentialsMatcher)
+     * @deprecated Use {@link #includeMatchingAs(Authentication, ItemGroup, Class, List, CredentialsMatcher)} instead.
+     * @since 2.1.0
+     */
+    @Deprecated
+    public AbstractIdCredentialsListBoxModel<T, C> includeMatchingAs(@NonNull org.acegisecurity.Authentication authentication,
+                                                                     @NonNull ItemGroup context,
+                                                                     @NonNull Class<? extends C> type,
+                                                                     @NonNull
+                                                                             List<DomainRequirement> domainRequirements,
+                                                                     @NonNull CredentialsMatcher matcher) {
+        return includeMatchingAs(authentication.toSpring(), context, type, domainRequirements, matcher);
     }
 
     /**

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsProviderTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsProviderTest.java
@@ -41,7 +41,6 @@ import hudson.slaves.RetentionStrategy;
 import hudson.security.ACL;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
-import org.acegisecurity.Authentication;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -80,7 +79,7 @@ public class CredentialsProviderTest {
         assertFalse(CredentialsProvider.lookupCredentials(DummyCredentials.class, ACL.SYSTEM).isEmpty());
         assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, Jenkins.ANONYMOUS).isEmpty());
         assertFalse("null auth -> ACL.SYSTEM",
-                CredentialsProvider.lookupCredentials(DummyCredentials.class, (Authentication) null).isEmpty());
+                CredentialsProvider.lookupCredentials(DummyCredentials.class, (org.acegisecurity.Authentication) null).isEmpty());
 
         assertFalse(CredentialsProvider.lookupCredentials(DummyCredentials.class, Jenkins.get()).isEmpty());
         assertFalse("null item -> Root",
@@ -98,7 +97,7 @@ public class CredentialsProviderTest {
         assertFalse(CredentialsProvider.lookupCredentials(DummyCredentials.class, ACL.SYSTEM).isEmpty());
         assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, Jenkins.ANONYMOUS).isEmpty());
         assertFalse("null auth -> ACL.SYSTEM",
-                CredentialsProvider.lookupCredentials(DummyCredentials.class, (Authentication) null).isEmpty());
+                CredentialsProvider.lookupCredentials(DummyCredentials.class, (org.acegisecurity.Authentication) null).isEmpty());
 
         assertFalse(CredentialsProvider.lookupCredentials(DummyCredentials.class, Jenkins.get()).isEmpty());
         assertFalse("null item -> Root",
@@ -125,7 +124,7 @@ public class CredentialsProviderTest {
         assertFalse(CredentialsProvider.lookupCredentials(DummyCredentials.class, ACL.SYSTEM).isEmpty());
         assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, Jenkins.ANONYMOUS).isEmpty());
         assertFalse("null auth -> ACL.SYSTEM",
-                CredentialsProvider.lookupCredentials(DummyCredentials.class, (Authentication) null).isEmpty());
+                CredentialsProvider.lookupCredentials(DummyCredentials.class, (org.acegisecurity.Authentication) null).isEmpty());
 
         assertFalse(CredentialsProvider.lookupCredentials(DummyCredentials.class, Jenkins.get()).isEmpty());
         assertFalse("null item -> Root",
@@ -142,7 +141,7 @@ public class CredentialsProviderTest {
         assertFalse(CredentialsProvider.lookupCredentials(DummyCredentials.class, ACL.SYSTEM).isEmpty());
         assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, Jenkins.ANONYMOUS).isEmpty());
         assertFalse("null auth -> ACL.SYSTEM",
-                CredentialsProvider.lookupCredentials(DummyCredentials.class, (Authentication) null).isEmpty());
+                CredentialsProvider.lookupCredentials(DummyCredentials.class, (org.acegisecurity.Authentication) null).isEmpty());
 
         assertFalse(CredentialsProvider.lookupCredentials(DummyCredentials.class, Jenkins.get()).isEmpty());
         assertFalse("null item -> Root",
@@ -171,22 +170,22 @@ public class CredentialsProviderTest {
             userStore.addCredentials(Domain.global(), aliceCred1);
             userStore.addCredentials(Domain.global(), aliceCred2);
 
-            assertEquals(2, CredentialsProvider.lookupCredentials(DummyCredentials.class, (Item) null, alice.impersonate(), Collections.emptyList()).size());
-            assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, Collections.emptyList()).isEmpty());
-            assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, Jenkins.ANONYMOUS, Collections.emptyList()).isEmpty());
+            assertEquals(2, CredentialsProvider.lookupCredentials(DummyCredentials.class, (Item) null, alice.impersonate2(), Collections.emptyList()).size());
+            assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, Collections.emptyList()).isEmpty());
+            assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, Jenkins.ANONYMOUS2, Collections.emptyList()).isEmpty());
 
             // Remove credentials
             userStore.removeCredentials(Domain.global(), aliceCred2);
 
-            assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, (Item) null, alice.impersonate(), Collections.emptyList()).size());
-            assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, Collections.emptyList()).isEmpty());
-            assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, Jenkins.ANONYMOUS, Collections.emptyList()).isEmpty());
+            assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, (Item) null, alice.impersonate2(), Collections.emptyList()).size());
+            assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, Collections.emptyList()).isEmpty());
+            assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, Jenkins.ANONYMOUS2, Collections.emptyList()).isEmpty());
 
             // Update credentials
             userStore.updateCredentials(Domain.global(), aliceCred1, aliceCred3);
 
-            assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, (Item) null, alice.impersonate(), Collections.emptyList()).size());
-            assertEquals(aliceCred3.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, (Item) null, alice.impersonate(), Collections.emptyList()).get(0).getUsername());
+            assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, (Item) null, alice.impersonate2(), Collections.emptyList()).size());
+            assertEquals(aliceCred3.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, (Item) null, alice.impersonate2(), Collections.emptyList()).get(0).getUsername());
         }
     }
     
@@ -205,22 +204,22 @@ public class CredentialsProviderTest {
         store.addCredentials(Domain.global(), systemCred2);
         store.addCredentials(Domain.global(), globalCred);
         
-        assertEquals(3, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, Collections.emptyList()).size());
-        assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, project, ACL.SYSTEM, Collections.emptyList()).size());
-        assertEquals(globalCred.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, project, ACL.SYSTEM, Collections.emptyList()).get(0).getUsername());
+        assertEquals(3, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, Collections.emptyList()).size());
+        assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, project, ACL.SYSTEM2, Collections.emptyList()).size());
+        assertEquals(globalCred.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, project, ACL.SYSTEM2, Collections.emptyList()).get(0).getUsername());
     
         // Update credentials
         store.updateCredentials(Domain.global(), globalCred, modCredential);
         
-        assertEquals(3, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, Collections.emptyList()).size());
-        assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, project, ACL.SYSTEM, Collections.emptyList()).size());
-        assertEquals(modCredential.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, project, ACL.SYSTEM, Collections.emptyList()).get(0).getUsername());
+        assertEquals(3, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, Collections.emptyList()).size());
+        assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, project, ACL.SYSTEM2, Collections.emptyList()).size());
+        assertEquals(modCredential.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, project, ACL.SYSTEM2, Collections.emptyList()).get(0).getUsername());
         
         // Remove credentials
         store.removeCredentials(Domain.global(), systemCred2);
         
-        assertEquals(2, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, Collections.emptyList()).size());
-        assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, project, ACL.SYSTEM, Collections.emptyList()).size());
+        assertEquals(2, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, Collections.emptyList()).size());
+        assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, project, ACL.SYSTEM2, Collections.emptyList()).size());
     }
 
     @Test
@@ -342,10 +341,10 @@ public class CredentialsProviderTest {
     @Test
     @Issue("JENKINS-65333")
     public void insertionOrderLookupCredentials() {
-        assertThat(CredentialsProvider.lookupCredentials(Credentials.class, (Item) null, ACL.SYSTEM, Collections.emptyList()), hasSize(0));
+        assertThat(CredentialsProvider.lookupCredentials(Credentials.class, (Item) null, ACL.SYSTEM2, Collections.emptyList()), hasSize(0));
         SystemCredentialsProvider.getInstance().getCredentials().add(new DummyIdCredentials("1", CredentialsScope.SYSTEM, "beta", "bar", "description 1"));
         SystemCredentialsProvider.getInstance().getCredentials().add(new DummyIdCredentials("2", CredentialsScope.SYSTEM, "alpha", "bar", "description 2"));
-        List<DummyIdCredentials> credentials = CredentialsProvider.lookupCredentials(DummyIdCredentials.class, (Item) null, ACL.SYSTEM, Collections.emptyList());
+        List<DummyIdCredentials> credentials = CredentialsProvider.lookupCredentials(DummyIdCredentials.class, (Item) null, ACL.SYSTEM2, Collections.emptyList());
         assertThat(credentials, hasSize(2));
         // Insertion order
         assertThat(credentials.get(0).getUsername(), is("beta"));
@@ -355,10 +354,10 @@ public class CredentialsProviderTest {
     @Test
     @Issue("JENKINS-65333")
     public void credentialsSortedByNameInUI() {
-        assertThat(CredentialsProvider.lookupCredentials(Credentials.class, (Item) null, ACL.SYSTEM, Collections.emptyList()), hasSize(0));
+        assertThat(CredentialsProvider.lookupCredentials(Credentials.class, (Item) null, ACL.SYSTEM2, Collections.emptyList()), hasSize(0));
         SystemCredentialsProvider.getInstance().getCredentials().add(new DummyIdCredentials("1", CredentialsScope.SYSTEM, "beta", "bar", "description 1"));
         SystemCredentialsProvider.getInstance().getCredentials().add(new DummyIdCredentials("2", CredentialsScope.SYSTEM, "alpha", "bar", "description 2"));
-        ListBoxModel options = CredentialsProvider.listCredentials(DummyIdCredentials.class, (Item) null, ACL.SYSTEM, Collections.emptyList(), CredentialsMatchers.always());
+        ListBoxModel options = CredentialsProvider.listCredentials(DummyIdCredentials.class, (Item) null, ACL.SYSTEM2, Collections.emptyList(), CredentialsMatchers.always());
         // Options are sorted by name
         assertThat(options, hasSize(2));
         assertThat(options.get(0).value, is("2"));

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsProviderTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsProviderTest.java
@@ -111,6 +111,54 @@ public class CredentialsProviderTest {
                 "manchu");
 
     }
+
+    /**
+     * Same test as {@link #testNoCredentialsUntilWeAddSome()} but using new APIs.
+     */
+    @Test
+    public void testNoCredentialsUntilWeAddSome2() throws Exception {
+        FreeStyleProject project = r.createFreeStyleProject();
+        assertTrue(CredentialsProvider.lookupCredentials2(Credentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+        SystemCredentialsProvider.getInstance().getCredentials().add(
+                new DummyCredentials(CredentialsScope.SYSTEM, "foo", "bar"));
+        assertFalse(CredentialsProvider.lookupCredentials2(Credentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+
+        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), ACL.SYSTEM2).isEmpty());
+        assertTrue(CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), Jenkins.ANONYMOUS2).isEmpty());
+        assertFalse("null auth -> ACL.SYSTEM",
+                CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), null).isEmpty());
+
+        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), ACL.SYSTEM2).isEmpty());
+        assertFalse("null item -> Root",
+                CredentialsProvider.lookupCredentials2(DummyCredentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+        assertFalse("null item -> Root",
+                CredentialsProvider.lookupCredentials2(DummyCredentials.class, (ItemGroup) null, ACL.SYSTEM2).isEmpty());
+        assertTrue(CredentialsProvider.lookupCredentials2(DummyCredentials.class, project, ACL.SYSTEM2).isEmpty());
+
+        SystemCredentialsProvider.getInstance().getCredentials().add(
+                new DummyCredentials(CredentialsScope.GLOBAL, "manchu", "bar"));
+
+        assertFalse(CredentialsProvider.lookupCredentials2(Credentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+
+        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), ACL.SYSTEM2).isEmpty());
+        assertTrue(CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), Jenkins.ANONYMOUS2).isEmpty());
+        assertFalse("null auth -> ACL.SYSTEM",
+                CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), null).isEmpty());
+
+        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), ACL.SYSTEM2).isEmpty());
+        assertFalse("null item -> Root",
+                CredentialsProvider.lookupCredentials2(DummyCredentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+        assertFalse("null item -> Root",
+                CredentialsProvider.lookupCredentials2(DummyCredentials.class, (ItemGroup) null, ACL.SYSTEM2).isEmpty());
+        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, project, ACL.SYSTEM2).isEmpty());
+        assertEquals(CredentialsProvider.lookupCredentials2(DummyCredentials.class, project, ACL.SYSTEM2).size(), 1);
+        assertEquals(
+                CredentialsProvider.lookupCredentials2(DummyCredentials.class, project, ACL.SYSTEM2).iterator().next().getUsername(),
+                "manchu");
+
+    }
     
     @Test
     public void testNoCredentialsUntilWeAddSomeViaStore() throws Exception {
@@ -154,6 +202,52 @@ public class CredentialsProviderTest {
                 CredentialsProvider.lookupCredentials(DummyCredentials.class, project).iterator().next().getUsername(),
                 "manchu");
 
+    }
+
+    /**
+     * Same test as {@link #testNoCredentialsUntilWeAddSomeViaStore()} but using new APIs.
+     */
+    @Test
+    public void testNoCredentialsUntilWeAddSomeViaStore2() throws Exception {
+        FreeStyleProject project = r.createFreeStyleProject();
+        assertTrue(CredentialsProvider.lookupCredentials2(Credentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+        CredentialsStore store = CredentialsProvider.lookupStores(Jenkins.get()).iterator().next();
+        store.addCredentials(Domain.global(), new DummyCredentials(CredentialsScope.SYSTEM, "foo", "bar"));
+        assertFalse(CredentialsProvider.lookupCredentials2(Credentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+
+        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), ACL.SYSTEM2).isEmpty());
+        assertTrue(CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), Jenkins.ANONYMOUS2).isEmpty());
+        assertFalse("null auth -> ACL.SYSTEM",
+                CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), null).isEmpty());
+
+        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), ACL.SYSTEM2).isEmpty());
+        assertFalse("null item -> Root",
+                CredentialsProvider.lookupCredentials2(DummyCredentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+        assertFalse("null item -> Root",
+                CredentialsProvider.lookupCredentials2(DummyCredentials.class, (ItemGroup) null, ACL.SYSTEM2).isEmpty());
+        assertTrue(CredentialsProvider.lookupCredentials2(DummyCredentials.class, project, ACL.SYSTEM2).isEmpty());
+
+        store.addCredentials(Domain.global(), new DummyCredentials(CredentialsScope.GLOBAL, "manchu", "bar"));
+
+        assertFalse(CredentialsProvider.lookupCredentials2(Credentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+
+        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), ACL.SYSTEM2).isEmpty());
+        assertTrue(CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), Jenkins.ANONYMOUS2).isEmpty());
+        assertFalse("null auth -> ACL.SYSTEM",
+                CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), null).isEmpty());
+
+        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), ACL.SYSTEM2).isEmpty());
+        assertFalse("null item -> Root",
+                CredentialsProvider.lookupCredentials2(DummyCredentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+        assertFalse("null item -> Root",
+                CredentialsProvider.lookupCredentials2(DummyCredentials.class, (ItemGroup) null, ACL.SYSTEM2).isEmpty());
+        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, project, ACL.SYSTEM2).isEmpty());
+        assertEquals(CredentialsProvider.lookupCredentials2(DummyCredentials.class, project, ACL.SYSTEM2).size(), 1);
+        assertEquals(
+                CredentialsProvider.lookupCredentials2(DummyCredentials.class, project, ACL.SYSTEM2).iterator().next().getUsername(),
+                "manchu");
     }
 
     @Test

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsProviderTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsProviderTest.java
@@ -118,44 +118,44 @@ public class CredentialsProviderTest {
     @Test
     public void testNoCredentialsUntilWeAddSome2() throws Exception {
         FreeStyleProject project = r.createFreeStyleProject();
-        assertTrue(CredentialsProvider.lookupCredentials2(Credentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+        assertTrue(CredentialsProvider.lookupCredentialsInItem(Credentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
         SystemCredentialsProvider.getInstance().getCredentials().add(
                 new DummyCredentials(CredentialsScope.SYSTEM, "foo", "bar"));
-        assertFalse(CredentialsProvider.lookupCredentials2(Credentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
-        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+        assertFalse(CredentialsProvider.lookupCredentialsInItem(Credentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+        assertFalse(CredentialsProvider.lookupCredentialsInItem(DummyCredentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
 
-        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), ACL.SYSTEM2).isEmpty());
-        assertTrue(CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), Jenkins.ANONYMOUS2).isEmpty());
+        assertFalse(CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, Jenkins.get(), ACL.SYSTEM2).isEmpty());
+        assertTrue(CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, Jenkins.get(), Jenkins.ANONYMOUS2).isEmpty());
         assertFalse("null auth -> ACL.SYSTEM",
-                CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), null).isEmpty());
+                CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, Jenkins.get(), null).isEmpty());
 
-        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), ACL.SYSTEM2).isEmpty());
+        assertFalse(CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, Jenkins.get(), ACL.SYSTEM2).isEmpty());
         assertFalse("null item -> Root",
-                CredentialsProvider.lookupCredentials2(DummyCredentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+                CredentialsProvider.lookupCredentialsInItem(DummyCredentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
         assertFalse("null item -> Root",
-                CredentialsProvider.lookupCredentials2(DummyCredentials.class, (ItemGroup) null, ACL.SYSTEM2).isEmpty());
-        assertTrue(CredentialsProvider.lookupCredentials2(DummyCredentials.class, project, ACL.SYSTEM2).isEmpty());
+                CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, (ItemGroup) null, ACL.SYSTEM2).isEmpty());
+        assertTrue(CredentialsProvider.lookupCredentialsInItem(DummyCredentials.class, project, ACL.SYSTEM2).isEmpty());
 
         SystemCredentialsProvider.getInstance().getCredentials().add(
                 new DummyCredentials(CredentialsScope.GLOBAL, "manchu", "bar"));
 
-        assertFalse(CredentialsProvider.lookupCredentials2(Credentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
-        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+        assertFalse(CredentialsProvider.lookupCredentialsInItem(Credentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+        assertFalse(CredentialsProvider.lookupCredentialsInItem(DummyCredentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
 
-        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), ACL.SYSTEM2).isEmpty());
-        assertTrue(CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), Jenkins.ANONYMOUS2).isEmpty());
+        assertFalse(CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, Jenkins.get(), ACL.SYSTEM2).isEmpty());
+        assertTrue(CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, Jenkins.get(), Jenkins.ANONYMOUS2).isEmpty());
         assertFalse("null auth -> ACL.SYSTEM",
-                CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), null).isEmpty());
+                CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, Jenkins.get(), null).isEmpty());
 
-        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), ACL.SYSTEM2).isEmpty());
+        assertFalse(CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, Jenkins.get(), ACL.SYSTEM2).isEmpty());
         assertFalse("null item -> Root",
-                CredentialsProvider.lookupCredentials2(DummyCredentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+                CredentialsProvider.lookupCredentialsInItem(DummyCredentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
         assertFalse("null item -> Root",
-                CredentialsProvider.lookupCredentials2(DummyCredentials.class, (ItemGroup) null, ACL.SYSTEM2).isEmpty());
-        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, project, ACL.SYSTEM2).isEmpty());
-        assertEquals(CredentialsProvider.lookupCredentials2(DummyCredentials.class, project, ACL.SYSTEM2).size(), 1);
+                CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, (ItemGroup) null, ACL.SYSTEM2).isEmpty());
+        assertFalse(CredentialsProvider.lookupCredentialsInItem(DummyCredentials.class, project, ACL.SYSTEM2).isEmpty());
+        assertEquals(CredentialsProvider.lookupCredentialsInItem(DummyCredentials.class, project, ACL.SYSTEM2).size(), 1);
         assertEquals(
-                CredentialsProvider.lookupCredentials2(DummyCredentials.class, project, ACL.SYSTEM2).iterator().next().getUsername(),
+                CredentialsProvider.lookupCredentialsInItem(DummyCredentials.class, project, ACL.SYSTEM2).iterator().next().getUsername(),
                 "manchu");
 
     }
@@ -210,43 +210,43 @@ public class CredentialsProviderTest {
     @Test
     public void testNoCredentialsUntilWeAddSomeViaStore2() throws Exception {
         FreeStyleProject project = r.createFreeStyleProject();
-        assertTrue(CredentialsProvider.lookupCredentials2(Credentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+        assertTrue(CredentialsProvider.lookupCredentialsInItem(Credentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
         CredentialsStore store = CredentialsProvider.lookupStores(Jenkins.get()).iterator().next();
         store.addCredentials(Domain.global(), new DummyCredentials(CredentialsScope.SYSTEM, "foo", "bar"));
-        assertFalse(CredentialsProvider.lookupCredentials2(Credentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
-        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+        assertFalse(CredentialsProvider.lookupCredentialsInItem(Credentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+        assertFalse(CredentialsProvider.lookupCredentialsInItem(DummyCredentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
 
-        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), ACL.SYSTEM2).isEmpty());
-        assertTrue(CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), Jenkins.ANONYMOUS2).isEmpty());
+        assertFalse(CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, Jenkins.get(), ACL.SYSTEM2).isEmpty());
+        assertTrue(CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, Jenkins.get(), Jenkins.ANONYMOUS2).isEmpty());
         assertFalse("null auth -> ACL.SYSTEM",
-                CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), null).isEmpty());
+                CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, Jenkins.get(), null).isEmpty());
 
-        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), ACL.SYSTEM2).isEmpty());
+        assertFalse(CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, Jenkins.get(), ACL.SYSTEM2).isEmpty());
         assertFalse("null item -> Root",
-                CredentialsProvider.lookupCredentials2(DummyCredentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+                CredentialsProvider.lookupCredentialsInItem(DummyCredentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
         assertFalse("null item -> Root",
-                CredentialsProvider.lookupCredentials2(DummyCredentials.class, (ItemGroup) null, ACL.SYSTEM2).isEmpty());
-        assertTrue(CredentialsProvider.lookupCredentials2(DummyCredentials.class, project, ACL.SYSTEM2).isEmpty());
+                CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, (ItemGroup) null, ACL.SYSTEM2).isEmpty());
+        assertTrue(CredentialsProvider.lookupCredentialsInItem(DummyCredentials.class, project, ACL.SYSTEM2).isEmpty());
 
         store.addCredentials(Domain.global(), new DummyCredentials(CredentialsScope.GLOBAL, "manchu", "bar"));
 
-        assertFalse(CredentialsProvider.lookupCredentials2(Credentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
-        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+        assertFalse(CredentialsProvider.lookupCredentialsInItem(Credentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+        assertFalse(CredentialsProvider.lookupCredentialsInItem(DummyCredentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
 
-        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), ACL.SYSTEM2).isEmpty());
-        assertTrue(CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), Jenkins.ANONYMOUS2).isEmpty());
+        assertFalse(CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, Jenkins.get(), ACL.SYSTEM2).isEmpty());
+        assertTrue(CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, Jenkins.get(), Jenkins.ANONYMOUS2).isEmpty());
         assertFalse("null auth -> ACL.SYSTEM",
-                CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), null).isEmpty());
+                CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, Jenkins.get(), null).isEmpty());
 
-        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, Jenkins.get(), ACL.SYSTEM2).isEmpty());
+        assertFalse(CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, Jenkins.get(), ACL.SYSTEM2).isEmpty());
         assertFalse("null item -> Root",
-                CredentialsProvider.lookupCredentials2(DummyCredentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
+                CredentialsProvider.lookupCredentialsInItem(DummyCredentials.class, (Item) null, ACL.SYSTEM2).isEmpty());
         assertFalse("null item -> Root",
-                CredentialsProvider.lookupCredentials2(DummyCredentials.class, (ItemGroup) null, ACL.SYSTEM2).isEmpty());
-        assertFalse(CredentialsProvider.lookupCredentials2(DummyCredentials.class, project, ACL.SYSTEM2).isEmpty());
-        assertEquals(CredentialsProvider.lookupCredentials2(DummyCredentials.class, project, ACL.SYSTEM2).size(), 1);
+                CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, (ItemGroup) null, ACL.SYSTEM2).isEmpty());
+        assertFalse(CredentialsProvider.lookupCredentialsInItem(DummyCredentials.class, project, ACL.SYSTEM2).isEmpty());
+        assertEquals(CredentialsProvider.lookupCredentialsInItem(DummyCredentials.class, project, ACL.SYSTEM2).size(), 1);
         assertEquals(
-                CredentialsProvider.lookupCredentials2(DummyCredentials.class, project, ACL.SYSTEM2).iterator().next().getUsername(),
+                CredentialsProvider.lookupCredentialsInItem(DummyCredentials.class, project, ACL.SYSTEM2).iterator().next().getUsername(),
                 "manchu");
     }
 
@@ -264,22 +264,22 @@ public class CredentialsProviderTest {
             userStore.addCredentials(Domain.global(), aliceCred1);
             userStore.addCredentials(Domain.global(), aliceCred2);
 
-            assertEquals(2, CredentialsProvider.lookupCredentials2(DummyCredentials.class, (Item) null, alice.impersonate2(), Collections.emptyList()).size());
-            assertTrue(CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, Collections.emptyList()).isEmpty());
-            assertTrue(CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, Jenkins.ANONYMOUS2, Collections.emptyList()).isEmpty());
+            assertEquals(2, CredentialsProvider.lookupCredentialsInItem(DummyCredentials.class, (Item) null, alice.impersonate2(), Collections.emptyList()).size());
+            assertTrue(CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, Collections.emptyList()).isEmpty());
+            assertTrue(CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, r.jenkins, Jenkins.ANONYMOUS2, Collections.emptyList()).isEmpty());
 
             // Remove credentials
             userStore.removeCredentials(Domain.global(), aliceCred2);
 
-            assertEquals(1, CredentialsProvider.lookupCredentials2(DummyCredentials.class, (Item) null, alice.impersonate2(), Collections.emptyList()).size());
-            assertTrue(CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, Collections.emptyList()).isEmpty());
-            assertTrue(CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, Jenkins.ANONYMOUS2, Collections.emptyList()).isEmpty());
+            assertEquals(1, CredentialsProvider.lookupCredentialsInItem(DummyCredentials.class, (Item) null, alice.impersonate2(), Collections.emptyList()).size());
+            assertTrue(CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, Collections.emptyList()).isEmpty());
+            assertTrue(CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, r.jenkins, Jenkins.ANONYMOUS2, Collections.emptyList()).isEmpty());
 
             // Update credentials
             userStore.updateCredentials(Domain.global(), aliceCred1, aliceCred3);
 
-            assertEquals(1, CredentialsProvider.lookupCredentials2(DummyCredentials.class, (Item) null, alice.impersonate2(), Collections.emptyList()).size());
-            assertEquals(aliceCred3.getUsername(), CredentialsProvider.lookupCredentials2(DummyCredentials.class, (Item) null, alice.impersonate2(), Collections.emptyList()).get(0).getUsername());
+            assertEquals(1, CredentialsProvider.lookupCredentialsInItem(DummyCredentials.class, (Item) null, alice.impersonate2(), Collections.emptyList()).size());
+            assertEquals(aliceCred3.getUsername(), CredentialsProvider.lookupCredentialsInItem(DummyCredentials.class, (Item) null, alice.impersonate2(), Collections.emptyList()).get(0).getUsername());
         }
     }
     
@@ -298,22 +298,22 @@ public class CredentialsProviderTest {
         store.addCredentials(Domain.global(), systemCred2);
         store.addCredentials(Domain.global(), globalCred);
         
-        assertEquals(3, CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, Collections.emptyList()).size());
-        assertEquals(1, CredentialsProvider.lookupCredentials2(DummyCredentials.class, project, ACL.SYSTEM2, Collections.emptyList()).size());
-        assertEquals(globalCred.getUsername(), CredentialsProvider.lookupCredentials2(DummyCredentials.class, project, ACL.SYSTEM2, Collections.emptyList()).get(0).getUsername());
+        assertEquals(3, CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, Collections.emptyList()).size());
+        assertEquals(1, CredentialsProvider.lookupCredentialsInItem(DummyCredentials.class, project, ACL.SYSTEM2, Collections.emptyList()).size());
+        assertEquals(globalCred.getUsername(), CredentialsProvider.lookupCredentialsInItem(DummyCredentials.class, project, ACL.SYSTEM2, Collections.emptyList()).get(0).getUsername());
     
         // Update credentials
         store.updateCredentials(Domain.global(), globalCred, modCredential);
         
-        assertEquals(3, CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, Collections.emptyList()).size());
-        assertEquals(1, CredentialsProvider.lookupCredentials2(DummyCredentials.class, project, ACL.SYSTEM2, Collections.emptyList()).size());
-        assertEquals(modCredential.getUsername(), CredentialsProvider.lookupCredentials2(DummyCredentials.class, project, ACL.SYSTEM2, Collections.emptyList()).get(0).getUsername());
+        assertEquals(3, CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, Collections.emptyList()).size());
+        assertEquals(1, CredentialsProvider.lookupCredentialsInItem(DummyCredentials.class, project, ACL.SYSTEM2, Collections.emptyList()).size());
+        assertEquals(modCredential.getUsername(), CredentialsProvider.lookupCredentialsInItem(DummyCredentials.class, project, ACL.SYSTEM2, Collections.emptyList()).get(0).getUsername());
         
         // Remove credentials
         store.removeCredentials(Domain.global(), systemCred2);
         
-        assertEquals(2, CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, Collections.emptyList()).size());
-        assertEquals(1, CredentialsProvider.lookupCredentials2(DummyCredentials.class, project, ACL.SYSTEM2, Collections.emptyList()).size());
+        assertEquals(2, CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, Collections.emptyList()).size());
+        assertEquals(1, CredentialsProvider.lookupCredentialsInItem(DummyCredentials.class, project, ACL.SYSTEM2, Collections.emptyList()).size());
     }
 
     @Test
@@ -435,10 +435,10 @@ public class CredentialsProviderTest {
     @Test
     @Issue("JENKINS-65333")
     public void insertionOrderLookupCredentials() {
-        assertThat(CredentialsProvider.lookupCredentials2(Credentials.class, (Item) null, ACL.SYSTEM2, Collections.emptyList()), hasSize(0));
+        assertThat(CredentialsProvider.lookupCredentialsInItem(Credentials.class, (Item) null, ACL.SYSTEM2, Collections.emptyList()), hasSize(0));
         SystemCredentialsProvider.getInstance().getCredentials().add(new DummyIdCredentials("1", CredentialsScope.SYSTEM, "beta", "bar", "description 1"));
         SystemCredentialsProvider.getInstance().getCredentials().add(new DummyIdCredentials("2", CredentialsScope.SYSTEM, "alpha", "bar", "description 2"));
-        List<DummyIdCredentials> credentials = CredentialsProvider.lookupCredentials2(DummyIdCredentials.class, (Item) null, ACL.SYSTEM2, Collections.emptyList());
+        List<DummyIdCredentials> credentials = CredentialsProvider.lookupCredentialsInItem(DummyIdCredentials.class, (Item) null, ACL.SYSTEM2, Collections.emptyList());
         assertThat(credentials, hasSize(2));
         // Insertion order
         assertThat(credentials.get(0).getUsername(), is("beta"));
@@ -448,10 +448,10 @@ public class CredentialsProviderTest {
     @Test
     @Issue("JENKINS-65333")
     public void credentialsSortedByNameInUI() {
-        assertThat(CredentialsProvider.lookupCredentials2(Credentials.class, (Item) null, ACL.SYSTEM2, Collections.emptyList()), hasSize(0));
+        assertThat(CredentialsProvider.lookupCredentialsInItem(Credentials.class, (Item) null, ACL.SYSTEM2, Collections.emptyList()), hasSize(0));
         SystemCredentialsProvider.getInstance().getCredentials().add(new DummyIdCredentials("1", CredentialsScope.SYSTEM, "beta", "bar", "description 1"));
         SystemCredentialsProvider.getInstance().getCredentials().add(new DummyIdCredentials("2", CredentialsScope.SYSTEM, "alpha", "bar", "description 2"));
-        ListBoxModel options = CredentialsProvider.listCredentials2(DummyIdCredentials.class, (Item) null, ACL.SYSTEM2, Collections.emptyList(), CredentialsMatchers.always());
+        ListBoxModel options = CredentialsProvider.listCredentialsInItem(DummyIdCredentials.class, (Item) null, ACL.SYSTEM2, Collections.emptyList(), CredentialsMatchers.always());
         // Options are sorted by name
         assertThat(options, hasSize(2));
         assertThat(options.get(0).value, is("2"));

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsProviderTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsProviderTest.java
@@ -170,22 +170,22 @@ public class CredentialsProviderTest {
             userStore.addCredentials(Domain.global(), aliceCred1);
             userStore.addCredentials(Domain.global(), aliceCred2);
 
-            assertEquals(2, CredentialsProvider.lookupCredentials(DummyCredentials.class, (Item) null, alice.impersonate2(), Collections.emptyList()).size());
-            assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, Collections.emptyList()).isEmpty());
-            assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, Jenkins.ANONYMOUS2, Collections.emptyList()).isEmpty());
+            assertEquals(2, CredentialsProvider.lookupCredentials2(DummyCredentials.class, (Item) null, alice.impersonate2(), Collections.emptyList()).size());
+            assertTrue(CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, Collections.emptyList()).isEmpty());
+            assertTrue(CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, Jenkins.ANONYMOUS2, Collections.emptyList()).isEmpty());
 
             // Remove credentials
             userStore.removeCredentials(Domain.global(), aliceCred2);
 
-            assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, (Item) null, alice.impersonate2(), Collections.emptyList()).size());
-            assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, Collections.emptyList()).isEmpty());
-            assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, Jenkins.ANONYMOUS2, Collections.emptyList()).isEmpty());
+            assertEquals(1, CredentialsProvider.lookupCredentials2(DummyCredentials.class, (Item) null, alice.impersonate2(), Collections.emptyList()).size());
+            assertTrue(CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, Collections.emptyList()).isEmpty());
+            assertTrue(CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, Jenkins.ANONYMOUS2, Collections.emptyList()).isEmpty());
 
             // Update credentials
             userStore.updateCredentials(Domain.global(), aliceCred1, aliceCred3);
 
-            assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, (Item) null, alice.impersonate2(), Collections.emptyList()).size());
-            assertEquals(aliceCred3.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, (Item) null, alice.impersonate2(), Collections.emptyList()).get(0).getUsername());
+            assertEquals(1, CredentialsProvider.lookupCredentials2(DummyCredentials.class, (Item) null, alice.impersonate2(), Collections.emptyList()).size());
+            assertEquals(aliceCred3.getUsername(), CredentialsProvider.lookupCredentials2(DummyCredentials.class, (Item) null, alice.impersonate2(), Collections.emptyList()).get(0).getUsername());
         }
     }
     
@@ -204,22 +204,22 @@ public class CredentialsProviderTest {
         store.addCredentials(Domain.global(), systemCred2);
         store.addCredentials(Domain.global(), globalCred);
         
-        assertEquals(3, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, Collections.emptyList()).size());
-        assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, project, ACL.SYSTEM2, Collections.emptyList()).size());
-        assertEquals(globalCred.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, project, ACL.SYSTEM2, Collections.emptyList()).get(0).getUsername());
+        assertEquals(3, CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, Collections.emptyList()).size());
+        assertEquals(1, CredentialsProvider.lookupCredentials2(DummyCredentials.class, project, ACL.SYSTEM2, Collections.emptyList()).size());
+        assertEquals(globalCred.getUsername(), CredentialsProvider.lookupCredentials2(DummyCredentials.class, project, ACL.SYSTEM2, Collections.emptyList()).get(0).getUsername());
     
         // Update credentials
         store.updateCredentials(Domain.global(), globalCred, modCredential);
         
-        assertEquals(3, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, Collections.emptyList()).size());
-        assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, project, ACL.SYSTEM2, Collections.emptyList()).size());
-        assertEquals(modCredential.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, project, ACL.SYSTEM2, Collections.emptyList()).get(0).getUsername());
+        assertEquals(3, CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, Collections.emptyList()).size());
+        assertEquals(1, CredentialsProvider.lookupCredentials2(DummyCredentials.class, project, ACL.SYSTEM2, Collections.emptyList()).size());
+        assertEquals(modCredential.getUsername(), CredentialsProvider.lookupCredentials2(DummyCredentials.class, project, ACL.SYSTEM2, Collections.emptyList()).get(0).getUsername());
         
         // Remove credentials
         store.removeCredentials(Domain.global(), systemCred2);
         
-        assertEquals(2, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, Collections.emptyList()).size());
-        assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, project, ACL.SYSTEM2, Collections.emptyList()).size());
+        assertEquals(2, CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, Collections.emptyList()).size());
+        assertEquals(1, CredentialsProvider.lookupCredentials2(DummyCredentials.class, project, ACL.SYSTEM2, Collections.emptyList()).size());
     }
 
     @Test
@@ -341,10 +341,10 @@ public class CredentialsProviderTest {
     @Test
     @Issue("JENKINS-65333")
     public void insertionOrderLookupCredentials() {
-        assertThat(CredentialsProvider.lookupCredentials(Credentials.class, (Item) null, ACL.SYSTEM2, Collections.emptyList()), hasSize(0));
+        assertThat(CredentialsProvider.lookupCredentials2(Credentials.class, (Item) null, ACL.SYSTEM2, Collections.emptyList()), hasSize(0));
         SystemCredentialsProvider.getInstance().getCredentials().add(new DummyIdCredentials("1", CredentialsScope.SYSTEM, "beta", "bar", "description 1"));
         SystemCredentialsProvider.getInstance().getCredentials().add(new DummyIdCredentials("2", CredentialsScope.SYSTEM, "alpha", "bar", "description 2"));
-        List<DummyIdCredentials> credentials = CredentialsProvider.lookupCredentials(DummyIdCredentials.class, (Item) null, ACL.SYSTEM2, Collections.emptyList());
+        List<DummyIdCredentials> credentials = CredentialsProvider.lookupCredentials2(DummyIdCredentials.class, (Item) null, ACL.SYSTEM2, Collections.emptyList());
         assertThat(credentials, hasSize(2));
         // Insertion order
         assertThat(credentials.get(0).getUsername(), is("beta"));
@@ -354,10 +354,10 @@ public class CredentialsProviderTest {
     @Test
     @Issue("JENKINS-65333")
     public void credentialsSortedByNameInUI() {
-        assertThat(CredentialsProvider.lookupCredentials(Credentials.class, (Item) null, ACL.SYSTEM2, Collections.emptyList()), hasSize(0));
+        assertThat(CredentialsProvider.lookupCredentials2(Credentials.class, (Item) null, ACL.SYSTEM2, Collections.emptyList()), hasSize(0));
         SystemCredentialsProvider.getInstance().getCredentials().add(new DummyIdCredentials("1", CredentialsScope.SYSTEM, "beta", "bar", "description 1"));
         SystemCredentialsProvider.getInstance().getCredentials().add(new DummyIdCredentials("2", CredentialsScope.SYSTEM, "alpha", "bar", "description 2"));
-        ListBoxModel options = CredentialsProvider.listCredentials(DummyIdCredentials.class, (Item) null, ACL.SYSTEM2, Collections.emptyList(), CredentialsMatchers.always());
+        ListBoxModel options = CredentialsProvider.listCredentials2(DummyIdCredentials.class, (Item) null, ACL.SYSTEM2, Collections.emptyList(), CredentialsMatchers.always());
         // Options are sorted by name
         assertThat(options, hasSize(2));
         assertThat(options.get(0).value, is("2"));

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsUnavailableExceptionTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsUnavailableExceptionTest.java
@@ -245,7 +245,7 @@ public class CredentialsUnavailableExceptionTest {
                 throws IOException {
             StandardUsernamePasswordCredentials credentials = CredentialsMatchers.firstOrNull(
                     CredentialsProvider.lookupCredentials(StandardUsernamePasswordCredentials.class, project,
-                            CredentialsProvider.getDefaultAuthenticationOf(project),
+                            CredentialsProvider.getDefaultAuthenticationOf2(project),
                             Collections.emptyList()), CredentialsMatchers.withId(id));
             if (credentials == null) {
                 throw new IOException(String.format("Could not find credentials with id '%s'", id));

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsUnavailableExceptionTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsUnavailableExceptionTest.java
@@ -244,7 +244,7 @@ public class CredentialsUnavailableExceptionTest {
                                                        @NonNull SCMRevisionState baseline)
                 throws IOException {
             StandardUsernamePasswordCredentials credentials = CredentialsMatchers.firstOrNull(
-                    CredentialsProvider.lookupCredentials2(StandardUsernamePasswordCredentials.class, project,
+                    CredentialsProvider.lookupCredentialsInItem(StandardUsernamePasswordCredentials.class, project,
                             CredentialsProvider.getDefaultAuthenticationOf2(project),
                             Collections.emptyList()), CredentialsMatchers.withId(id));
             if (credentials == null) {

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsUnavailableExceptionTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsUnavailableExceptionTest.java
@@ -244,7 +244,7 @@ public class CredentialsUnavailableExceptionTest {
                                                        @NonNull SCMRevisionState baseline)
                 throws IOException {
             StandardUsernamePasswordCredentials credentials = CredentialsMatchers.firstOrNull(
-                    CredentialsProvider.lookupCredentials(StandardUsernamePasswordCredentials.class, project,
+                    CredentialsProvider.lookupCredentials2(StandardUsernamePasswordCredentials.class, project,
                             CredentialsProvider.getDefaultAuthenticationOf2(project),
                             Collections.emptyList()), CredentialsMatchers.withId(id));
             if (credentials == null) {

--- a/src/test/java/com/cloudbees/plugins/credentials/MockFolderCredentialsProvider.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/MockFolderCredentialsProvider.java
@@ -35,7 +35,7 @@ import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.ModelObject;
 import hudson.security.ACL;
-import hudson.security.AccessDeniedException2;
+import hudson.security.AccessDeniedException3;
 import hudson.security.Permission;
 import hudson.util.CopyOnWriteMap;
 import java.io.IOException;
@@ -45,9 +45,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import jenkins.model.Jenkins;
-import org.acegisecurity.Authentication;
-import org.acegisecurity.context.SecurityContextHolder;
 import org.jvnet.hudson.test.MockFolder;
+import org.springframework.security.core.Authentication;
 
 /**
  * Analogue of <a href="https://github.com/jenkinsci/cloudbees-folder-plugin/blob/cloudbees-folder-4.2.3/src/main/java/com/cloudbees/hudson/plugins/folder/properties/FolderCredentialsProvider.java">{@code FolderCredentialsProvider}</a> for {@link MockFolder}.
@@ -88,10 +87,10 @@ import org.jvnet.hudson.test.MockFolder;
                                                           @Nullable Authentication authentication,
                                                           @NonNull List<DomainRequirement> domainRequirements) {
         if (authentication == null) {
-            authentication = ACL.SYSTEM;
+            authentication = ACL.SYSTEM2;
         }
         List<C> result = new ArrayList<>();
-        if (ACL.SYSTEM.equals(authentication)) {
+        if (ACL.SYSTEM2.equals(authentication)) {
             while (itemGroup != null) {
                 if (itemGroup instanceof MockFolder) {
                     final MockFolder folder = (MockFolder) itemGroup;
@@ -204,7 +203,7 @@ import org.jvnet.hudson.test.MockFolder;
          */
         private void checkPermission(Permission p) {
             if (!store.hasPermission(p)) {
-                throw new AccessDeniedException2(Jenkins.getAuthentication(), p);
+                throw new AccessDeniedException3(Jenkins.getAuthentication2(), p);
             }
         }
 
@@ -217,12 +216,8 @@ import org.jvnet.hudson.test.MockFolder;
          */
         private void checkedSave(Permission p) throws IOException {
             checkPermission(p);
-            Authentication old = SecurityContextHolder.getContext().getAuthentication();
-            SecurityContextHolder.getContext().setAuthentication(ACL.SYSTEM);
-            try {
+            try (var ignored = ACL.as2(ACL.SYSTEM2)) {
                 owner.save();
-            } finally {
-                SecurityContextHolder.getContext().setAuthentication(old);
             }
         }
 
@@ -365,8 +360,8 @@ import org.jvnet.hudson.test.MockFolder;
             }
 
             @Override
-            public boolean hasPermission(@NonNull Authentication a, @NonNull Permission permission) {
-                return owner.getACL().hasPermission(a, permission);
+            public boolean hasPermission2(@NonNull Authentication a, @NonNull Permission permission) {
+                return owner.getACL().hasPermission2(a, permission);
             }
 
             /**

--- a/src/test/java/com/cloudbees/plugins/credentials/MockFolderCredentialsProvider.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/MockFolderCredentialsProvider.java
@@ -76,16 +76,16 @@ import org.springframework.security.core.Authentication;
 
     @NonNull
     @Override
-    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
-                                                          @Nullable Authentication authentication) {
-        return getCredentials2(type, itemGroup, authentication, Collections.emptyList());
+    public <C extends Credentials> List<C> getCredentials2ItemGroup(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
+                                                                    @Nullable Authentication authentication) {
+        return getCredentials2ItemGroup(type, itemGroup, authentication, Collections.emptyList());
     }
 
     @NonNull
     @Override
-    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
-                                                          @Nullable Authentication authentication,
-                                                          @NonNull List<DomainRequirement> domainRequirements) {
+    public <C extends Credentials> List<C> getCredentials2ItemGroup(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
+                                                                    @Nullable Authentication authentication,
+                                                                    @NonNull List<DomainRequirement> domainRequirements) {
         if (authentication == null) {
             authentication = ACL.SYSTEM2;
         }

--- a/src/test/java/com/cloudbees/plugins/credentials/MockFolderCredentialsProvider.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/MockFolderCredentialsProvider.java
@@ -76,16 +76,16 @@ import org.springframework.security.core.Authentication;
 
     @NonNull
     @Override
-    public <C extends Credentials> List<C> getCredentials2ItemGroup(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
-                                                                    @Nullable Authentication authentication) {
-        return getCredentials2ItemGroup(type, itemGroup, authentication, Collections.emptyList());
+    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
+                                                           @Nullable Authentication authentication) {
+        return getCredentials2(type, itemGroup, authentication, Collections.emptyList());
     }
 
     @NonNull
     @Override
-    public <C extends Credentials> List<C> getCredentials2ItemGroup(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
-                                                                    @Nullable Authentication authentication,
-                                                                    @NonNull List<DomainRequirement> domainRequirements) {
+    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
+                                                           @Nullable Authentication authentication,
+                                                           @NonNull List<DomainRequirement> domainRequirements) {
         if (authentication == null) {
             authentication = ACL.SYSTEM2;
         }

--- a/src/test/java/com/cloudbees/plugins/credentials/MockFolderCredentialsProvider.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/MockFolderCredentialsProvider.java
@@ -76,9 +76,9 @@ import org.springframework.security.core.Authentication;
 
     @NonNull
     @Override
-    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
-                                                           @Nullable Authentication authentication,
-                                                           @NonNull List<DomainRequirement> domainRequirements) {
+    public <C extends Credentials> List<C> getCredentialsInItemGroup(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
+                                                                     @Nullable Authentication authentication,
+                                                                     @NonNull List<DomainRequirement> domainRequirements) {
         if (authentication == null) {
             authentication = ACL.SYSTEM2;
         }

--- a/src/test/java/com/cloudbees/plugins/credentials/MockFolderCredentialsProvider.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/MockFolderCredentialsProvider.java
@@ -76,14 +76,14 @@ import org.springframework.security.core.Authentication;
 
     @NonNull
     @Override
-    public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
+    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
                                                           @Nullable Authentication authentication) {
-        return getCredentials(type, itemGroup, authentication, Collections.emptyList());
+        return getCredentials2(type, itemGroup, authentication, Collections.emptyList());
     }
 
     @NonNull
     @Override
-    public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
+    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
                                                           @Nullable Authentication authentication,
                                                           @NonNull List<DomainRequirement> domainRequirements) {
         if (authentication == null) {

--- a/src/test/java/com/cloudbees/plugins/credentials/MockFolderCredentialsProvider.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/MockFolderCredentialsProvider.java
@@ -77,13 +77,6 @@ import org.springframework.security.core.Authentication;
     @NonNull
     @Override
     public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
-                                                           @Nullable Authentication authentication) {
-        return getCredentials2(type, itemGroup, authentication, Collections.emptyList());
-    }
-
-    @NonNull
-    @Override
-    public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup,
                                                            @Nullable Authentication authentication,
                                                            @NonNull List<DomainRequirement> domainRequirements) {
         if (authentication == null) {

--- a/src/test/java/com/cloudbees/plugins/credentials/casc/CredentialsProviderTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/casc/CredentialsProviderTest.java
@@ -19,7 +19,6 @@ import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Mapping;
-import org.acegisecurity.Authentication;
 import org.jenkinsci.Symbol;
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import org.springframework.security.core.Authentication;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -46,7 +46,7 @@ public class CredentialsProviderTest {
     @ConfiguredWithCode("CredentialsProviderExtension.yaml")
     public void import_credentials_provider_extension_credentials() {
         List<DummyCredentials> dummyCred = CredentialsProvider.lookupCredentials(
-                DummyCredentials.class, j.jenkins, ACL.SYSTEM,
+                DummyCredentials.class, j.jenkins, ACL.SYSTEM2,
                 Collections.emptyList()
         );
         assertThat(dummyCred, hasSize(1));
@@ -54,7 +54,7 @@ public class CredentialsProviderTest {
 
         // the system provider works fine too
         List<UsernamePasswordCredentials> ups = CredentialsProvider.lookupCredentials(
-                UsernamePasswordCredentials.class, j.jenkins, ACL.SYSTEM,
+                UsernamePasswordCredentials.class, j.jenkins, ACL.SYSTEM2,
                 Collections.singletonList(new HostnameRequirement("api.test.com"))
         );
         assertThat(ups, hasSize(1));

--- a/src/test/java/com/cloudbees/plugins/credentials/casc/CredentialsProviderTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/casc/CredentialsProviderTest.java
@@ -84,7 +84,7 @@ public class CredentialsProviderTest {
 
         @NonNull
         @Override
-        public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup, @Nullable Authentication authentication) {
+        public <C extends Credentials> List<C> getCredentials2ItemGroup(@NonNull Class<C> type, @Nullable ItemGroup itemGroup, @Nullable Authentication authentication) {
             if (!type.equals(DummyCredentials.class)) {
                 return Collections.emptyList();
             }

--- a/src/test/java/com/cloudbees/plugins/credentials/casc/CredentialsProviderTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/casc/CredentialsProviderTest.java
@@ -4,6 +4,7 @@ import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.cloudbees.plugins.credentials.domains.HostnameRequirement;
 import com.cloudbees.plugins.credentials.impl.DummyCredentials;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -84,7 +85,7 @@ public class CredentialsProviderTest {
 
         @NonNull
         @Override
-        public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup, @Nullable Authentication authentication) {
+        public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup, @Nullable Authentication authentication, @Nullable List<DomainRequirement> domainRequirements) {
             if (!type.equals(DummyCredentials.class)) {
                 return Collections.emptyList();
             }

--- a/src/test/java/com/cloudbees/plugins/credentials/casc/CredentialsProviderTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/casc/CredentialsProviderTest.java
@@ -84,7 +84,7 @@ public class CredentialsProviderTest {
 
         @NonNull
         @Override
-        public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type, @Nullable ItemGroup itemGroup, @Nullable Authentication authentication) {
+        public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup, @Nullable Authentication authentication) {
             if (!type.equals(DummyCredentials.class)) {
                 return Collections.emptyList();
             }

--- a/src/test/java/com/cloudbees/plugins/credentials/casc/CredentialsProviderTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/casc/CredentialsProviderTest.java
@@ -46,7 +46,7 @@ public class CredentialsProviderTest {
     @Test
     @ConfiguredWithCode("CredentialsProviderExtension.yaml")
     public void import_credentials_provider_extension_credentials() {
-        List<DummyCredentials> dummyCred = CredentialsProvider.lookupCredentials2(
+        List<DummyCredentials> dummyCred = CredentialsProvider.lookupCredentialsInItemGroup(
                 DummyCredentials.class, j.jenkins, ACL.SYSTEM2,
                 Collections.emptyList()
         );
@@ -54,7 +54,7 @@ public class CredentialsProviderTest {
         assertThat(dummyCred.get(0).getUsername(), equalTo("user1"));
 
         // the system provider works fine too
-        List<UsernamePasswordCredentials> ups = CredentialsProvider.lookupCredentials2(
+        List<UsernamePasswordCredentials> ups = CredentialsProvider.lookupCredentialsInItemGroup(
                 UsernamePasswordCredentials.class, j.jenkins, ACL.SYSTEM2,
                 Collections.singletonList(new HostnameRequirement("api.test.com"))
         );
@@ -85,7 +85,7 @@ public class CredentialsProviderTest {
 
         @NonNull
         @Override
-        public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup, @Nullable Authentication authentication, @Nullable List<DomainRequirement> domainRequirements) {
+        public <C extends Credentials> List<C> getCredentialsInItemGroup(@NonNull Class<C> type, @Nullable ItemGroup itemGroup, @Nullable Authentication authentication, @Nullable List<DomainRequirement> domainRequirements) {
             if (!type.equals(DummyCredentials.class)) {
                 return Collections.emptyList();
             }

--- a/src/test/java/com/cloudbees/plugins/credentials/casc/CredentialsProviderTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/casc/CredentialsProviderTest.java
@@ -45,7 +45,7 @@ public class CredentialsProviderTest {
     @Test
     @ConfiguredWithCode("CredentialsProviderExtension.yaml")
     public void import_credentials_provider_extension_credentials() {
-        List<DummyCredentials> dummyCred = CredentialsProvider.lookupCredentials(
+        List<DummyCredentials> dummyCred = CredentialsProvider.lookupCredentials2(
                 DummyCredentials.class, j.jenkins, ACL.SYSTEM2,
                 Collections.emptyList()
         );
@@ -53,7 +53,7 @@ public class CredentialsProviderTest {
         assertThat(dummyCred.get(0).getUsername(), equalTo("user1"));
 
         // the system provider works fine too
-        List<UsernamePasswordCredentials> ups = CredentialsProvider.lookupCredentials(
+        List<UsernamePasswordCredentials> ups = CredentialsProvider.lookupCredentials2(
                 UsernamePasswordCredentials.class, j.jenkins, ACL.SYSTEM2,
                 Collections.singletonList(new HostnameRequirement("api.test.com"))
         );
@@ -84,7 +84,7 @@ public class CredentialsProviderTest {
 
         @NonNull
         @Override
-        public <C extends Credentials> List<C> getCredentials2ItemGroup(@NonNull Class<C> type, @Nullable ItemGroup itemGroup, @Nullable Authentication authentication) {
+        public <C extends Credentials> List<C> getCredentials2(@NonNull Class<C> type, @Nullable ItemGroup itemGroup, @Nullable Authentication authentication) {
             if (!type.equals(DummyCredentials.class)) {
                 return Collections.emptyList();
             }

--- a/src/test/java/com/cloudbees/plugins/credentials/casc/SystemCredentialsTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/casc/SystemCredentialsTest.java
@@ -58,7 +58,7 @@ public class SystemCredentialsTest {
 
     @Test
     public void import_system_credentials() {
-        List<UsernamePasswordCredentials> ups = CredentialsProvider.lookupCredentials2(
+        List<UsernamePasswordCredentials> ups = CredentialsProvider.lookupCredentialsInItemGroup(
             UsernamePasswordCredentials.class, j.jenkins, ACL.SYSTEM2,
             Collections.singletonList(new HostnameRequirement("api.test.com"))
         );

--- a/src/test/java/com/cloudbees/plugins/credentials/casc/SystemCredentialsTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/casc/SystemCredentialsTest.java
@@ -59,7 +59,7 @@ public class SystemCredentialsTest {
     @Test
     public void import_system_credentials() {
         List<UsernamePasswordCredentials> ups = CredentialsProvider.lookupCredentials(
-            UsernamePasswordCredentials.class, j.jenkins, ACL.SYSTEM,
+            UsernamePasswordCredentials.class, j.jenkins, ACL.SYSTEM2,
             Collections.singletonList(new HostnameRequirement("api.test.com"))
         );
         assertThat(ups, hasSize(1));

--- a/src/test/java/com/cloudbees/plugins/credentials/casc/SystemCredentialsTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/casc/SystemCredentialsTest.java
@@ -58,7 +58,7 @@ public class SystemCredentialsTest {
 
     @Test
     public void import_system_credentials() {
-        List<UsernamePasswordCredentials> ups = CredentialsProvider.lookupCredentials(
+        List<UsernamePasswordCredentials> ups = CredentialsProvider.lookupCredentials2(
             UsernamePasswordCredentials.class, j.jenkins, ACL.SYSTEM2,
             Collections.singletonList(new HostnameRequirement("api.test.com"))
         );

--- a/src/test/java/com/cloudbees/plugins/credentials/domains/DomainRestrictedCredentialsTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/domains/DomainRestrictedCredentialsTest.java
@@ -71,7 +71,7 @@ public class DomainRestrictedCredentialsTest {
                 .add(falseCredentials);
 
         Collection<Credentials> matchingCredentials =
-                CredentialsProvider.lookupCredentials(Credentials.class,
+                CredentialsProvider.lookupCredentials2(Credentials.class,
                         Jenkins.get(), ACL.SYSTEM2);
 
         assertThat(matchingCredentials, hasItems(trueCredentials));

--- a/src/test/java/com/cloudbees/plugins/credentials/domains/DomainRestrictedCredentialsTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/domains/DomainRestrictedCredentialsTest.java
@@ -72,7 +72,7 @@ public class DomainRestrictedCredentialsTest {
 
         Collection<Credentials> matchingCredentials =
                 CredentialsProvider.lookupCredentials(Credentials.class,
-                        Jenkins.get(), ACL.SYSTEM);
+                        Jenkins.get(), ACL.SYSTEM2);
 
         assertThat(matchingCredentials, hasItems(trueCredentials));
         assertThat(matchingCredentials, not(hasItems(falseCredentials)));

--- a/src/test/java/com/cloudbees/plugins/credentials/domains/DomainRestrictedCredentialsTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/domains/DomainRestrictedCredentialsTest.java
@@ -71,7 +71,7 @@ public class DomainRestrictedCredentialsTest {
                 .add(falseCredentials);
 
         Collection<Credentials> matchingCredentials =
-                CredentialsProvider.lookupCredentials2(Credentials.class,
+                CredentialsProvider.lookupCredentialsInItemGroup(Credentials.class,
                         Jenkins.get(), ACL.SYSTEM2);
 
         assertThat(matchingCredentials, hasItems(trueCredentials));

--- a/src/test/java/com/cloudbees/plugins/credentials/domains/DomainTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/domains/DomainTest.java
@@ -96,32 +96,32 @@ public class DomainTest {
         List<DomainRequirement> reqFoo = Arrays.asList(new DomainRequirement[] { new HostnameRequirement("foo.com") });
         List<DomainRequirement> reqBar = Arrays.asList(new DomainRequirement[] { new HostnameRequirement("bar.com") });
         
-        assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, reqFoo).isEmpty());
-        assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, reqBar).isEmpty());
+        assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).isEmpty());
+        assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).isEmpty());
     
         // Add credentials to domains
         store.addCredentials(domainFoo, systemCred);
         store.addCredentials(domainBar, systemCred1);
     
         // Search credentials with specific domain restrictions
-        assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, reqFoo).size());
-        assertEquals(systemCred.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, reqFoo).get(0).getUsername());
-        assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, reqBar).size());
-        assertEquals(systemCred1.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, reqBar).get(0).getUsername());
+        assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).size());
+        assertEquals(systemCred.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).get(0).getUsername());
+        assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).size());
+        assertEquals(systemCred1.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).get(0).getUsername());
     
         // Update credential from domain
         store.updateCredentials(domainFoo, systemCred, systemCredMod);
         
-        assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, reqFoo).size());
-        assertEquals(systemCredMod.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, reqFoo).get(0).getUsername());
-        assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, reqBar).size());
-        assertEquals(systemCred1.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, reqBar).get(0).getUsername());
+        assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).size());
+        assertEquals(systemCredMod.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).get(0).getUsername());
+        assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).size());
+        assertEquals(systemCred1.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).get(0).getUsername());
   
         // Remove credential from domain
         store.removeCredentials(domainFoo, systemCredMod);
         
-        assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, reqFoo).isEmpty());
-        assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, reqBar).size());
-        assertEquals(systemCred1.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM, reqBar).get(0).getUsername());
+        assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).isEmpty());
+        assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).size());
+        assertEquals(systemCred1.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).get(0).getUsername());
     }
 }

--- a/src/test/java/com/cloudbees/plugins/credentials/domains/DomainTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/domains/DomainTest.java
@@ -96,32 +96,32 @@ public class DomainTest {
         List<DomainRequirement> reqFoo = Arrays.asList(new DomainRequirement[] { new HostnameRequirement("foo.com") });
         List<DomainRequirement> reqBar = Arrays.asList(new DomainRequirement[] { new HostnameRequirement("bar.com") });
         
-        assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).isEmpty());
-        assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).isEmpty());
+        assertTrue(CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).isEmpty());
+        assertTrue(CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).isEmpty());
     
         // Add credentials to domains
         store.addCredentials(domainFoo, systemCred);
         store.addCredentials(domainBar, systemCred1);
     
         // Search credentials with specific domain restrictions
-        assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).size());
-        assertEquals(systemCred.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).get(0).getUsername());
-        assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).size());
-        assertEquals(systemCred1.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).get(0).getUsername());
+        assertEquals(1, CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).size());
+        assertEquals(systemCred.getUsername(), CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).get(0).getUsername());
+        assertEquals(1, CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).size());
+        assertEquals(systemCred1.getUsername(), CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).get(0).getUsername());
     
         // Update credential from domain
         store.updateCredentials(domainFoo, systemCred, systemCredMod);
         
-        assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).size());
-        assertEquals(systemCredMod.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).get(0).getUsername());
-        assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).size());
-        assertEquals(systemCred1.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).get(0).getUsername());
+        assertEquals(1, CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).size());
+        assertEquals(systemCredMod.getUsername(), CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).get(0).getUsername());
+        assertEquals(1, CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).size());
+        assertEquals(systemCred1.getUsername(), CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).get(0).getUsername());
   
         // Remove credential from domain
         store.removeCredentials(domainFoo, systemCredMod);
         
-        assertTrue(CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).isEmpty());
-        assertEquals(1, CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).size());
-        assertEquals(systemCred1.getUsername(), CredentialsProvider.lookupCredentials(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).get(0).getUsername());
+        assertTrue(CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).isEmpty());
+        assertEquals(1, CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).size());
+        assertEquals(systemCred1.getUsername(), CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).get(0).getUsername());
     }
 }

--- a/src/test/java/com/cloudbees/plugins/credentials/domains/DomainTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/domains/DomainTest.java
@@ -96,32 +96,32 @@ public class DomainTest {
         List<DomainRequirement> reqFoo = Arrays.asList(new DomainRequirement[] { new HostnameRequirement("foo.com") });
         List<DomainRequirement> reqBar = Arrays.asList(new DomainRequirement[] { new HostnameRequirement("bar.com") });
         
-        assertTrue(CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).isEmpty());
-        assertTrue(CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).isEmpty());
+        assertTrue(CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).isEmpty());
+        assertTrue(CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).isEmpty());
     
         // Add credentials to domains
         store.addCredentials(domainFoo, systemCred);
         store.addCredentials(domainBar, systemCred1);
     
         // Search credentials with specific domain restrictions
-        assertEquals(1, CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).size());
-        assertEquals(systemCred.getUsername(), CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).get(0).getUsername());
-        assertEquals(1, CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).size());
-        assertEquals(systemCred1.getUsername(), CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).get(0).getUsername());
+        assertEquals(1, CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).size());
+        assertEquals(systemCred.getUsername(), CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).get(0).getUsername());
+        assertEquals(1, CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).size());
+        assertEquals(systemCred1.getUsername(), CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).get(0).getUsername());
     
         // Update credential from domain
         store.updateCredentials(domainFoo, systemCred, systemCredMod);
         
-        assertEquals(1, CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).size());
-        assertEquals(systemCredMod.getUsername(), CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).get(0).getUsername());
-        assertEquals(1, CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).size());
-        assertEquals(systemCred1.getUsername(), CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).get(0).getUsername());
+        assertEquals(1, CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).size());
+        assertEquals(systemCredMod.getUsername(), CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).get(0).getUsername());
+        assertEquals(1, CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).size());
+        assertEquals(systemCred1.getUsername(), CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).get(0).getUsername());
   
         // Remove credential from domain
         store.removeCredentials(domainFoo, systemCredMod);
         
-        assertTrue(CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).isEmpty());
-        assertEquals(1, CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).size());
-        assertEquals(systemCred1.getUsername(), CredentialsProvider.lookupCredentials2(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).get(0).getUsername());
+        assertTrue(CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqFoo).isEmpty());
+        assertEquals(1, CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).size());
+        assertEquals(systemCred1.getUsername(), CredentialsProvider.lookupCredentialsInItemGroup(DummyCredentials.class, r.jenkins, ACL.SYSTEM2, reqBar).get(0).getUsername());
     }
 }

--- a/src/test/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImplTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImplTest.java
@@ -340,12 +340,12 @@ public class CertificateCredentialsImplTest {
         newCredentialsForm.getInputsByName("_.password").forEach(input -> input.setValue(VALID_PASSWORD));
         htmlPage.getDocumentElement().querySelector("input[type=file][name=uploadedCertFile]");
         
-        List<CertificateCredentials> certificateCredentials = CredentialsProvider.lookupCredentials2(CertificateCredentials.class, (ItemGroup<?>) null, ACL.SYSTEM2);
+        List<CertificateCredentials> certificateCredentials = CredentialsProvider.lookupCredentialsInItemGroup(CertificateCredentials.class, (ItemGroup<?>) null, ACL.SYSTEM2);
         assertThat(certificateCredentials, hasSize(0));
         
         r.submit(newCredentialsForm);
 
-        certificateCredentials = CredentialsProvider.lookupCredentials2(CertificateCredentials.class, (ItemGroup<?>) null, ACL.SYSTEM2);
+        certificateCredentials = CredentialsProvider.lookupCredentialsInItemGroup(CertificateCredentials.class, (ItemGroup<?>) null, ACL.SYSTEM2);
         assertThat(certificateCredentials, hasSize(1));
 
         CertificateCredentials certificate = certificateCredentials.get(0);

--- a/src/test/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImplTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImplTest.java
@@ -340,12 +340,12 @@ public class CertificateCredentialsImplTest {
         newCredentialsForm.getInputsByName("_.password").forEach(input -> input.setValue(VALID_PASSWORD));
         htmlPage.getDocumentElement().querySelector("input[type=file][name=uploadedCertFile]");
         
-        List<CertificateCredentials> certificateCredentials = CredentialsProvider.lookupCredentials(CertificateCredentials.class, (ItemGroup<?>) null, ACL.SYSTEM);
+        List<CertificateCredentials> certificateCredentials = CredentialsProvider.lookupCredentials(CertificateCredentials.class, (ItemGroup<?>) null, ACL.SYSTEM2);
         assertThat(certificateCredentials, hasSize(0));
         
         r.submit(newCredentialsForm);
 
-        certificateCredentials = CredentialsProvider.lookupCredentials(CertificateCredentials.class, (ItemGroup<?>) null, ACL.SYSTEM);
+        certificateCredentials = CredentialsProvider.lookupCredentials(CertificateCredentials.class, (ItemGroup<?>) null, ACL.SYSTEM2);
         assertThat(certificateCredentials, hasSize(1));
 
         CertificateCredentials certificate = certificateCredentials.get(0);

--- a/src/test/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImplTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImplTest.java
@@ -340,12 +340,12 @@ public class CertificateCredentialsImplTest {
         newCredentialsForm.getInputsByName("_.password").forEach(input -> input.setValue(VALID_PASSWORD));
         htmlPage.getDocumentElement().querySelector("input[type=file][name=uploadedCertFile]");
         
-        List<CertificateCredentials> certificateCredentials = CredentialsProvider.lookupCredentials(CertificateCredentials.class, (ItemGroup<?>) null, ACL.SYSTEM2);
+        List<CertificateCredentials> certificateCredentials = CredentialsProvider.lookupCredentials2(CertificateCredentials.class, (ItemGroup<?>) null, ACL.SYSTEM2);
         assertThat(certificateCredentials, hasSize(0));
         
         r.submit(newCredentialsForm);
 
-        certificateCredentials = CredentialsProvider.lookupCredentials(CertificateCredentials.class, (ItemGroup<?>) null, ACL.SYSTEM2);
+        certificateCredentials = CredentialsProvider.lookupCredentials2(CertificateCredentials.class, (ItemGroup<?>) null, ACL.SYSTEM2);
         assertThat(certificateCredentials, hasSize(1));
 
         CertificateCredentials certificate = certificateCredentials.get(0);


### PR DESCRIPTION
This is the implementation of
https://github.com/jenkinsci/jenkins/pull/4848 for Credentials API.

cf. https://github.com/jenkinsci/jep/blob/31859bedd4594df528428ccc737117b44b786fce/jep/227/README.adoc

This will allow consumers of the credentials API to remove references to deprecated acegi APIs.

Some overloads methods were renamed in order to avoid the ambiguous signatures involving `Item` and `ItemGroup`.

For example, `lookupCredentials` become `lookupCredentialsInItem` and `lookupCredentialsInItemGroup`.

cc @jglick 

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
