### PR TITLE
Register `OptionHandler` through `META-INF/services/annotations` and Annotation Indexer rather than `META-INF/services` and Commons Discovery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,12 +125,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.kohsuke.metainf-services</groupId>
-      <artifactId>metainf-services</artifactId>
-      <version>1.11</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-matchers</artifactId>
       <version>2.10.0</version>

--- a/src/main/java/com/cloudbees/plugins/credentials/cli/CredentialsStoreOptionHandler.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/cli/CredentialsStoreOptionHandler.java
@@ -25,7 +25,7 @@ package com.cloudbees.plugins.credentials.cli;
 
 import com.cloudbees.plugins.credentials.CredentialsSelectHelper;
 import com.cloudbees.plugins.credentials.CredentialsStore;
-import org.kohsuke.MetaInfServices;
+import hudson.cli.declarative.OptionHandlerExtension;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.OptionDef;
@@ -38,7 +38,7 @@ import org.kohsuke.args4j.spi.Setter;
  *
  * @since 2.1.1
  */
-@MetaInfServices(OptionHandler.class)
+@OptionHandlerExtension
 public class CredentialsStoreOptionHandler extends OptionHandler<CredentialsStore> {
     /**
      * {@inheritDoc}


### PR DESCRIPTION
See https://github.com/jenkinsci/jenkins/pull/9980.

### Testing done

CI build; loaded the plugin in a real Jenkins install and verified that the handler was still loaded by stepping through the code in a debugger