### PR TITLE
Use jenkins-button over yui-button in 'New domain' and 'Update domain' screens

### DIFF
--- a/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/DomainWrapper/configure.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/DomainWrapper/configure.jelly
@@ -44,7 +44,7 @@
         <j:otherwise>
           <f:form action="configSubmit" method="POST" name="config">
             <f:entry title="${%Name}" help="/plugin/credentials/help/domain/name.html">
-              <f:textbox field="name" id="name" onchange="updateSave(this.form)" onkeyup="updateSave(this.form)"/>
+              <f:textbox field="name" id="name" onchange="updateSave()" onkeyup="updateSave()"/>
             </f:entry>
             <f:entry title="${%Description}" help="/plugin/credentials/help/domain/description.html">
               <f:textarea field="description"/>
@@ -54,23 +54,24 @@
                              items="${instance.specifications}"/>
             </f:entry>
             <f:bottomButtonBar>
-              <input type="submit" name="Submit" value="${%Save}" id="save" class="submit-button primary" />
+              <button class="jenkins-button jenkins-button--primary"
+                      id="save"
+                      name="Submit">
+                ${%Save}
+              </button>
             </f:bottomButtonBar>
           </f:form>
         </j:otherwise>
       </j:choose>
       <script><![CDATA[
-        var saveButton = makeButton(document.getElementById('save'), null);
+        function updateSave() {
+          const input = document.querySelector("#name");
+          const saveButton = document.querySelector("#save");
 
-        function updateSave(form) {
-          function state() {
-            return (document.getElementById('name').value.length === 0);
-          }
-
-          saveButton.set('disabled', state(), false);
+          saveButton.disabled = input.value.length === 0;
         }
 
-        updateSave(saveButton.getForm());
+        updateSave();
         window.setTimeout(function () {
           // TODO remove this JENKINS-24662 workaround when baseline core has fix for root cause
           layoutUpdateCallback.call();

--- a/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/newDomain.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/newDomain.jelly
@@ -32,7 +32,7 @@
       <j:set var="instance" value="${null}"/>
       <f:form action="createDomain" method="POST" name="newDomain">
         <f:entry title="${%Domain Name}" help="/plugin/credentials/help/domain/name.html">
-          <f:textbox id="name" field="name" onchange="updateOk(this.form)" onkeyup="updateOk(this.form)"/>
+          <f:textbox id="name" field="name" onchange="updateOk()" onkeyup="updateOk()"/>
           <script>document.getElementById('name').focus();</script>
         </f:entry>
         <f:entry title="${%Description}" help="/plugin/credentials/help/domain/description.html">
@@ -43,21 +43,22 @@
                          items="${null}"/>
         </f:entry>
         <f:bottomButtonBar>
-          <input type="submit" name="Submit" value="${%Create}" id="ok" class="submit-button primary" />
+          <button class="jenkins-button jenkins-button--primary"
+                  id="ok"
+                  name="Submit">
+            ${%Create}
+          </button>
         </f:bottomButtonBar>
       </f:form>
       <script><![CDATA[
-        var okButton = makeButton(document.getElementById('ok'), null);
-
-        function updateOk(form) {
-          function state() {
-            return (document.getElementById('name').value.length === 0);
-          }
-
-          okButton.set('disabled', state(), false);
+        function updateOk() {
+          const input = document.querySelector("#name");
+          const okButton = document.querySelector("#ok");
+          
+          okButton.disabled = input.value.length === 0;
         }
 
-        updateOk(okButton.getForm());
+        updateOk();
         ]]></script>
     </l:main-panel>
   </l:layout>


### PR DESCRIPTION
Small PR to use the `jenkins-button` class over `yui-button` in the 'New domain' and 'Update domain' screens.

**Before**

<img width="295" alt="image" src="https://github.com/user-attachments/assets/ba5dc91c-5c1a-450c-997a-e16a4451f59f">

<img width="316" alt="image" src="https://github.com/user-attachments/assets/5d98a54c-c07f-4bcf-a6d0-7ef610134888">

**After**

<img width="302" alt="image" src="https://github.com/user-attachments/assets/01b65804-9ceb-4c7d-b16c-b402e1bfa53b">

<img width="315" alt="image" src="https://github.com/user-attachments/assets/e8cd1c1a-f609-4fc2-ba32-a0fa6c473609">

### Testing done

* Button behaves as expected
* Disables when there isn't a name, enables when there is.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
