### PR TITLE
Hide 'Move credential' button if not possible

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsStoreAction.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsStoreAction.java
@@ -1487,6 +1487,11 @@ public abstract class CredentialsStoreAction
             return getACL().hasPermission(permission);
         }
 
+        @Restricted(NoExternalUse.class)
+        public boolean isMoveable() {
+            return getDomain().getParent().getDomains().size() > 1;
+        }
+
         /**
          * Our {@link Descriptor}.
          */

--- a/src/main/java/com/cloudbees/plugins/credentials/ViewCredentialsAction.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/ViewCredentialsAction.java
@@ -496,6 +496,11 @@ public class ViewCredentialsAction implements Action, IconSpec, AccessControlled
             return store.hasPermission(CredentialsProvider.UPDATE);
         }
 
+        @Restricted(NoExternalUse.class)
+        public boolean isMoveable() {
+            return store.getDomains().size() > 1;
+        }
+
         /**
          * Returns the {@link Credentials#getScope()} of the {@link #credentials}.
          *

--- a/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/CredentialsWrapper/index.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/CredentialsWrapper/index.jelly
@@ -42,17 +42,19 @@
             ${%Update credential}
           </button>
           <l:overflowButton>
-            <dd:custom>
-              <button class="jenkins-dropdown__item"
-                      data-type="credentials-move"
-                      data-url="moveDialog">
-                <div class="jenkins-dropdown__item__icon">
-                  <l:icon src="symbol-swap" />
-                </div>
-                ${%Move credential}
-              </button>
-            </dd:custom>
-            <dd:separator />
+            <j:if test="${it.moveable}">
+              <dd:custom>
+                <button class="jenkins-dropdown__item"
+                        data-type="credentials-move"
+                        data-url="moveDialog">
+                  <div class="jenkins-dropdown__item__icon">
+                    <l:icon src="symbol-swap" />
+                  </div>
+                  ${%Move credential}
+                </button>
+              </dd:custom>
+              <dd:separator />
+            </j:if>
             <dd:custom>
               <l:confirmationLink class="jenkins-dropdown__item jenkins-!-destructive-color"
                                   href="doDelete"

--- a/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/DomainWrapper/index.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/DomainWrapper/index.jelly
@@ -114,7 +114,6 @@
                       <span><j:out value="${safeDescription}"/></span>
                     </div>
                   </j:if>
-
                 </div>
                 <div class="credentials-card__controls">
                   <j:if test="${h.hasPermission(c, it.parent.UPDATE)}">
@@ -125,17 +124,19 @@
                       <l:icon src="symbol-edit"/>
                     </button>
                     <l:overflowButton clazz="jenkins-button--tertiary">
-                      <dd:custom>
-                        <button class="jenkins-dropdown__item"
-                                data-type="credentials-move"
-                                data-url="credential/${c.urlName}/moveDialog">
-                          <div class="jenkins-dropdown__item__icon">
-                            <l:icon src="symbol-swap" />
-                          </div>
-                          ${%Move credential}
-                        </button>
-                      </dd:custom>
-                      <dd:separator />
+                      <j:if test="${c.moveable}">
+                        <dd:custom>
+                          <button class="jenkins-dropdown__item"
+                                  data-type="credentials-move"
+                                  data-url="credential/${c.urlName}/moveDialog">
+                            <div class="jenkins-dropdown__item__icon">
+                              <l:icon src="symbol-swap" />
+                            </div>
+                            ${%Move credential}
+                          </button>
+                        </dd:custom>
+                        <dd:separator />
+                      </j:if>
                       <dd:custom>
                         <l:confirmationLink class="jenkins-dropdown__item jenkins-!-destructive-color"
                                             href="credential/${c.urlName}/doDelete"

--- a/src/main/resources/com/cloudbees/plugins/credentials/ViewCredentialsAction/index.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/ViewCredentialsAction/index.jelly
@@ -94,7 +94,6 @@
         <t:help href="https://www.jenkins.io/doc/book/security/credentials/"/>
       </l:app-bar>
 
-
       <j:choose>
         <j:when test="${tableEntries.isEmpty()}">
           <j:choose>
@@ -158,17 +157,19 @@
                       <l:icon src="symbol-edit"/>
                     </button>
                     <l:overflowButton clazz="jenkins-button--tertiary">
-                      <dd:custom>
-                        <button class="jenkins-dropdown__item"
-                                data-type="credentials-move"
-                                data-url="${url}/moveDialog">
-                          <div class="jenkins-dropdown__item__icon">
-                            <l:icon src="symbol-swap"/>
-                          </div>
-                          ${%Move credential}
-                        </button>
-                      </dd:custom>
-                      <dd:separator/>
+                      <j:if test="${d.moveable}">
+                        <dd:custom>
+                          <button class="jenkins-dropdown__item"
+                                  data-type="credentials-move"
+                                  data-url="${url}/moveDialog">
+                            <div class="jenkins-dropdown__item__icon">
+                              <l:icon src="symbol-swap"/>
+                            </div>
+                            ${%Move credential}
+                          </button>
+                        </dd:custom>
+                        <dd:separator/>
+                      </j:if>
                       <dd:custom>
                         <l:confirmationLink class="jenkins-dropdown__item jenkins-!-destructive-color"
                                             href="${url}/doDelete"


### PR DESCRIPTION
Based on https://github.com/jenkinsci/credentials-plugin/pull/1024

This PR hides the 'Move credential' button if there's no where to move the credential to, i.e. no additional domains.

@timja 

**Before**
<img width="1261" height="366" alt="Screenshot 2026-03-20 at 11 38 09" src="https://github.com/user-attachments/assets/8f1497d9-a292-49d5-bad9-e2154f3d2de0" />

**After**
<img width="1282" height="367" alt="Screenshot 2026-03-20 at 11 37 51" src="https://github.com/user-attachments/assets/396f0dce-76f4-415b-88b1-318ab561a5e8" />

### Testing done

* Button hides if no domains to move to
* Button shows if there are
* Button hides inside of folders with one domain

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
