### PR TITLE
Add id to credential more action button for ATH

### DIFF
--- a/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/CredentialsWrapper/index.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/CredentialsStoreAction/CredentialsWrapper/index.jelly
@@ -40,7 +40,7 @@
                 data-url="updateDialog">
           ${%Update credential}
         </button>
-        <l:overflowButton>
+        <l:overflowButton id="more-credential-actions">
           <j:if test="${it.moveable}">
             <dd:custom>
               <button class="jenkins-dropdown__item"


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://github.com/jenkinsci/credentials-plugin/pull/1024 changes the UI to add a new button for `More Actions`. Proposing to add an id for this field, as if there are other buttons with the same `More Actions` name, it will cause conflict

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
