### PR TITLE
Update Jenkins baseline to 2.555.3 and require Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildPlugin(useContainerAgent: true, configurations: [
   [platform: 'linux', jdk: 21],
   [platform: 'linux', jdk: 25],
-  [platform: 'windows', jdk: 17],
+  [platform: 'windows', jdk: 21],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,8 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.541</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <jenkins.baseline>2.555</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
     <hpi.compatibleSinceVersion>1372</hpi.compatibleSinceVersion>
   </properties>
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>6166.va_a_8b_5eda_8ef5</version>
+        <version>6931.vea_a_b_c6fd017d</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
Update the Jenkins baseline from 2.541.1 to 2.555.3, one of the [currently recommended versions](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/#currently-recommended-versions).

## What's changed

- `jenkins.baseline` 2.541 -> 2.555, and the plugin BOM to `bom-2.555.x`.
- Jenkins 2.555.1 and newer require Java 21, so the JDK 17 build had to move: `linux/21, linux/25, windows/17` -> `linux/21, linux/25, windows/21`, per the [Java support policy](https://www.jenkins.io/doc/book/platform-information/support-policy-java/).

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk baseline update across the plugins I maintain. If anything here looks wrong, please comment on this PR.
