### PR TITLE
Restore compatibility for `CredentialsStore` implementing `IconSpec`

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsStore.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsStore.java
@@ -54,6 +54,9 @@ import java.util.stream.Collectors;
 import hudson.tasks.UserAvatarResolver;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang3.StringUtils;
+import org.jenkins.ui.icon.IconSpec;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.springframework.security.core.Authentication;
@@ -535,9 +538,12 @@ public abstract class CredentialsStore implements AccessControlled, Saveable {
      * Returns the icon class name of the {@link #getContext()} of this {@link CredentialsStore}.
      *
      * @return the icon class name for the store.
-     * @since TODO
      */
-    public final String getIconClassName() {
+    @Restricted(DoNotUse.class) // Jelly
+    public final String getContextIconClassName() {
+        if (this instanceof IconSpec iconSpec) {
+            return iconSpec.getIconClassName();
+        }
         ModelObject context = getContext();
         if (context instanceof User user) {
             return UserAvatarResolver.resolve(user, "96x96");

--- a/src/main/resources/com/cloudbees/plugins/credentials/ViewCredentialsAction/index.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/ViewCredentialsAction/index.jelly
@@ -62,7 +62,7 @@
                   </div>
                   <div class="credentials-card__details">
                     <a href="${storeAction==null?d.store.relativeLinkToAction:d.store.relativeLinkToContext+'credentials/store/'+storeAction.urlName}">
-                      <l:icon src="${d.store.iconClassName}" class="jenkins-avatar" tooltip="${d.provider.displayName}"/>
+                      <l:icon src="${d.store.contextIconClassName}" class="jenkins-avatar" tooltip="${d.provider.displayName}"/>
                       ${d.store.context == app ? d.store.displayName : d.store.contextDisplayName}
                     </a>
                     <span>-</span>

--- a/src/main/resources/lib/credentials/store.jelly
+++ b/src/main/resources/lib/credentials/store.jelly
@@ -31,7 +31,7 @@ THE SOFTWARE.
     <div class="credentials-card">
         <div class="credentials-card__inner credentials-card__inner--split">
             <div class="credentials-card__title">
-                <l:icon src="${store.iconClassName}" class="jenkins-avatar" tooltip="${store.provider.displayName}"/>
+                <l:icon src="${store.contextIconClassName}" class="jenkins-avatar" tooltip="${store.provider.displayName}"/>
                 <a href="${storeAction==null?store.relativeLinkToAction:store.relativeLinkToContext+'credentials/store/'+storeAction.urlName}">
                     ${store.context == app ? store.displayName : store.contextDisplayName}
                 </a>


### PR DESCRIPTION
https://github.com/jenkinsci/credentials-plugin/pull/984#discussion_r2662851525 Fixes automated tests but I have not checked it interactively.