### PR TITLE
[JENKINS-62429] Allow SYSTEM_READ viewers to view Configure Credentials read-only

### DIFF
--- a/src/main/java/com/cloudbees/plugins/credentials/GlobalCredentialsConfiguration.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/GlobalCredentialsConfiguration.java
@@ -33,6 +33,7 @@ import hudson.model.Descriptor;
 import hudson.model.Descriptor.FormException;
 import hudson.model.ManagementLink;
 import hudson.security.GlobalSecurityConfiguration;
+import hudson.security.Permission;
 import hudson.util.FormApply;
 import java.io.IOException;
 import java.util.function.Predicate;
@@ -107,6 +108,17 @@ public class GlobalCredentialsConfiguration extends ManagementLink
 
     public String getCategoryName() {
         return "SECURITY";
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Allow users with {@link Jenkins#SYSTEM_READ} to view (but not modify) this configuration screen,
+     * matching {@link GlobalSecurityConfiguration}'s read-only behavior.
+     */
+    @Override
+    public Permission getRequiredPermission() {
+        return Jenkins.SYSTEM_READ;
     }
 
 // TODO uncomment once ContextMenu is IconSpec aware

--- a/src/main/java/com/cloudbees/plugins/credentials/GlobalCredentialsConfiguration.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/GlobalCredentialsConfiguration.java
@@ -68,6 +68,15 @@ public class GlobalCredentialsConfiguration extends ManagementLink
 
     /**
      * Our filter.
+     *
+     * <p>Any {@link Descriptor} whose {@link Descriptor#getCategory()} is an {@code instanceof}
+     * {@link Category} (including subclasses) is rendered on this page via
+     * {@code index.jelly}, which {@code st:include}s the descriptor's full
+     * {@link Descriptor#getGlobalConfigPage()} &mdash; not just simple properties such as
+     * {@code getId()}/{@code getDisplayName()}. Since {@link #getRequiredPermission()} only
+     * requires {@link Jenkins#SYSTEM_READ}, any descriptor that opts into {@link Category} must
+     * ensure its global config page renders correctly in read-only mode (i.e. does not assume
+     * {@link Jenkins#ADMINISTER}).
      */
     @SuppressWarnings("rawtypes")
     public static final Predicate<Descriptor> FILTER = d -> d.getCategory() instanceof Category;
@@ -230,6 +239,14 @@ public class GlobalCredentialsConfiguration extends ManagementLink
 
     /**
      * Security related configurations.
+     *
+     * <p><strong>Note for implementors:</strong> any {@link Descriptor} (including third-party
+     * ones) that returns this class, or a subclass of it, from {@link Descriptor#getCategory()}
+     * will have its global config page ({@link Descriptor#getGlobalConfigPage()}) rendered on
+     * {@code /configureCredentials}, which is reachable by any user with {@link Jenkins#SYSTEM_READ}
+     * &mdash; not just {@link Jenkins#ADMINISTER}. Make sure such a page does not assume the
+     * viewer holds {@link Jenkins#ADMINISTER} (e.g. avoid actions that only make sense for admins,
+     * and don't render data that non-admins should not see).
      */
     @Extension
     @Symbol("globalCredentialsConfiguration")

--- a/src/main/java/com/cloudbees/plugins/credentials/GlobalCredentialsConfiguration.java
+++ b/src/main/java/com/cloudbees/plugins/credentials/GlobalCredentialsConfiguration.java
@@ -70,13 +70,12 @@ public class GlobalCredentialsConfiguration extends ManagementLink
      * Our filter.
      *
      * <p>Any {@link Descriptor} whose {@link Descriptor#getCategory()} is an {@code instanceof}
-     * {@link Category} (including subclasses) is rendered on this page via
-     * {@code index.jelly}, which {@code st:include}s the descriptor's full
-     * {@link Descriptor#getGlobalConfigPage()} &mdash; not just simple properties such as
-     * {@code getId()}/{@code getDisplayName()}. Since {@link #getRequiredPermission()} only
-     * requires {@link Jenkins#SYSTEM_READ}, any descriptor that opts into {@link Category} must
-     * ensure its global config page renders correctly in read-only mode (i.e. does not assume
-     * {@link Jenkins#ADMINISTER}).
+     * {@link Category} is rendered on this page via {@code index.jelly}, which
+     * {@code st:include}s the descriptor's full {@link Descriptor#getGlobalConfigPage()}
+     * &mdash; not just simple properties such as {@code getId()}/{@code getDisplayName()}. Since
+     * {@link #getRequiredPermission()} only requires {@link Jenkins#SYSTEM_READ}, any descriptor
+     * that opts into {@link Category} must ensure its global config page renders correctly in
+     * read-only mode.
      */
     @SuppressWarnings("rawtypes")
     public static final Predicate<Descriptor> FILTER = d -> d.getCategory() instanceof Category;

--- a/src/main/resources/com/cloudbees/plugins/credentials/GlobalCredentialsConfiguration/index.jelly
+++ b/src/main/resources/com/cloudbees/plugins/credentials/GlobalCredentialsConfiguration/index.jelly
@@ -24,7 +24,8 @@
  ~ THE SOFTWARE.
  -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form">
-  <l:settings-subpage permission="${app.ADMINISTER}">
+  <l:settings-subpage permission="${app.SYSTEM_READ}">
+    <j:set var="readOnlyMode" value="${!app.hasPermission(app.ADMINISTER)}"/>
     <f:form action="configure" method="post" name="config">
       <j:set var="instance" value="${it}"/>
       <j:set var="descriptor" value="${it.descriptor}"/>

--- a/src/test/java/com/cloudbees/plugins/credentials/GlobalCredentialsConfigurationTest.java
+++ b/src/test/java/com/cloudbees/plugins/credentials/GlobalCredentialsConfigurationTest.java
@@ -1,0 +1,74 @@
+package com.cloudbees.plugins.credentials;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import jenkins.model.Jenkins;
+import org.htmlunit.FailingHttpStatusCodeException;
+import org.htmlunit.HttpMethod;
+import org.htmlunit.WebRequest;
+import org.htmlunit.html.HtmlPage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+/**
+ * Verifies that the "Manage Jenkins &gt; Configure Credentials" page
+ * ({@link GlobalCredentialsConfiguration}, {@code configureCredentials}) is viewable
+ * (but not editable) by a user with {@link Jenkins#SYSTEM_READ} but not
+ * {@link Jenkins#ADMINISTER}, matching the read-only rendering convention already used
+ * by {@code hudson.security.GlobalSecurityConfiguration}.
+ */
+@WithJenkins
+class GlobalCredentialsConfigurationTest {
+
+    private JenkinsRule j;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) {
+        j = rule;
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                .grant(Jenkins.ADMINISTER).everywhere().to("admin")
+                .grant(Jenkins.READ, Jenkins.SYSTEM_READ).everywhere().to("viewer"));
+    }
+
+    @Issue("JENKINS-62429")
+    @Test
+    void systemReadViewerCanViewButNotSaveConfigureCredentials() throws Exception {
+        JenkinsRule.WebClient wc = j.createWebClient();
+        wc.withBasicCredentials("viewer");
+
+        HtmlPage page = wc.goTo("configureCredentials");
+        assertThat("a Jenkins.SYSTEM_READ viewer should not see Save/Apply controls on a page they cannot save",
+                page.getByXPath("//button[@type='submit' or contains(@class,'apply-button')]"), empty());
+
+        // Attach a valid crumb so the 403 we assert on below can only come from the
+        // Jenkins.ADMINISTER permission check inside doConfigure, not from crumb validation.
+        WebRequest request = wc.addCrumb(
+                new WebRequest(new URL(j.getURL(), "configureCredentials/configure"), HttpMethod.POST));
+        FailingHttpStatusCodeException ex = assertThrows(FailingHttpStatusCodeException.class,
+                () -> wc.getPage(request),
+                "submitting the configuration should still require Jenkins.ADMINISTER");
+        assertEquals(HttpURLConnection.HTTP_FORBIDDEN, ex.getStatusCode());
+    }
+
+    @Issue("JENKINS-62429")
+    @Test
+    void administerUserStillSeesSaveApplyControls() throws Exception {
+        JenkinsRule.WebClient wc = j.createWebClient();
+        wc.withBasicCredentials("admin");
+
+        HtmlPage page = wc.goTo("configureCredentials");
+        assertThat("an administrator must still be able to save this page",
+                page.getByXPath("//button[@type='submit' or contains(@class,'apply-button')]"), not(empty()));
+    }
+}


### PR DESCRIPTION
# [JENKINS-62429] Allow SYSTEM_READ viewers to view Configure Credentials read-only

## Problem

The "Manage Jenkins > Configure Credentials" page (`GlobalCredentialsConfiguration`, `configureCredentials`) previously required `Jenkins.ADMINISTER` just to *view* it — a user with only `Overall/SystemRead` got an "Access Denied" page, and the "Credential Providers" link didn't even appear in the "Manage Jenkins" listing for them.

This is part of the [JENKINS-12548](https://github.com/jenkinsci/jenkins/issues/12412) epic (read-only system configuration browsing / JEP-224), and mirrors the pattern Jenkins core already uses for `hudson.security.GlobalSecurityConfiguration` ("Manage Jenkins > Security"), which has supported `Jenkins.SYSTEM_READ` viewing since 2.222.

## Changes

- `GlobalCredentialsConfiguration.java`: override `getRequiredPermission()` to return `Jenkins.SYSTEM_READ` instead of the default `Jenkins.ADMINISTER`. Submitting the form (`doConfigure`/`configure()`) is unchanged and still requires `Jenkins.ADMINISTER`.
- `GlobalCredentialsConfiguration/index.jelly`: change `l:settings-subpage`'s `permission` to `app.SYSTEM_READ`, and set the `readOnlyMode` Jelly variable (`!app.hasPermission(app.ADMINISTER)`), matching `hudson/security/GlobalSecurityConfiguration/index.groovy`. `f:saveApplyBar` already hides Save/Apply automatically when `readOnlyMode` is true, and the descriptor-provided form fields (`Providers`/`Types` selects) already inherit `readOnlyMode` through core's standard form tags.

## Screenshots

Local `mvn hpi:run` instance with a `viewer` user (`Jenkins.READ` + `Jenkins.SYSTEM_READ`, no `Jenkins.ADMINISTER`) and an `admin` user (`Jenkins.ADMINISTER`).

### Before

**viewer: page denied entirely**
<img width="1689" height="1221" alt="01-viewer-access-denied-before" src="https://github.com/user-attachments/assets/86232a87-9b49-43ff-8c4d-cb3c360fef0d" />

**viewer: link absent from "Manage Jenkins"**
<img width="1689" height="1221" alt="02-viewer-manage-jenkins-no-link-before" src="https://github.com/user-attachments/assets/7166c73e-9a33-4255-be88-bf85cb35f25a" />

### After

**viewer: page viewable, read-only**
<img width="1689" height="1221" alt="03-viewer-configure-credentials-after" src="https://github.com/user-attachments/assets/07c23703-b4ea-4e1b-bb48-d921beb4417a" />

**admin: unchanged, still editable**
<img width="1689" height="1221" alt="04-admin-configure-credentials-no-regression" src="https://github.com/user-attachments/assets/5b777f94-fbba-48cc-b321-19a027fd633e" />

After the fix, the viewer sees the page with the `Providers`/`Types` selects rendered `disabled` and no Save/Apply buttons or "Añadir" (restrictions) button. The admin view is unchanged — both selects enabled and Save/Apply present.

## Testing

- New test `GlobalCredentialsConfigurationTest`:
  - `systemReadViewerCanViewButNotSaveConfigureCredentials`: a `Jenkins.SYSTEM_READ` viewer can `GET configureCredentials` with no Save/Apply controls rendered, and a crumb-authenticated `POST configureCredentials/configure` still returns 403 (`AccessDeniedException3: ... missing the Overall/Administer permission`).
  - `administerUserStillSeesSaveApplyControls`: no regression — an administrator still sees Save/Apply.
- Full module test suite: 282/282 passing, no regressions.
- Manual verification on a local `mvn hpi:run` instance (screenshots above).

## Checklist

- [x] Referenced the Jira issue (JENKINS-62429) in the commit message
- [x] Added a test that verifies the change
- [x] Unit tests pass locally (282/282)
- [x] Interactively tested the change on a local Jenkins instance

### Proposed changelog entry

* JENKINS-62429: The "Configure Credentials" page ("Manage Jenkins > Credential Providers") is now viewable, read-only, by users with `Overall/SystemRead`.
