### PR TITLE
Suppress FIPS-related tests on Windows

### DIFF
--- a/src/test/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImplFIPSTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImplFIPSTest.java
@@ -7,6 +7,8 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import hudson.ExtensionList;
@@ -19,6 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@DisabledOnOs(OS.WINDOWS)
 class CertificateCredentialsImplFIPSTest {
 
     @RegisterExtension

--- a/src/test/java/com/cloudbees/plugins/credentials/impl/UsernamePasswordCredentialsImplFIPSTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/impl/UsernamePasswordCredentialsImplFIPSTest.java
@@ -12,6 +12,8 @@ import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
 import org.apache.commons.text.StringEscapeUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.jvnet.hudson.test.junit.jupiter.RealJenkinsExtension;
 
@@ -24,6 +26,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@DisabledOnOs(OS.WINDOWS)
 class UsernamePasswordCredentialsImplFIPSTest {
 
     @RegisterExtension


### PR DESCRIPTION
Failing to get an incremental deployment from #1003 due to an apparent flake https://github.com/jenkinsci/credentials-plugin/pull/1003/checks?check_run_id=59945432880 in a test related to FIPS. From what I understand, this test was added with CloudBees CI in mind, but that never supported running Windows controllers in FIPS mode. Since Windows CI tests are far slower than Linux, let us suppress these.