### PR TITLE
Use new dialog design for adding credentials

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.387.1</jenkins.version>
+    <jenkins.version>2.426.1</jenkins.version>
   </properties>
 
   <repositories>

--- a/src/main/resources/com/cloudbees/plugins/credentials/CredentialsSelectHelper/WrappedCredentialsStore/dialog.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/CredentialsSelectHelper/WrappedCredentialsStore/dialog.jelly
@@ -25,12 +25,9 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:l="/lib/layout">
   <l:ajax>
-    <div class="hd">
-      <h2 style="margin-top: 1rem" tooltip="${it.description}">${it.description}: ${it.displayName}</h2>
-    </div>
-    <div class="bd">
-      <h3>${%Add Credentials}</h3>
-      <form action="${it.url}/addCredentials" method="POST" id="credentials-dialog-form">
+    <div>
+      <form action="${it.url}/addCredentials" method="POST" id="credentials-dialog-form" data-title="${it.description}: ${it.displayName}" data-add="${%Add}">
+		<h3>${%Add Credentials}</h3>
         <table width="100%">
           <f:entry title="${%Domain}">
             <select class="setting-input" name="_.domain">
@@ -42,10 +39,6 @@
           <f:block>
             <j:set var="descriptors" value="${it.credentialsDescriptors}"/>
             <st:include page="credential"/>
-          </f:block>
-          <f:block>
-            <input id="credentials-add-submit" class="yui-button primary" value="${%Add}"/>
-            <input id="credentials-add-abort" class="yui-button" value="${%Cancel}"/>
           </f:block>
         </table>
       </form>

--- a/src/main/resources/lib/credentials/dialog.js
+++ b/src/main/resources/lib/credentials/dialog.js
@@ -1,7 +1,0 @@
-Behaviour.specify("#credentials-add-submit", 'credentials-dialog-add', 0, function (e) {
-    e.onclick = (_) => window.credentials.addSubmit(e);
-});
-
-Behaviour.specify("#credentials-add-abort", 'credentials-dialog-abort', 0, function (e) {
-    e.onclick = (_) => window.credentials.dialog.hide();
-});

--- a/src/main/resources/lib/credentials/select/select.css
+++ b/src/main/resources/lib/credentials/select/select.css
@@ -1,6 +1,5 @@
 select.credentials-select {  width:auto; vertical-align: top; }
 div.credentials-select-content-inactive { display:none; }
-div#credentialsDialog {overflow-y: scroll;}
 body.masked {overflow-y: hidden;}
 div.include-user-credentials { padding: 0.2em; }
 /* adapted from Jenkins' style.css */

--- a/src/main/resources/lib/credentials/select/select.js
+++ b/src/main/resources/lib/credentials/select/select.js
@@ -28,22 +28,6 @@ window.credentials.init = function () {
         document.body.appendChild(div);
         div.innerHTML = "<div id='credentialsDialog'><div class='bd'></div></div>";
         window.credentials.body = document.getElementById('credentialsDialog');
-        window.credentials.dialog = new YAHOO.widget.Panel(window.credentials.body, {
-            fixedcenter: true,
-            close: true,
-            draggable: true,
-            zindex: 1000,
-            modal: true,
-            visible: false,
-            keylisteners: [
-              new YAHOO.util.KeyListener(document, {keys:27}, {
-                fn:(function() {window.credentials.dialog.hide();}),
-                scope:document,
-                correctScope:false
-              })
-            ]
-        });
-        window.credentials.dialog.render();
     }
 };
 window.credentials.add = function (e) {
@@ -57,12 +41,11 @@ window.credentials.add = function (e) {
                 window.credentials.body.innerHTML = responseText;
                 Behaviour.applySubtree(window.credentials.body, false);
                 window.credentials.form = document.getElementById('credentials-dialog-form');
-                // window.credentials.form.action = e;
-                var r = YAHOO.util.Dom.getClientRegion();
-                window.credentials.dialog.cfg.setProperty("width", r.width * 3 / 4 + "px");
-                window.credentials.dialog.cfg.setProperty("height", r.height * 3 / 4 + "px");
-                window.credentials.dialog.center();
-                window.credentials.dialog.show();
+				const data = window.credentials.form.dataset;
+				const options = {'title': data['title'], 'okText': data['add'], 'submitButton':false, 'minWidth': '75vw'};
+				dialog.form(window.credentials.form, options)
+					.then(window.credentials.addSubmit);
+				window.credentials.form.querySelector('select').focus();
             });
         }
     });
@@ -109,9 +92,6 @@ window.credentials.refreshAll = function () {
                     if (window.console != null) {
                         console.warn("Unable to find nearby " + name);
                     }
-                    if (window.YUI != null) {
-                        YUI.log("Unable to find a nearby control of the name " + name, "warn")
-                    }
                     return;
                 }
                 deps.push({name: Path.tail(name), control: c});
@@ -121,7 +101,7 @@ window.credentials.refreshAll = function () {
     });
 };
 window.credentials.addSubmit = function (_) {
-    const form = document.getElementById('credentials-dialog-form');
+    const form = window.credentials.form;
     buildFormTree(form);
     ajaxFormSubmit(form);
 
@@ -140,9 +120,6 @@ window.credentials.addSubmit = function (_) {
                 // notificationBar.show(...) with logging ID could be handy here?
                 console.error("Could not add credentials:", e);
             })
-            .finally(() => {
-                window.credentials.dialog.hide();
-            });
     }
 };
 


### PR DESCRIPTION
Uses a nicer dialog (no need to scroll to get OK button, works with dark theme, ...), reducing dependency on YUI framework.

### Testing done

Checked that credentials can be added (username and password) when running `hpi:run`

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] No tests - frontend change only
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
