### PR TITLE
Handle password with empty string for certificate auth

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImpl.java
@@ -147,12 +147,10 @@ public class CertificateCredentialsImpl extends BaseStandardCredentials implemen
      * Helper to convert a {@link Secret} password into a {@code char[]}
      *
      * @param password the password.
-     * @return a {@code char[]} containing the password or {@code null}
+     * @return a {@code char[]} containing the password
      */
-    @CheckForNull
     private static char[] toCharArray(@NonNull Secret password) {
-        String plainText = Util.fixEmpty(password.getPlainText());
-        return plainText == null ? null : plainText.toCharArray();
+        return password.getPlainText().toCharArray();
     }
 
     /**
@@ -248,7 +246,7 @@ public class CertificateCredentialsImpl extends BaseStandardCredentials implemen
                 return FormValidation.error(Messages.CertificateCredentialsImpl_ShortPasswordFIPS());
             }
             if (pw.isEmpty()) {
-                return FormValidation.warning(Messages.CertificateCredentialsImpl_NoPassword());
+                return FormValidation.ok(Messages.CertificateCredentialsImpl_NoPassword());
             }
             if (pw.length() < 14) {
                 return FormValidation.warning(Messages.CertificateCredentialsImpl_ShortPassword());
@@ -624,9 +622,7 @@ public class CertificateCredentialsImpl extends BaseStandardCredentials implemen
                 } catch (KeyStoreException | CertificateException | NoSuchAlgorithmException | IOException e) {
                     return FormValidation.warning(e, Messages.CertificateCredentialsImpl_LoadKeystoreFailed());
                 } finally {
-                    if (passwordChars != null) {
-                        Arrays.fill(passwordChars, ' ');
-                    }
+                    Arrays.fill(passwordChars, ' ');
                 }
             }
 
@@ -739,6 +735,9 @@ public class CertificateCredentialsImpl extends BaseStandardCredentials implemen
                     List<PEMEncodable> pemEncodables = PEMEncodable.decodeAll(pemCerts, null);
                     long count = pemEncodables.stream().map(PEMEncodable::toCertificate).filter(Objects::nonNull).count();
                     if (count < 1) {
+                        if (Util.fixEmpty(value) == null) {
+                            return FormValidation.ok();
+                        }
                         return FormValidation.error(Messages.CertificateCredentialsImpl_PEMNoCertificates());
                     }
                     // ensure only certs are provided.
@@ -771,6 +770,9 @@ public class CertificateCredentialsImpl extends BaseStandardCredentials implemen
                     List<PEMEncodable> pemEncodables = PEMEncodable.decodeAll(key, toCharArray(Secret.fromString(password)));
                     long count = pemEncodables.stream().map(PEMEncodable::toPrivateKey).filter(Objects::nonNull).count();
                     if (count == 0) {
+                        if (Util.fixEmpty(value) == null) {
+                            return FormValidation.ok();
+                        }
                         return FormValidation.error(Messages.CertificateCredentialsImpl_PEMNoKeys());
                     }
                     if (count > 1) {

--- a/src/main/resources/com/cloudbees/plugins/credentials/impl/Messages.properties
+++ b/src/main/resources/com/cloudbees/plugins/credentials/impl/Messages.properties
@@ -24,8 +24,8 @@
 UsernamePasswordCredentialsImpl.DisplayName=Username with password
 CertificateCredentialsImpl.DisplayName=Certificate
 CertificateCredentialsImpl.EmptyKeystore=Empty keystore
-CertificateCredentialsImpl.LoadKeyFailed=Could retrieve key "{0}"
-CertificateCredentialsImpl.LoadKeyFailedQueryEmptyPassword=Could retrieve key "{0}". You may need to provide a password
+CertificateCredentialsImpl.LoadKeyFailed=Couldn''t retrieve key for alias "{0}"
+CertificateCredentialsImpl.LoadKeyFailedQueryEmptyPassword=Couldn''t retrieve key for alias "{0}". You may need to provide a password
 CertificateCredentialsImpl.LoadKeystoreFailed=Could not load keystore
 CertificateCredentialsImpl.NoCertificateUploaded=No certificate uploaded
 CertificateCredentialsImpl.UploadedKeyStoreSourceDisplayName=Upload PKCS#12 certificate and key

--- a/src/test/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImplTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImplTest.java
@@ -32,6 +32,7 @@ import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.SecretBytes;
 import com.cloudbees.plugins.credentials.common.CertificateCredentials;
 import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
+import hudson.util.FormValidation;
 import org.htmlunit.FormEncodingType;
 import org.htmlunit.HttpMethod;
 import org.htmlunit.Page;
@@ -130,14 +131,6 @@ public class CertificateCredentialsImplTest {
 
     @Test
     @Issue("JENKINS-64542")
-    public void doCheckUploadedKeystore_uploadedFileValid_butMissingPassword() throws Exception {
-        String content = getContentFrom_doCheckUploadedKeystore("", getValidP12_base64(), "");
-        assertThat(content, containsString("warning"));
-        assertThat(content, containsString(Util.escape(Messages.CertificateCredentialsImpl_LoadKeyFailedQueryEmptyPassword("1"))));
-    }
-
-    @Test
-    @Issue("JENKINS-64542")
     public void doCheckUploadedKeystore_uploadedFileValid_butInvalidPassword() throws Exception {
         String content = getContentFrom_doCheckUploadedKeystore("", getValidP12_base64(), INVALID_PASSWORD);
         assertThat(content, containsString("warning"));
@@ -193,10 +186,11 @@ public class CertificateCredentialsImplTest {
 
     @Test
     @Issue("JENKINS-64542")
-    public void doCheckUploadedKeystore_keyStoreValid_butMissingPassword() throws Exception {
-        String content = getContentFrom_doCheckUploadedKeystore(getValidP12_secretBytes(), "", "");
-        assertThat(content, containsString("warning"));
-        assertThat(content, containsString(Util.escape(Messages.CertificateCredentialsImpl_LoadKeyFailedQueryEmptyPassword("1"))));
+    public void doCheckPassword_missing() {
+        CertificateCredentialsImpl.DescriptorImpl descriptor = r.jenkins.getDescriptorByType(CertificateCredentialsImpl.DescriptorImpl.class);
+        FormValidation formValidation = descriptor.doCheckPassword("");
+        assertThat(formValidation.kind, is(FormValidation.Kind.OK));
+        assertThat(formValidation.getMessage(), is(Messages.CertificateCredentialsImpl_NoPassword()));
     }
 
     @Test


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

<img width="378" alt="image" src="https://github.com/user-attachments/assets/d2bf3b86-0d1a-4716-a0f0-e286378030fb">


### Testing done

Uploaded a cert generated inside Azure Key Vault

Tested with https://github.com/jenkinsci/azure-credentials-plugin/pull/274
and checked end 2 end and I can provision VMs with https://plugins.jenkins.io/azure-vm-agents using certificate auth

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
