### PR TITLE
Consistently use Commons Text library plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,10 @@
       <artifactId>commons-lang3-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>commons-text-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
       <optional>true</optional>

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsMatchers.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsMatchers.java
@@ -63,8 +63,8 @@ import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.tree.ErrorNode;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
-import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 /**
  * Some standard matchers and filtering utility methods.

--- a/src/main/java/com/cloudbees/plugins/credentials/matchers/BeanPropertyMatcher.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/matchers/BeanPropertyMatcher.java
@@ -36,7 +36,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Objects;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 /**
  * Matches credentials that have a Java Bean property with an expected value.

--- a/src/main/java/com/cloudbees/plugins/credentials/matchers/IdMatcher.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/matchers/IdMatcher.java
@@ -27,7 +27,7 @@ import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsMatcher;
 import com.cloudbees.plugins.credentials.common.IdCredentials;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.Objects;
 

--- a/src/main/java/com/cloudbees/plugins/credentials/matchers/UsernameMatcher.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/matchers/UsernameMatcher.java
@@ -27,7 +27,7 @@ import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsMatcher;
 import com.cloudbees.plugins.credentials.common.UsernameCredentials;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.Objects;
 


### PR DESCRIPTION
Amends #641. `org.apache.commons.lang3.StringEscapeUtils` is deprecated, so use the non-deprecated replacement in `commons-text` instead.