### PR TITLE
improve dialog to add credentials

### DIFF
--- a/src/main/resources/com/cloudbees/plugins/credentials/CredentialsSelectHelper/WrappedCredentialsStore/dialog.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/CredentialsSelectHelper/WrappedCredentialsStore/dialog.jelly
@@ -29,11 +29,13 @@
       <form action="${it.url}/addCredentials" method="POST" id="credentials-dialog-form" data-title="${it.description}: ${it.displayName}" data-add="${%Add}">
 		<h3>${%Add Credentials}</h3>
         <f:entry title="${%Domain}">
-          <select class="setting-input" name="_.domain">
-            <j:forEach var="domain" items="${it.wrappers.entrySet()}">
-              <f:option value="${domain.key}" selected="${domain.key=='_'}">${domain.value.displayName}</f:option>
-            </j:forEach>
-          </select>
+          <div class="jenkins-select">
+            <select class="jenkins-select__input" name="_.domain">
+              <j:forEach var="domain" items="${it.wrappers.entrySet()}">
+                <f:option value="${domain.key}" selected="${domain.key=='_'}">${domain.value.displayName}</f:option>
+              </j:forEach>
+            </select>
+          </div>
         </f:entry>
         <f:block>
           <j:set var="descriptors" value="${it.credentialsDescriptors}"/>

--- a/src/main/resources/lib/credentials/select/select.js
+++ b/src/main/resources/lib/credentials/select/select.js
@@ -43,7 +43,7 @@ window.credentials.add = function (e) {
                 window.credentials.body.innerHTML = responseText;
                 window.credentials.form = document.getElementById('credentials-dialog-form');
 				const data = window.credentials.form.dataset;
-				const options = {'title': data['title'], 'okText': data['add'], 'submitButton':false, 'minWidth': '75vw'};
+				const options = {'title': data['title'], 'okText': data['add'], 'submitButton':false, 'minWidth': 'min(1641px, 65vw)'};
 				dialog.form(window.credentials.form, options)
 					.then(window.credentials.addSubmit);
 				window.credentials.form.querySelector('select').focus();


### PR DESCRIPTION
apply jenkins style to the domain select

set minwidth of dialog via min function so it doesn't get too wide on large screens


Before:
Dialog was always 75% of screen width adding a large blank area to the right in the dialog on large screens
inputs are not right aligned
Domain select with old styling
![image](https://github.com/user-attachments/assets/87b2171a-6e2c-4478-b25c-7ff514cf1fdc)


After:
Large screen 
![image](https://github.com/user-attachments/assets/9ce4ea14-70dc-4ece-bb87-aacab80e3c7b)

Small Screen:
all inputs are properly right aligned
![image](https://github.com/user-attachments/assets/dc691581-81d9-42a3-a183-d95e22eb3dee)


<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
