### PR TITLE
Add 'type' to dropdown button

### DIFF
--- a/src/main/resources/lib/credentials/select.jelly
+++ b/src/main/resources/lib/credentials/select.jelly
@@ -124,6 +124,7 @@
                         tooltip="${storeItem.description}"
                         data-type="credentials-add-store-item"
                         data-url="${request2.contextPath}/${storeItem.url}/dialog"
+                        type="button"
                         disabled="${storeItem.enabled ? null : true}">
                   <div class="jenkins-dropdown__item__icon">
                     <l:icon src="${storeItem.iconClassName} icon-sm" />


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/10245 changes dropdowns slightly, rather than being appended directly to the `<body>` element, they are now appended within the button's parent element. This has broken the credentials plugin as the dropdown menu's buttons lack a `type`. `type` defaults to `submit` causing the form to submit, whereas we just want to treat it as a plain button.

### Testing done

* Menu works as expected

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
