### PR TITLE
[JENKINS-72364] Close provider dialog window when cancel is clicked

### DIFF
--- a/src/main/resources/lib/credentials/dialog.js
+++ b/src/main/resources/lib/credentials/dialog.js
@@ -3,5 +3,5 @@ Behaviour.specify("#credentials-add-submit", 'credentials-dialog-add', 0, functi
 });
 
 Behaviour.specify("#credentials-add-abort", 'credentials-dialog-abort', 0, function (e) {
-    e.onclick = (_) => window.credentials.dialog.style.display = "none";
+    e.onclick = (_) => window.credentials.dialog.hide();
 });


### PR DESCRIPTION
## [JENKINS-72364](https://issues.jenkins.io/browse/JENKINS-72364) Close provider dialog window when cancel is clicked

One change from https://github.com/jenkinsci/credentials-plugin/pull/491 was applied to a reference that was not using Prototype.js.

### Testing done

Confirmed interactively that I can see the problem before the change and that with this change the problem is resolved.

No test automation created due to the high effort to create the test and low long term value of the test.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes

I'd prefer to have a review from @rsandell , @raul-arabaolaza, @yaroslavafenkin, or @ampuscas