### PR TITLE
Fix moving credential to domain with unsafe URL characters

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsStoreAction.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsStoreAction.java
@@ -1348,7 +1348,7 @@ public abstract class CredentialsStoreAction
             for (CredentialsStore store : CredentialsProvider.lookupStores(context)) {
                 if (store.getContext() == context) {
                     for (Domain d : store.getDomains()) {
-                        if (domainName.equals("_") ? d.getName() == null : domainName.equals(d.getName())) {
+                        if (isDomainEqual(domainName, d)) {
                             destinationStore = store;
                             destinationDomain = d;
                             break;
@@ -1378,6 +1378,17 @@ public abstract class CredentialsStoreAction
                 }
             }
             return HttpResponses.redirectToDot();
+        }
+
+        private boolean isDomainEqual(String domainName, Domain d){
+            final var name = d.getName();
+            if (domainName.equals("_")) {
+                return name == null;
+            }
+            if (name == null){
+                return false;
+            }
+            return domainName.equals(Util.rawEncode(name));
         }
 
         /**


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Fix an issue (HTTP 400) while moving a credential to a domain with spaces in the name. 

Should fix #671. 

### Testing done

Tested moving a credential between global domain, simple domain and domain with spaces. Added unit test. 

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
