### PR TITLE
Enable Jenkins Security Scan

### DIFF
--- a/.github/workflows/jenkins-security-scan.yml
+++ b/.github/workflows/jenkins-security-scan.yml
@@ -1,0 +1,21 @@
+name: Jenkins Security Scan
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+  workflow_dispatch:
+
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+
+jobs:
+  security-scan:
+    uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
+    with:
+      java-cache: 'maven' # Optionally enable use of a build dependency cache. Specify 'maven' or 'gradle' as appropriate.
+      java-version: 17 # What version of Java to set up for the build.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![credentials version](https://img.shields.io/jenkins/plugin/v/credentials?label=credentials)
 ![credentials installs](https://img.shields.io/jenkins/plugin/i/credentials)
 [![MIT license](https://img.shields.io/github/license/jenkinsci/credentials-plugin)](https://github.com/jenkinsci/credentials-plugin/blob/master/LICENSE.txt)
-[![Language grade: Java](https://img.shields.io/lgtm/grade/java/g/jenkinsci/credentials-plugin.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/jenkinsci/credentials-plugin/context:java)
+[![security scan](https://github.com/jenkinsci/credentials-plugin/actions/workflows/jenkins-security-scan.yml/badge.svg)](https://github.com/jenkinsci/credentials-plugin/actions/workflows/jenkins-security-scan.yml)
 
 ## Documentation
 


### PR DESCRIPTION
I noticed that the LGTM badge in the `README.md` was broken since it [got deprecated](https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/) quite some time ago. I think the proper replacement would be the Jenkins Security Scan as it includes the LGTM successor CodeQL.

### Testing done

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue