### PR TITLE
CredentialsProvider: extend public API with find*() and get*() method variants that can specify the Run

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
@@ -894,6 +894,58 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
+     * As {@link #findCredentialByIdInItemGroup(String, Class, ItemGroup, Authentication, List)}, additionally
+     * identifying the specific {@link Run} in whose context the lookup is being performed, if known - threaded
+     * down to {@link #getCredentialByIdInItemGroup(String, Class, ItemGroup, Authentication, List, Run)} for
+     * each registered provider. See {@link #getCredentialsInItemGroup(Class, ItemGroup, Authentication, List, Run)}
+     * for why this matters.
+     *
+     * @param id                 the ID of the credential to find.
+     * @param type               the type of credential to find.
+     * @param itemGroup          the item group (if {@code null} assume {@link Jenkins#get()}).
+     * @param authentication     the authentication (if {@code null} assume {@link ACL#SYSTEM2}).
+     * @param domainRequirements the credential domains to match (if {@code null} assume empty list).
+     * @param run                the {@link Run} in whose context this lookup is being performed, or {@code null}
+     *                           if the caller has no such context.
+     * @param <C>                the credentials type.
+     * @return the credential or {@code null} if no credential with the specified ID is found.
+     * @since TODO
+     */
+    @CheckForNull
+    public static <C extends IdCredentials> C findCredentialByIdInItemGroup(@NonNull String id,
+                                                                            @NonNull Class<C> type,
+                                                                            @Nullable ItemGroup<?> itemGroup,
+                                                                            @Nullable Authentication authentication,
+                                                                            @Nullable List<DomainRequirement> domainRequirements,
+                                                                            @CheckForNull Run<?, ?> run) {
+        Objects.requireNonNull(id);
+        Objects.requireNonNull(type);
+        if (itemGroup == null) {
+            itemGroup = Jenkins.get();
+        }
+        if (authentication == null) {
+            authentication = ACL.SYSTEM2;
+        }
+        if (domainRequirements == null) {
+            domainRequirements = List.of();
+        }
+        var g = itemGroup;
+        LOGGER.fine(() -> "looking for " + id + " of " + type + " in " + g + " (run=" + run + ")");
+        for (CredentialsProvider provider : all()) {
+            if (provider.isEnabled(itemGroup) && provider.isApplicable(type)) {
+                LOGGER.fine(() -> "checking " + provider + " for " + id);
+                C credential = provider.getCredentialByIdInItemGroup(id, type, itemGroup, authentication, domainRequirements, run);
+                if (credential != null) {
+                    LOGGER.fine(() -> "found " + credential + " in " + provider);
+                    return credential;
+                }
+            }
+        }
+        LOGGER.fine(() -> "did not find " + id);
+        return null;
+    }
+
+    /**
      * Returns the credential with the specified ID which is available to the specified {@link Authentication}
      * for use by the specified {@link Item}.
      *
@@ -930,6 +982,61 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
             if (provider.isEnabled(item) && provider.isApplicable(type)) {
                 LOGGER.fine(() -> "checking " + provider + " for " + id);
                 C credential = provider.getCredentialByIdInItem(id, type, item, authentication, domainRequirements);
+                if (credential != null) {
+                    LOGGER.fine(() -> "found " + credential + " in " + provider);
+                    return credential;
+                }
+            }
+        }
+        LOGGER.fine(() -> "did not find " + id);
+        return null;
+    }
+
+    /**
+     * As {@link #findCredentialByIdInItem(String, Class, Item, Authentication, List)}, additionally identifying
+     * the specific {@link Run} in whose context the lookup is being performed, if known - threaded down to
+     * {@link #getCredentialByIdInItem(String, Class, Item, Authentication, List, Run)} for each registered
+     * provider (or to {@link #findCredentialByIdInItemGroup(String, Class, ItemGroup, Authentication, List, Run)}
+     * if {@code item} is itself an {@link ItemGroup}). See
+     * {@link #getCredentialsInItemGroup(Class, ItemGroup, Authentication, List, Run)} for why this matters.
+     *
+     * @param id                 the ID of the credential to find.
+     * @param type               the type of credential to find.
+     * @param item               the item (if {@code null} assume {@link Jenkins#get()}).
+     * @param authentication     the authentication (if {@code null} assume {@link ACL#SYSTEM2}).
+     * @param domainRequirements the credential domains to match (if {@code null} assume empty list).
+     * @param run                the {@link Run} in whose context this lookup is being performed, or {@code null}
+     *                           if the caller has no such context.
+     * @param <C>                the credentials type.
+     * @return the credential or {@code null} if no credential with the specified ID is found.
+     * @since TODO
+     */
+    @CheckForNull
+    public static <C extends IdCredentials> C findCredentialByIdInItem(@NonNull String id,
+                                                                       @NonNull Class<C> type,
+                                                                       @Nullable Item item,
+                                                                       @Nullable Authentication authentication,
+                                                                       @Nullable List<DomainRequirement> domainRequirements,
+                                                                       @CheckForNull Run<?, ?> run) {
+        Objects.requireNonNull(id);
+        Objects.requireNonNull(type);
+        if (item == null) {
+            return findCredentialByIdInItemGroup(id, type, Jenkins.get(), authentication, domainRequirements, run);
+        }
+        if (item instanceof ItemGroup<?> group) {
+            return findCredentialByIdInItemGroup(id, type, group, authentication, domainRequirements, run);
+        }
+        if (authentication == null) {
+            authentication = ACL.SYSTEM2;
+        }
+        if (domainRequirements == null) {
+            domainRequirements = List.of();
+        }
+        LOGGER.fine(() -> "looking for " + id + " of " + type + " in " + item + " (run=" + run + ")");
+        for (CredentialsProvider provider : all()) {
+            if (provider.isEnabled(item) && provider.isApplicable(type)) {
+                LOGGER.fine(() -> "checking " + provider + " for " + id);
+                C credential = provider.getCredentialByIdInItem(id, type, item, authentication, domainRequirements, run);
                 if (credential != null) {
                     LOGGER.fine(() -> "found " + credential + " in " + provider);
                     return credential;
@@ -1021,10 +1128,10 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
             // as you would have no way to configure it
             Authentication runAuth = CredentialsProvider.getDefaultAuthenticationOf2(run.getParent());
             // we want the credentials available to the user the build is running as
-            C credential = findCredentialByIdInItem(id, type, run.getParent(), runAuth, domainRequirements);
+            C credential = findCredentialByIdInItem(id, type, run.getParent(), runAuth, domainRequirements, run);
             // if that user can use the item's credentials, try those too
             if (credential == null && runAuth != ACL.SYSTEM2 && run.hasPermission2(runAuth, CredentialsProvider.USE_ITEM)) {
-                credential = findCredentialByIdInItem(id, type, run.getParent(), ACL.SYSTEM2, domainRequirements);
+                credential = findCredentialByIdInItem(id, type, run.getParent(), ACL.SYSTEM2, domainRequirements, run);
             }
             // TODO should this be calling track?
             return contextualize(type, credential, run);
@@ -1037,14 +1144,14 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
             // the user triggered this job directly and they are allowed to supply their own credentials, so
             // search those first. We do not want to follow the chain for the user's authentication
             // though, as there is no way to limit how far the passed-through parameters can be used
-            result = findCredentialByIdInItem(id, type, run.getParent(), a, domainRequirements);
+            result = findCredentialByIdInItem(id, type, run.getParent(), a, domainRequirements, run);
         }
         if (result == null && inputUserId != null) {
             final User inputUser = User.getById(inputUserId, false);
             if (inputUser != null) {
                 final Authentication inputAuth = inputUser.impersonate2();
                 if (run.hasPermission2(inputAuth, CredentialsProvider.USE_OWN)) {
-                    result = findCredentialByIdInItem(id, type, run.getParent(), inputAuth, domainRequirements);
+                    result = findCredentialByIdInItem(id, type, run.getParent(), inputAuth, domainRequirements, run);
                 }
             }
         }
@@ -1055,10 +1162,10 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
             // as you would have no way to configure it
             Authentication runAuth = CredentialsProvider.getDefaultAuthenticationOf2(run.getParent());
             // we want the credentials available to the user the build is running as
-            result = findCredentialByIdInItem(id, type, run.getParent(), runAuth, domainRequirements);
+            result = findCredentialByIdInItem(id, type, run.getParent(), runAuth, domainRequirements, run);
             // if that user can use the item's credentials, try those too
             if (result == null && runAuth != ACL.SYSTEM2 && run.hasPermission2(runAuth, CredentialsProvider.USE_ITEM)) {
-                result = findCredentialByIdInItem(id, type, run.getParent(), ACL.SYSTEM2, domainRequirements);
+                result = findCredentialByIdInItem(id, type, run.getParent(), ACL.SYSTEM2, domainRequirements, run);
             }
         }
         // if the run has not completed yet then we can safely assume that the credential is being used for this run
@@ -1282,6 +1389,48 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
+     * Returns the credentials provided by this provider which are available to the specified {@link Authentication}
+     * for items in the specified {@link ItemGroup} and are appropriate for the specified {@link DomainRequirement}s,
+     * additionally identifying the specific {@link Run} in whose context the lookup is being performed, if known.
+     *
+     * <p>Most callers reach this indirectly via {@link #findCredentialById(String, Class, Run, List)}, which
+     * already has the {@link Run} in hand but historically discarded it before dispatching to any provider -
+     * providers had no way to distinguish "which build is asking" at all, only the build's containing
+     * {@link Item}/{@link ItemGroup} and effective {@link Authentication}. This matters specifically for
+     * providers whose credentials are scoped to an individual build rather than to a persisted
+     * {@link Item}/{@link ItemGroup} (for example, a build-scoped in-memory store populated interactively during
+     * a Pipeline run) - such a provider cannot answer "which build's cache should I consult" from the 4-argument
+     * overload alone, since many different concurrent builds of the same or sibling jobs share the same
+     * {@code itemGroup}.</p>
+     *
+     * <p>The default implementation ignores {@code run} entirely and delegates to the existing
+     * {@link #getCredentialsInItemGroup(Class, ItemGroup, Authentication, List)}, so this is fully backward
+     * compatible: providers that do not override this method behave exactly as before. A provider that does
+     * override it can consult {@code run} directly instead of having to reconstruct or guess at "which build"
+     * some other way.</p>
+     *
+     * @param type               the type of credentials to return.
+     * @param itemGroup          the item group (if {@code null} assume {@link Jenkins#get()}.
+     * @param authentication     the authentication (if {@code null} assume {@link ACL#SYSTEM2}.
+     * @param domainRequirements the credential domains to match (if the {@link CredentialsProvider} does not support
+     *                           {@link DomainRequirement}s then it should
+     *                           assume the match is true).
+     * @param run                the {@link Run} in whose context this lookup is being performed, or {@code null}
+     *                           if the caller has no such context (e.g. a job configuration screen).
+     * @param <C>                the credentials type.
+     * @return the list of credentials.
+     * @since TODO
+     */
+    @NonNull
+    public <C extends Credentials> List<C> getCredentialsInItemGroup(@NonNull Class<C> type,
+                                                                     @Nullable ItemGroup itemGroup,
+                                                                     @Nullable Authentication authentication,
+                                                                     @NonNull List<DomainRequirement> domainRequirements,
+                                                                     @CheckForNull Run<?, ?> run) {
+        return getCredentialsInItemGroup(type, itemGroup, authentication, domainRequirements);
+    }
+
+    /**
      * @deprecated Use {@link #getCredentialIdsInItemGroup(Class, ItemGroup, Authentication, List, CredentialsMatcher)} instead.
      */
     @NonNull
@@ -1325,6 +1474,39 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     }
 
     /**
+     * As {@link #getCredentialByIdInItemGroup(String, Class, ItemGroup, Authentication, List)}, additionally
+     * identifying the specific {@link Run} in whose context the lookup is being performed, if known - see
+     * {@link #getCredentialsInItemGroup(Class, ItemGroup, Authentication, List, Run)} for why this matters.
+     * The default implementation filters {@link #getCredentialsInItemGroup(Class, ItemGroup, Authentication, List, Run)},
+     * so a provider only needs to override that method to become run-aware for ID-based lookups too; this
+     * overload only needs overriding directly if run-awareness can make ID-based lookup itself cheaper or more
+     * precise than filtering the full list would.
+     *
+     * @param <C>                the credentials type.
+     * @param id                 the ID of the credential to find.
+     * @param type               the type of credentials to return.
+     * @param itemGroup          the item group.
+     * @param authentication     the authentication.
+     * @param domainRequirements the credential domain to match.
+     * @param run                the {@link Run} in whose context this lookup is being performed, or {@code null}
+     *                           if the caller has no such context.
+     * @return the credential or {@code null} if no credential with the specified ID is found.
+     * @since TODO
+     */
+    @CheckForNull
+    public <C extends IdCredentials> C getCredentialByIdInItemGroup(@NonNull String id,
+                                                                    @NonNull Class<C> type,
+                                                                    @NonNull ItemGroup<?> itemGroup,
+                                                                    @NonNull Authentication authentication,
+                                                                    @NonNull List<DomainRequirement> domainRequirements,
+                                                                    @CheckForNull Run<?, ?> run) {
+        return CredentialsMatchers.firstOrNull(
+                getCredentialsInItemGroup(type, itemGroup, authentication, domainRequirements, run),
+                CredentialsMatchers.withId(id)
+        );
+    }
+
+    /**
      * Returns the credential with the specified ID provided by this provider which is available to the
      * specified {@link Authentication} for the specified {@link Item} and is appropriate for the
      * specified {@link DomainRequirement}s.
@@ -1349,6 +1531,36 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
                                                                @NonNull List<DomainRequirement> domainRequirements) {
         return CredentialsMatchers.firstOrNull(
                 getCredentialsInItem(type, item, authentication, domainRequirements),
+                CredentialsMatchers.withId(id)
+        );
+    }
+
+    /**
+     * As {@link #getCredentialByIdInItem(String, Class, Item, Authentication, List)}, additionally identifying
+     * the specific {@link Run} in whose context the lookup is being performed, if known - see
+     * {@link #getCredentialsInItemGroup(Class, ItemGroup, Authentication, List, Run)} for why this matters.
+     * The default implementation filters {@link #getCredentialsInItem(Class, Item, Authentication, List, Run)}.
+     *
+     * @param <C>                the credentials type.
+     * @param id                 the ID of the credential to find.
+     * @param type               the type of credentials to return.
+     * @param item               the item.
+     * @param authentication     the authentication.
+     * @param domainRequirements the credential domain to match.
+     * @param run                the {@link Run} in whose context this lookup is being performed, or {@code null}
+     *                           if the caller has no such context.
+     * @return the credential or {@code null} if no credential with the specified ID is found.
+     * @since TODO
+     */
+    @CheckForNull
+    public <C extends IdCredentials> C getCredentialByIdInItem(@NonNull String id,
+                                                               @NonNull Class<C> type,
+                                                               @NonNull Item item,
+                                                               @NonNull Authentication authentication,
+                                                               @NonNull List<DomainRequirement> domainRequirements,
+                                                               @CheckForNull Run<?, ?> run) {
+        return CredentialsMatchers.firstOrNull(
+                getCredentialsInItem(type, item, authentication, domainRequirements, run),
                 CredentialsMatchers.withId(id)
         );
     }
@@ -1441,6 +1653,39 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     private <C extends Credentials> List<C> getCredentialsInItemFallback(@NonNull Class<C> type, @NonNull Item item, @Nullable Authentication authentication, @NonNull List<DomainRequirement> domainRequirements) {
         return getCredentialsInItemGroup(type, item instanceof ItemGroup ? (ItemGroup) item : item.getParent(),
                 authentication, domainRequirements);
+    }
+
+    /**
+     * As {@link #getCredentialsInItem(Class, Item, Authentication, List)}, additionally identifying the specific
+     * {@link Run} in whose context the lookup is being performed, if known - see
+     * {@link #getCredentialsInItemGroup(Class, ItemGroup, Authentication, List, Run)} for why this matters. The
+     * default implementation ignores {@code run} unless {@code item} resolves to an {@link ItemGroup} (in which
+     * case it is threaded through to {@link #getCredentialsInItemGroup(Class, ItemGroup, Authentication, List, Run)}),
+     * so this is fully backward compatible.
+     *
+     * @param type               the type of credentials to return.
+     * @param item               the item.
+     * @param authentication     the authentication (if {@code null} assume {@link ACL#SYSTEM2}.
+     * @param domainRequirements the credential domain to match.
+     * @param run                the {@link Run} in whose context this lookup is being performed, or {@code null}
+     *                           if the caller has no such context.
+     * @param <C>                the credentials type.
+     * @return the list of credentials.
+     * @since TODO
+     */
+    @NonNull
+    public <C extends Credentials> List<C> getCredentialsInItem(@NonNull Class<C> type,
+                                                                @NonNull Item item,
+                                                                @Nullable Authentication authentication,
+                                                                @NonNull List<DomainRequirement> domainRequirements,
+                                                                @CheckForNull Run<?, ?> run) {
+        return getCredentialsInItemFallback(type, item, authentication, domainRequirements, run);
+    }
+
+    @NonNull
+    private <C extends Credentials> List<C> getCredentialsInItemFallback(@NonNull Class<C> type, @NonNull Item item, @Nullable Authentication authentication, @NonNull List<DomainRequirement> domainRequirements, @CheckForNull Run<?, ?> run) {
+        return getCredentialsInItemGroup(type, item instanceof ItemGroup ? (ItemGroup) item : item.getParent(),
+                authentication, domainRequirements, run);
     }
 
     /**

--- a/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java
@@ -1658,10 +1658,25 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
     /**
      * As {@link #getCredentialsInItem(Class, Item, Authentication, List)}, additionally identifying the specific
      * {@link Run} in whose context the lookup is being performed, if known - see
-     * {@link #getCredentialsInItemGroup(Class, ItemGroup, Authentication, List, Run)} for why this matters. The
-     * default implementation ignores {@code run} unless {@code item} resolves to an {@link ItemGroup} (in which
-     * case it is threaded through to {@link #getCredentialsInItemGroup(Class, ItemGroup, Authentication, List, Run)}),
-     * so this is fully backward compatible.
+     * {@link #getCredentialsInItemGroup(Class, ItemGroup, Authentication, List, Run)} for why this matters.
+     *
+     * <p>Unlike the {@link ItemGroup} overload, this default implementation cannot simply delegate to the plain
+     * {@link #getCredentialsInItem(Class, Item, Authentication, List)} overload and rely on virtual dispatch alone:
+     * that overload is itself a legitimate, commonly-overridden extension point (for example
+     * {@code SystemCredentialsProvider.ProviderImpl} overrides it to unconditionally exclude
+     * {@link CredentialsScope#SYSTEM}-scoped credentials, a check that only applies at the {@link Item} level, not
+     * at the {@link ItemGroup} level where the root {@link Jenkins} instance is itself a valid, SYSTEM-scope-visible
+     * {@link ItemGroup}). If this method threaded {@code run} straight through to
+     * {@link #getCredentialsInItemGroup(Class, ItemGroup, Authentication, List, Run)} regardless, it would bypass
+     * any such override entirely - for a job directly under {@link Jenkins#get()}, {@code item.getParent()} is
+     * {@link Jenkins#get()}, so the {@link ItemGroup} overload would (correctly, for that overload's own contract)
+     * treat the lookup as a root-level, SYSTEM-scope-visible one, silently exposing SYSTEM-scoped credentials to
+     * item-level (i.e. build-level) callers that the {@link Item} overload was specifically written to hide them
+     * from. So: if a provider overrides the plain {@link Item} overload (or either older deprecated equivalent),
+     * that override - which knows nothing about {@code run} - is used as-is (run is not threaded through, exactly
+     * as if this new overload did not exist); only providers that have <em>not</em> customized the {@link Item}
+     * overload at all fall through to the {@link ItemGroup}-based, {@code run}-aware resolution below. This is
+     * fully backward compatible either way.</p>
      *
      * @param type               the type of credentials to return.
      * @param item               the item.
@@ -1674,11 +1689,19 @@ public abstract class CredentialsProvider extends Descriptor<CredentialsProvider
      * @since TODO
      */
     @NonNull
+    @SuppressWarnings("deprecation")
     public <C extends Credentials> List<C> getCredentialsInItem(@NonNull Class<C> type,
                                                                 @NonNull Item item,
                                                                 @Nullable Authentication authentication,
                                                                 @NonNull List<DomainRequirement> domainRequirements,
                                                                 @CheckForNull Run<?, ?> run) {
+        // NOTE: if we are here, the descendent class did not override this method
+        //  (assume it does not call super class method for implementation)
+        if (Util.isOverridden(CredentialsProvider.class, getClass(), "getCredentialsInItem", Class.class, Item.class, Authentication.class, List.class)
+                || Util.isOverridden(CredentialsProvider.class, getClass(), "getCredentials", Class.class, Item.class, org.acegisecurity.Authentication.class, List.class)
+                || Util.isOverridden(CredentialsProvider.class, getClass(), "getCredentials", Class.class, Item.class, org.acegisecurity.Authentication.class)) {
+            return getCredentialsInItem(type, item, authentication, domainRequirements);
+        }
         return getCredentialsInItemFallback(type, item, authentication, domainRequirements, run);
     }
 

--- a/src/test/java/com/cloudbees/plugins/credentials/RunAwareLookupTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/RunAwareLookupTest.java
@@ -1,0 +1,244 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026, Jim Klimov, PROVYS Technologies a.s.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.plugins.credentials;
+
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.Descriptor;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.ItemGroup;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.tasks.Builder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.steps.SynchronousStepExecution;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.springframework.security.core.Authentication;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end demonstration that the {@link Run}-aware overloads added to
+ * {@link CredentialsProvider} (see {@link CredentialsProvider#getCredentialsInItemGroup(Class, ItemGroup, Authentication, List, Run)})
+ * really do carry the specific {@link Run} that triggered the lookup all the
+ * way to a provider, for both a classic {@link FreeStyleProject} build and a
+ * Pipeline build.
+ *
+ * <p>{@link ObservingProvider} is a throwaway {@link CredentialsProvider} that
+ * records every {@link Run} it is asked about into a static list (the "global
+ * variable" approach) and additionally bakes the observed run's id into the
+ * looked-up credential's own value, which the calling build step/Pipeline step
+ * logs (the "log something" approach) - so the test can assert on the actual
+ * build log, not just on the provider's internal state, proving the value
+ * really flowed through {@code findCredentialById} and back out again.</p>
+ */
+@WithJenkins
+class RunAwareLookupTest {
+
+    private static final String CREDENTIALS_ID = "run-observing";
+
+    private JenkinsRule r;
+
+    @BeforeEach
+    void setUp(JenkinsRule r) {
+        this.r = r;
+        ObservingProvider.OBSERVED_RUN_IDS.clear();
+    }
+
+    @Test
+    void freeStyleBuildIsIdentifiedToTheProvider() throws Exception {
+        FreeStyleProject project = r.createFreeStyleProject();
+        project.getBuildersList().add(new ObservingBuildStep());
+        FreeStyleBuild build = r.buildAndAssertSuccess(project);
+        String runId = build.getExternalizableId();
+        r.assertLogContains("observed run: " + runId, build);
+        assertTrue(ObservingProvider.OBSERVED_RUN_IDS.contains(runId),
+                "provider should have recorded the build's own externalizable id, got: "
+                        + ObservingProvider.OBSERVED_RUN_IDS);
+    }
+
+    @Test
+    void pipelineBuildIsIdentifiedToTheProvider() throws Exception {
+        WorkflowJob job = r.createProject(WorkflowJob.class);
+        job.setDefinition(new CpsFlowDefinition("observeRunCredential()", true));
+        WorkflowRun run = r.buildAndAssertSuccess(job);
+        String runId = run.getExternalizableId();
+        r.assertLogContains("observed run: " + runId, run);
+        assertTrue(ObservingProvider.OBSERVED_RUN_IDS.contains(runId),
+                "provider should have recorded the pipeline run's own externalizable id, got: "
+                        + ObservingProvider.OBSERVED_RUN_IDS);
+    }
+
+    /** Records every {@link Run} (or {@code "<null>"} if none) it is asked to look up credentials for. */
+    @TestExtension
+    public static class ObservingProvider extends CredentialsProvider {
+
+        static final List<String> OBSERVED_RUN_IDS = Collections.synchronizedList(new ArrayList<>());
+
+        @NonNull
+        @Override
+        public <C extends Credentials> List<C> getCredentialsInItemGroup(@NonNull Class<C> type,
+                @Nullable ItemGroup itemGroup, @Nullable Authentication authentication,
+                @NonNull List<DomainRequirement> domainRequirements) {
+            return getCredentialsInItemGroup(type, itemGroup, authentication, domainRequirements, null);
+        }
+
+        @NonNull
+        @Override
+        public <C extends Credentials> List<C> getCredentialsInItemGroup(@NonNull Class<C> type,
+                @Nullable ItemGroup itemGroup, @Nullable Authentication authentication,
+                @NonNull List<DomainRequirement> domainRequirements, @CheckForNull Run<?, ?> run) {
+            OBSERVED_RUN_IDS.add(run == null ? "<null>" : run.getExternalizableId());
+            if (!type.isAssignableFrom(ObservingCredentials.class)) {
+                return Collections.emptyList();
+            }
+            String observed = run == null ? "<null>" : run.getExternalizableId();
+            return Collections.singletonList(type.cast(new ObservingCredentials(CREDENTIALS_ID, observed)));
+        }
+    }
+
+    /** A trivial credential whose value is fixed, at construction time, to whichever {@link Run} the provider last saw. */
+    public static class ObservingCredentials extends BaseStandardCredentials implements StandardCredentials {
+
+        private final String observedRunExternalizableId;
+
+        ObservingCredentials(String id, String observedRunExternalizableId) {
+            super(id, "records which Run last looked it up");
+            this.observedRunExternalizableId = observedRunExternalizableId;
+        }
+
+        String getObservedRunExternalizableId() {
+            return observedRunExternalizableId;
+        }
+
+        @TestExtension
+        public static class DescriptorImpl extends BaseStandardCredentialsDescriptor {
+            @NonNull
+            @Override
+            public String getDisplayName() {
+                return "Run-observing credentials (test only)";
+            }
+        }
+    }
+
+    /** Classic-job equivalent of {@link ObserveRunCredentialStep}: looks up and logs, from within a real build. */
+    private static class ObservingBuildStep extends Builder {
+
+        @Override
+        public boolean perform(AbstractBuild<?, ?> build, hudson.Launcher launcher, BuildListener listener) {
+            ObservingCredentials credentials =
+                    CredentialsProvider.findCredentialById(CREDENTIALS_ID, ObservingCredentials.class, build);
+            listener.getLogger().println("observed run: "
+                    + (credentials == null ? "<none>" : credentials.getObservedRunExternalizableId()));
+            return true;
+        }
+
+        @TestExtension
+        public static class DescriptorImpl extends Descriptor<Builder> {
+            @NonNull
+            @Override
+            public String getDisplayName() {
+                return "Observing build step (test only)";
+            }
+        }
+    }
+
+    /** Pipeline step {@code observeRunCredential()}: looks up and logs, from within a real running script. */
+    public static class ObserveRunCredentialStep extends Step {
+
+        @DataBoundConstructor
+        public ObserveRunCredentialStep() {
+        }
+
+        @Override
+        public StepExecution start(StepContext context) {
+            return new Execution(context);
+        }
+
+        @TestExtension
+        public static class DescriptorImpl extends StepDescriptor {
+
+            @NonNull
+            @Override
+            public String getFunctionName() {
+                return "observeRunCredential";
+            }
+
+            @NonNull
+            @Override
+            public String getDisplayName() {
+                return "Observe run credential (test only)";
+            }
+
+            @NonNull
+            @Override
+            public Set<? extends Class<?>> getRequiredContext() {
+                Set<Class<?>> context = new java.util.HashSet<>();
+                context.add(Run.class);
+                context.add(TaskListener.class);
+                return context;
+            }
+        }
+
+        private static class Execution extends SynchronousStepExecution<Void> {
+            private static final long serialVersionUID = 1L;
+
+            Execution(StepContext context) {
+                super(context);
+            }
+
+            @Override
+            protected Void run() throws Exception {
+                Run<?, ?> run = getContext().get(Run.class);
+                ObservingCredentials credentials =
+                        CredentialsProvider.findCredentialById(CREDENTIALS_ID, ObservingCredentials.class, run);
+                getContext().get(TaskListener.class).getLogger().println("observed run: "
+                        + (credentials == null ? "<none>" : credentials.getObservedRunExternalizableId()));
+                return null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Until now the `build` or `run` reference passed into some methods was used to get its "parent" (such as a Jenkins Folder) and use it as context for persistently configured credentials; the `build` was then effectively discarded during lookups in available credentials stores (not passed into methods that `CredentialsProvider` descendant classes can actually override).

With this change, additional method signatures are added which allow the `Run` argument to be passed further down the road, so credential stores scoped to individual builds (such as with the "Ephemeral Credentials" plugin, hosting pending per https://github.com/jenkins-infra/repository-permissions-updater/issues/5182) can reliably know which code path they were called for during a lookup done by `withCredentials`, `checkout`, `sshagent` and other plugin steps or Java code.

The common entry path for code which wants to find some relevant credentials is to call `static CredentialsProvider findCredentialById(id, type, run, criteria)` which internally called `findCredentialByIdInItem()` -- originally the variant which did not accept the `run` object as its argument, and newly the variant which does.

Default implementations short-circuit to old code without the `run` argument, so existing plugins should not notice the change until they decide to `@Override` the new methods.

* Co-authored-by: Claude Sonnet 4.6

### Testing done

Experimenting how it goes with work on "Ephemeral Credentials" plugin, currently in a side branch - see https://github.com/jimklimov/ephemeral-credentials/pull/1 - HPI files from a build of that PR and a build of this PR are deployed on an internal testing instance, seems satisfactory (log details posted to that PR).

Changes posted here did not preclude passing of existing credentials-plugin tests, at least locally.
Additional `src/test/java/com/cloudbees/plugins/credentials/RunAwareLookupTest.java` crafted specifically for passing `Run` arguments.

For a bit more context: The problem was actually found during work on that "Ephemeral Credentials" plugin: it seemed "obvious" that when we get called from a pipeline or other build, we can know who the caller is, and look up exactly the credentials stored by that build, not by its siblings (same job, different number) or neighbors in a job folder. It turned out that this information is not available in all contexts (e.g. easy to see directly in a pipeline step like `withEphemeralCredentials` offered by that plugin, but not when some `checkout` simply iterates all credential stores to see if somebody defines what it asks for). Experiments with discovery of a thread or executor, or looking at call stack traces, proved outright dysfunctional, or unreliable, or too expensive - and in any case they are hacks that would likely be broken sooner or later by evolution of Jenkins and/or Java. So the best solution is to directly hand down the relevant information this plugin already has, just chose to forget until now.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
