### PR TITLE
Fix a compatibility error in `CredentialsProvider`

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
@@ -1255,7 +1255,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                           @NonNull Item item,
                                                           @Nullable org.acegisecurity.Authentication authentication) {
         Objects.requireNonNull(item);
-        return getCredentialsInItemGroup(type, item.getParent(), authentication == null ? null : authentication.toSpring(), List.of());
+        return getCredentialsInItemFallback(type, item, authentication == null ? null : authentication.toSpring(), List.of());
     }
 
     /**
@@ -1267,7 +1267,7 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                           @NonNull Item item,
                                                           @Nullable org.acegisecurity.Authentication authentication,
                                                           @NonNull List<DomainRequirement> domainRequirements) {
-        return getCredentialsInItem(type, item, authentication == null ? null : authentication.toSpring(), domainRequirements);
+        return getCredentialsInItemFallback(type, item, authentication == null ? null : authentication.toSpring(), domainRequirements);
     }
 
     /**
@@ -1287,6 +1287,17 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                                 @NonNull Item item,
                                                                 @Nullable Authentication authentication,
                                                                 @NonNull List<DomainRequirement> domainRequirements) {
+        if (Util.isOverridden(CredentialsProvider.class, getClass(), "getCredentials", Class.class, Item.class, org.acegisecurity.Authentication.class, List.class)) {
+            return getCredentials(type, item, authentication == null ? null : org.acegisecurity.Authentication.fromSpring(authentication), domainRequirements);
+        }
+        if (Util.isOverridden(CredentialsProvider.class, getClass(), "getCredentials", Class.class, Item.class, org.acegisecurity.Authentication.class)) {
+            return getCredentials(type, item, authentication == null ? null : org.acegisecurity.Authentication.fromSpring(authentication));
+        }
+        return getCredentialsInItemFallback(type, item, authentication, domainRequirements);
+    }
+
+    @NonNull
+    private <C extends Credentials> List<C> getCredentialsInItemFallback(@NonNull Class<C> type, @NonNull Item item, @Nullable Authentication authentication, @NonNull List<DomainRequirement> domainRequirements) {
         return getCredentialsInItemGroup(type, item instanceof ItemGroup ? (ItemGroup) item : item.getParent(),
                 authentication, domainRequirements);
     }


### PR DESCRIPTION
Follows up #490 

Prefer calling deprecated overrides of `getCredentials(..., Item, ...)` if implemented rather than resolving closest `ItemGroup`.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
