### PR TITLE
Reject illegal characters in new credential IDs

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsSelectHelper.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsSelectHelper.java
@@ -33,6 +33,7 @@ import hudson.cli.declarative.CLIResolver;
 import hudson.model.ComputerSet;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
+import hudson.model.Failure;
 import hudson.model.Item;
 import hudson.model.ManageJenkinsAction;
 import hudson.model.ModelObject;
@@ -656,6 +657,13 @@ public class CredentialsSelectHelper extends Descriptor<CredentialsSelectHelper>
             try {
                 Credentials credentials = Descriptor.bindJSON(req, Credentials.class,
                                                               data.getJSONObject("credentials"));
+                try {
+                    CredentialsStoreAction.checkCredentialsId(credentials);
+                } catch (Failure f) {
+                    return new JSONObject()
+                            .element("message", f.getMessage())
+                            .element("notificationType", "ERROR");
+                }
                 credentialsWereAdded = store.addCredentials(wrapper.getDomain(), credentials);
             } catch (LinkageError e) {
                 /*

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsStoreAction.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsStoreAction.java
@@ -536,6 +536,17 @@ public abstract class CredentialsStoreAction
     }
 
     /**
+     * Checks that the id of the supplied credentials does not contain illegal characters.
+     *
+     * @param credentials the credentials to check.
+     */
+    static void checkCredentialsId(Credentials credentials) {
+        if (credentials instanceof IdCredentials) {
+            Jenkins.checkGoodName(((IdCredentials) credentials).getId());
+        }
+    }
+
+    /**
      * A wrapper object to bind and expose {@link Domain} instances into the web UI.
      */
     @ExportedBean
@@ -775,6 +786,16 @@ public abstract class CredentialsStoreAction
                 try {
                     JSONObject data = req.getSubmittedForm();
                     Credentials credentials = Descriptor.bindJSON(req, Credentials.class, data.getJSONObject("credentials"));
+                    try {
+                        checkCredentialsId(credentials);
+                    } catch (Failure f) {
+                        if (jsonResponse) {
+                            return HttpResponses.okJSON(new JSONObject()
+                                    .element("message", f.getMessage())
+                                    .element("notificationType", "ERROR"));
+                        }
+                        throw f;
+                    }
                     boolean credentialsWereAdded = getStore().addCredentials(domain, credentials);
 
                     if (jsonResponse) {

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsSelectHelperTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsSelectHelperTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.cloudbees.plugins.credentials.common.CertificateCredentials;
 import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl;
 
@@ -14,6 +15,9 @@ import com.cloudbees.plugins.credentials.impl.CertificateCredentialsImplTest;
 import hudson.model.UnprotectedRootAction;
 import hudson.security.ACL;
 import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import net.sf.json.JSONObject;
@@ -48,6 +52,11 @@ public class CredentialsSelectHelperTest {
 
     private static final String VALID_PASSWORD = "password";
     private static final String INVALID_PASSWORD = "bla";
+    private static final String ADD_CREDENTIALS_URL =
+            "descriptor/com.cloudbees.plugins.credentials.CredentialsSelectHelper"
+                    + "/resolver/com.cloudbees.plugins.credentials.CredentialsSelectHelper$SystemContextResolver"
+                    + "/provider/com.cloudbees.plugins.credentials.SystemCredentialsProvider$ProviderImpl"
+                    + "/context/jenkins/addCredentials";
 
     @BeforeEach
     void setup(JenkinsRule j) throws IOException {
@@ -95,6 +104,40 @@ public class CredentialsSelectHelperTest {
             assertThat(cred.getUsername(), is("bob"));
             assertThat(cred.getPassword().getPlainText(), is("secret"));
         }
+    }
+
+    @Test
+    @Issue("JENKINS-75943")
+    void doAddCredentialsRejectsIllegalId() throws Exception {
+        j.getInstance().setCrumbIssuer(null);
+
+        postAddCredentials("valid.id");
+        assertThat(systemCredentialIds(), is(List.of("valid.id")));
+
+        postAddCredentials("illegal?id");
+        assertThat(systemCredentialIds(), is(List.of("valid.id")));
+    }
+
+    private void postAddCredentials(String id) throws IOException {
+        String json = "{\"domain\": \"_\", \"credentials\": {"
+                + "\"$class\": \"com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl\", "
+                + "\"scope\": \"GLOBAL\", \"id\": \"" + id + "\", "
+                + "\"username\": \"bob\", \"password\": \"secret\"}}";
+        HttpURLConnection con = (HttpURLConnection) new URL(j.getURL(), ADD_CREDENTIALS_URL).openConnection();
+        con.setRequestMethod("POST");
+        con.setRequestProperty("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+        con.setDoOutput(true);
+        con.getOutputStream()
+                .write(("json=" + URLEncoder.encode(json, StandardCharsets.UTF_8)).getBytes(StandardCharsets.UTF_8));
+        con.getResponseCode();
+    }
+
+    private static List<String> systemCredentialIds() {
+        return CredentialsProvider
+                .lookupCredentialsInItem(StandardUsernamePasswordCredentials.class, null, ACL.SYSTEM2)
+                .stream()
+                .map(StandardUsernamePasswordCredentials::getId)
+                .toList();
     }
 
     @Test

--- a/src/test/java/com/cloudbees/plugins/credentials/CredentialsStoreActionTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/CredentialsStoreActionTest.java
@@ -338,6 +338,27 @@ class CredentialsStoreActionTest {
         assertThat(data.getString("message"), notNullValue());
     }
 
+    @Test
+    @Issue("JENKINS-75943")
+    void createCredentialsFromFormRejectsIllegalId() throws Exception {
+        j.getInstance().setCrumbIssuer(null);
+        HttpURLConnection con = postCreateByForm(systemStore, null,
+                "{\"credentials\": {\"$class\": \"com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl\", "
+                        + "\"scope\": \"GLOBAL\", \"id\": \"valid.id\", \"description\": \"first\", "
+                        + "\"username\": \"bob\", \"password\": \"secret\"}}");
+        assertThat(con.getResponseCode(), is(HttpServletResponse.SC_FOUND));
+        assertThat(CredentialsMatchers.firstOrNull(systemStore.getCredentials(Domain.global()),
+                CredentialsMatchers.withId("valid.id")), notNullValue());
+
+        con = postCreateByForm(systemStore, null,
+                "{\"credentials\": {\"$class\": \"com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl\", "
+                        + "\"scope\": \"GLOBAL\", \"id\": \"illegal?id\", \"description\": \"second\", "
+                        + "\"username\": \"bob\", \"password\": \"secret\"}}");
+        assertThat(con.getResponseCode(), is(HttpServletResponse.SC_BAD_REQUEST));
+        assertThat(CredentialsMatchers.firstOrNull(systemStore.getCredentials(Domain.global()),
+                CredentialsMatchers.withId("illegal?id")), nullValue());
+    }
+
     private static String readResponseBody(HttpURLConnection con) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         byte[] buf = new byte[4096];
@@ -348,6 +369,21 @@ class CredentialsStoreActionTest {
             }
         }
         return new String(baos.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    private HttpURLConnection postCreateByForm(CredentialsStore store, String domainName, String json)
+            throws IOException {
+        HttpURLConnection con = (HttpURLConnection) new URL(j.getURL(),
+                "credentials/store/" + store.getStoreAction().getUrlName() + "/domain/" + Util
+                        .rawEncode(StringUtils.defaultIfBlank(domainName, "_")) + "/createCredentials")
+                .openConnection();
+        con.setRequestMethod("POST");
+        con.setInstanceFollowRedirects(false);
+        con.setRequestProperty("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+        con.setDoOutput(true);
+        con.getOutputStream()
+                .write(("json=" + URLEncoder.encode(json, StandardCharsets.UTF_8)).getBytes(StandardCharsets.UTF_8));
+        return con;
     }
 
     private HttpURLConnection postCreateByXml(CredentialsStore store, String xml)


### PR DESCRIPTION
The ID field in the credential forms already warns about illegal characters, but the form can still be submitted and the credential is created anyway. This adds server side validation with Jenkins.checkGoodName at the two interactive creation endpoints, doCreateCredentials in CredentialsStoreAction and doAddCredentials in CredentialsSelectHelper. The popup dialog returns its usual error notification and a plain form submission gets a 400 response.

The XML REST endpoint and the CLI command are left as they are, so credentials exported from an existing instance can still be imported even if their IDs predate this check, in line with the comment about allowing pre stored credentials. Updating and moving existing credentials are also unaffected since the check only runs on creation.

Both new tests fail without the main change and pass with it.

Fixes #977