### PR TITLE
Fix missing url for credentials used by agents

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/fingerprints/NodeCredentialsFingerprintFacet.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/fingerprints/NodeCredentialsFingerprintFacet.java
@@ -26,9 +26,12 @@ package com.cloudbees.plugins.credentials.fingerprints;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Util;
+import hudson.model.Computer;
 import hudson.model.Fingerprint;
 import hudson.model.Node;
 import jenkins.model.Jenkins;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 
 /**
  * Tracks usage of a credential by a {@link Node}.
@@ -91,6 +94,22 @@ public class NodeCredentialsFingerprintFacet extends AbstractCredentialsFingerpr
     @CheckForNull
     public Node getNode() {
         return nodeName.isEmpty() ? Jenkins.get() : Jenkins.get().getNode(nodeName);
+    }
+
+    /**
+     * Return the url of the {@link Node}.
+     *
+     * @return the url of the {@link Node} or {@code null} if either the node no longer exists or the current authentication
+     * does not have permission to access the node.
+     */
+    @Restricted(DoNotUse.class)
+    public String getNodeUrl() {
+        Node node = getNode();
+        if (node == null) {
+            return null;
+        }
+        Computer c = node.toComputer();
+        return c == null ? null : c.getUrl();
     }
 
     /**

--- a/src/main/resources/com/cloudbees/plugins/credentials/fingerprints/NodeCredentialsFingerprintFacet/main.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/fingerprints/NodeCredentialsFingerprintFacet/main.jelly
@@ -35,7 +35,7 @@
         <td class="fingerprint-summary-header">
           <j:choose>
             <j:when test="${node!=null}">
-              <a href="${rootURL}/${node.url}" class="model-link inside">${node.displayName}</a>
+              <a href="${rootURL}/${it.nodeUrl}" class="model-link inside">${node.displayName}</a>
             </j:when>
             <j:otherwise>
               ${%Unknown}


### PR DESCRIPTION
When a credential is used by an agent the main.jelly used `node.url`. But the `Node` class has no `getUrl` method so a link to Jenkins root was created.
The jelly now properly renders the url to the agent

Before:
<img width="1159" height="605" alt="image" src="https://github.com/user-attachments/assets/eefc31b5-4a3e-4a78-b95d-bd48f455d8b2" />

After:
<img width="1096" height="573" alt="image" src="https://github.com/user-attachments/assets/e5ab8cb9-9c52-474a-870b-c72ffb224f87" />

<!-- Please describe your pull request here. -->

### Testing done
Verified that a credential used by a node leads to the correct link 

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
