### PR TITLE
Re-enable fips tests on Windows

### DIFF
--- a/src/test/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImplFIPSTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/impl/CertificateCredentialsImplFIPSTest.java
@@ -7,8 +7,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import hudson.ExtensionList;
@@ -21,7 +19,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@DisabledOnOs(OS.WINDOWS)
 class CertificateCredentialsImplFIPSTest {
 
     @RegisterExtension

--- a/src/test/java/com/cloudbees/plugins/credentials/impl/UsernamePasswordCredentialsImplFIPSTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/impl/UsernamePasswordCredentialsImplFIPSTest.java
@@ -12,8 +12,6 @@ import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
 import org.apache.commons.text.StringEscapeUtils;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.jvnet.hudson.test.junit.jupiter.RealJenkinsExtension;
 
@@ -26,7 +24,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@DisabledOnOs(OS.WINDOWS)
 class UsernamePasswordCredentialsImplFIPSTest {
 
     @RegisterExtension


### PR DESCRIPTION
Reverts jenkinsci/credentials-plugin#1008

Probably won't ship this as its they aren't needed on Windows but worth a test for https://github.com/jenkinsci/credentials-plugin/pull/999#issuecomment-3799735539