### PR TITLE
Show credential ID in store card header

### DIFF
--- a/src/main/resources/lib/credentials/store.jelly
+++ b/src/main/resources/lib/credentials/store.jelly
@@ -33,7 +33,10 @@ THE SOFTWARE.
             <div class="credentials-card__title">
                 <l:icon src="${store.contextIconClassName}" class="jenkins-avatar" tooltip="${store.provider.displayName}"/>
                 <a href="${storeAction==null?store.relativeLinkToAction:store.relativeLinkToContext+'credentials/store/'+storeAction.urlName}">
-                    ${store.context == app ? store.displayName : store.contextDisplayName}
+                    <span class="credentials-card__id" title="Credential ID">
+    <strong>ID:</strong> ${store.id}
+</span>
+
                 </a>
             </div>
             <div class="credentials-card__tags">


### PR DESCRIPTION
In many real-world Jenkins installations, users manage a large number of credentials.
While display names are helpful, the credential ID is what users actually reference in pipelines, scripts, and configuration files.

Currently, the credential store card shows only the display name.
To identify the correct credential ID, users must either open each credential or rely on memory, which makes credential management slower and more error-prone—especially when multiple credentials have similar names.

What this PR does

This change surfaces the credential ID directly in the store card header, positioned beneath the display name.

The goal is to make credential identification:
- Immediate
- Unambiguous
- Less error-prone

Why this is useful
-  Reduces unnecessary clicks
-  Improves usability for Jenkins administrators. 
-Helps avoid mistakes when selecting credentials for pipelines
- Scales better for instances with many credentials

**### UI Changes**
**Before**
The store card displayed only the credential display name, with no visible credential ID.
![before ui](https://github.com/user-attachments/assets/7296309a-1e74-4e2f-b6a3-ec5d82aa75e5)
![before ui2](https://github.com/user-attachments/assets/8aceab83-52b2-433c-b7e9-7205785f529a)


**After**
The credential ID is now clearly visible below the display name in the card header.
![after ui](https://github.com/user-attachments/assets/af641ab9-a49a-4839-9b4b-c78b529e9726)


**Design Notes**

[ ] Preserves the existing visual hierarchy
[ ] Does not introduce UI clutter
[ ] Uses existing layout and styling conventions
[ ] No behavioral changes to credential handling

**Testing**

- Verified locally using mvn clean hpi:run
- Confirmed credential ID renders correctly for multiple credentials
- No regressions observed in the credentials UI
